### PR TITLE
Add Phase 2: menus, file dialogs, timers, clipboard

### DIFF
--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(win32shim PUBLIC
     "-framework CoreText"
     "-framework CoreFoundation"
     "-framework Security"
+    "-framework UniformTypeIdentifiers"
 )
 
 # ============================================================
@@ -283,20 +284,20 @@ target_link_libraries(win32shim PUBLIC
 )
 
 # ============================================================
-# Phase 1: Window + Scintilla App
+# Phase 2: File I/O + Menus App
 # ============================================================
-# A runnable macOS app with a window containing a ScintillaView editor.
-# Demonstrates: NSApplication, window creation, Scintilla integration.
-add_executable(npp_phase1_app
+# Win32 menu APIs backed by NSMenu, file open/save via dialogs,
+# WM_COMMAND dispatch from menus to WndProc, timers, clipboard.
+add_executable(npp_phase2_app
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/main.mm"
 )
-target_include_directories(npp_phase1_app PRIVATE
+target_include_directories(npp_phase2_app PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/platform"
     "${SHIM_INCLUDE_DIR}"
     "${SCINTILLA_INCLUDE_DIR}"
     "${LEXILLA_INCLUDE_DIR}"
 )
-target_link_libraries(npp_phase1_app
+target_link_libraries(npp_phase2_app
     win32shim
     scintilla_bridge
     Scintilla
@@ -306,15 +307,16 @@ target_link_libraries(npp_phase1_app
     "-framework Foundation"
     "-framework AppKit"
     "-framework QuartzCore"
+    "-framework UniformTypeIdentifiers"
 )
-target_compile_options(npp_phase1_app PRIVATE
+target_compile_options(npp_phase2_app PRIVATE
     -fobjc-arc
     -Wno-deprecated-declarations
 )
 
 message(STATUS "=== Notepad++ macOS Port ===")
 message(STATUS "Phase 0: Shim compilation test (npp_phase0_test)")
-message(STATUS "Phase 1: Window + Scintilla app (npp_phase1_app)")
+message(STATUS "Phase 2: File I/O + Menus app (npp_phase2_app)")
 message(STATUS "Shim headers: ${SHIM_INCLUDE_DIR}")
 message(STATUS "Scintilla: ${SCINTILLA_DIR}")
 message(STATUS "Lexilla: ${LEXILLA_DIR}")

--- a/macos/platform/main.mm
+++ b/macos/platform/main.mm
@@ -1,278 +1,116 @@
-// Notepad++ macOS Port — Phase 1 Entry Point
-// Creates an NSApplication with a window containing a ScintillaView editor.
-// This demonstrates: window creation, Scintilla Cocoa integration,
-// and the Win32 shim bridge (HandleRegistry + ScintillaBridge).
+// Notepad++ macOS Port — Phase 2 Entry Point
+// Demonstrates: Win32 menu APIs backed by NSMenu, file open/save via
+// GetOpenFileNameW/GetSaveFileNameW, WM_COMMAND dispatch, timers.
+//
+// This uses the Win32 shim APIs to build the UI, proving the shim works
+// end-to-end. The same APIs will be called by the real N++ code.
 
 #import <Cocoa/Cocoa.h>
+#include "windows.h"
+#include "commdlg.h"
+#include "handle_registry.h"
 #include "scintilla_bridge.h"
 
 // ============================================================
-// Application Delegate
+// Command IDs (matching Notepad++ IDM_* convention)
 // ============================================================
-
-@interface NppAppDelegate : NSObject <NSApplicationDelegate, NSWindowDelegate>
-@property (strong) NSWindow* mainWindow;
-@property (assign) void* scintillaView;  // ScintillaView* as void*
-@end
-
-@implementation NppAppDelegate
-
-- (void)applicationDidFinishLaunching:(NSNotification*)notification
-{
-	[self createMainWindow];
-	[self createScintillaEditor];
-	[self setupMenuBar];
-
-	[self.mainWindow makeKeyAndOrderFront:nil];
-	[NSApp activateIgnoringOtherApps:YES];
-
-	NSLog(@"=== Notepad++ macOS Port — Phase 1 ===");
-	NSLog(@"Window created, Scintilla editor active. Type away!");
-}
-
-- (void)createMainWindow
-{
-	NSRect frame = NSMakeRect(100, 100, 900, 700);
-	NSUInteger styleMask = NSWindowStyleMaskTitled |
-	                       NSWindowStyleMaskClosable |
-	                       NSWindowStyleMaskMiniaturizable |
-	                       NSWindowStyleMaskResizable;
-
-	self.mainWindow = [[NSWindow alloc] initWithContentRect:frame
-	                                    styleMask:styleMask
-	                                    backing:NSBackingStoreBuffered
-	                                    defer:NO];
-
-	[self.mainWindow setTitle:@"Notepad++ (macOS) — Phase 1"];
-	[self.mainWindow setMinSize:NSMakeSize(400, 300)];
-	[self.mainWindow setReleasedWhenClosed:NO];
-	self.mainWindow.delegate = self;
-}
-
-- (void)createScintillaEditor
-{
-	NSView* contentView = self.mainWindow.contentView;
-
-	// Create ScintillaView via the bridge (fills the content area)
-	self.scintillaView = ScintillaBridge_createView((__bridge void*)contentView, 0, 0, 0, 0);
-
-	if (!self.scintillaView)
-	{
-		NSLog(@"ERROR: Failed to create ScintillaView!");
-		return;
-	}
-
-	// Configure the editor with some sensible defaults
-	[self configureScintilla];
-
-	// Set welcome text
-	const char* welcomeText =
-		"// Welcome to Notepad++ on macOS!\n"
-		"//\n"
-		"// Phase 1: Window + Scintilla integration working.\n"
-		"// You can type, select, copy/paste, undo/redo.\n"
-		"//\n"
-		"// Key milestones achieved:\n"
-		"//   - Win32 shim layer compiles ~90 N++ source files\n"
-		"//   - HandleRegistry maps HWND to NSView/NSWindow\n"
-		"//   - ScintillaView (Cocoa) bridge functional\n"
-		"//   - Real CreateWindowEx / SendMessage dispatch\n"
-		"//\n"
-		"// Next: File I/O, menus, tabs, full N++ init.\n"
-		"\n"
-		"#include <iostream>\n"
-		"\n"
-		"int main() {\n"
-		"    std::cout << \"Hello from Notepad++ macOS!\" << std::endl;\n"
-		"    return 0;\n"
-		"}\n";
-
-	// SCI_SETTEXT = 2181
-	ScintillaBridge_sendMessage(self.scintillaView, 2181, 0, (intptr_t)welcomeText);
-
-	// Go to start
-	// SCI_GOTOPOS = 2025
-	ScintillaBridge_sendMessage(self.scintillaView, 2025, 0, 0);
-
-	// Clear undo buffer so welcome text isn't undoable
-	// SCI_EMPTYUNDOBUFFER = 2175
-	ScintillaBridge_sendMessage(self.scintillaView, 2175, 0, 0);
-
-	// Mark as not modified
-	// SCI_SETSAVEPOINT = 2014
-	ScintillaBridge_sendMessage(self.scintillaView, 2014, 0, 0);
-}
-
-- (void)configureScintilla
-{
-	void* sci = self.scintillaView;
-	if (!sci) return;
-
-	// SCI_SETCODEPAGE = 2037, SC_CP_UTF8 = 65001
-	ScintillaBridge_sendMessage(sci, 2037, 65001, 0);
-
-	// SCI_SETWRAPMODE = 2268, SC_WRAP_NONE = 0
-	ScintillaBridge_sendMessage(sci, 2268, 0, 0);
-
-	// SCI_SETTABWIDTH = 2036
-	ScintillaBridge_sendMessage(sci, 2036, 4, 0);
-
-	// SCI_SETUSETABS = 2124, 0 = use spaces
-	ScintillaBridge_sendMessage(sci, 2124, 0, 0);
-
-	// Show line numbers
-	// SCI_SETMARGINTYPEN = 2240, SC_MARGIN_NUMBER = 0
-	ScintillaBridge_sendMessage(sci, 2240, 0, 0);  // margin 0 = line numbers
-
-	// SCI_SETMARGINWIDTHN = 2242, margin 0, width 50
-	ScintillaBridge_sendMessage(sci, 2242, 0, 50);
-
-	// Set C++ lexer
-	// SCI_SETLEXERLANGUAGE = 4006
-	ScintillaBridge_sendMessage(sci, 4006, 0, (intptr_t)"cpp");
-
-	// Configure some C++ keywords
-	// SCI_SETKEYWORDS = 4005
-	const char* keywords = "int char float double void bool true false "
-	                        "if else for while do switch case break continue return "
-	                        "class struct enum namespace using typedef "
-	                        "const static virtual override public private protected "
-	                        "new delete nullptr sizeof typeof "
-	                        "try catch throw include define ifdef ifndef endif";
-	ScintillaBridge_sendMessage(sci, 4005, 0, (intptr_t)keywords);
-
-	// Default style: Menlo font, 13pt
-	// SCI_STYLESETFONT = 2056
-	ScintillaBridge_sendMessage(sci, 2056, 32, (intptr_t)"Menlo");  // STYLE_DEFAULT = 32
-
-	// SCI_STYLESETSIZE = 2055
-	ScintillaBridge_sendMessage(sci, 2055, 32, 13);
-
-	// SCI_STYLECLEARALL = 2050 (apply default to all styles)
-	ScintillaBridge_sendMessage(sci, 2050, 0, 0);
-
-	// Set some syntax highlighting colors
-	// SCI_STYLESETFORE = 2051
-	// SCE_C_COMMENT = 1, SCE_C_COMMENTLINE = 2, SCE_C_NUMBER = 4,
-	// SCE_C_WORD = 5, SCE_C_STRING = 6, SCE_C_PREPROCESSOR = 9
-	ScintillaBridge_sendMessage(sci, 2051, 1, 0x008000);   // Comments: green
-	ScintillaBridge_sendMessage(sci, 2051, 2, 0x008000);   // Line comments: green
-	ScintillaBridge_sendMessage(sci, 2051, 4, 0xFF8000);   // Numbers: orange
-	ScintillaBridge_sendMessage(sci, 2051, 5, 0x0000FF);   // Keywords: blue
-	ScintillaBridge_sendMessage(sci, 2051, 6, 0x800080);   // Strings: purple
-	ScintillaBridge_sendMessage(sci, 2051, 9, 0x808080);   // Preprocessor: gray
-
-	// Bold keywords
-	// SCI_STYLESETBOLD = 2053
-	ScintillaBridge_sendMessage(sci, 2053, 5, 1);
-
-	// Enable code folding
-	// SCI_SETPROPERTY = 4004
-	ScintillaBridge_sendMessage(sci, 4004, (uintptr_t)"fold", (intptr_t)"1");
-	ScintillaBridge_sendMessage(sci, 4004, (uintptr_t)"fold.compact", (intptr_t)"0");
-
-	// SCI_SETMARGINTYPEN = 2240 (margin 2 = folder)
-	ScintillaBridge_sendMessage(sci, 2240, 2, 4);  // SC_MARGIN_SYMBOL = 1... actually type 4 for folding
-	// Hmm, let's use margin type SC_MARGIN_SYMBOL=1 with fold mask
-	// SCI_SETMARGINMASKN = 2244, SC_MASK_FOLDERS = 0xFE000000
-	ScintillaBridge_sendMessage(sci, 2244, 2, 0xFE000000);
-	ScintillaBridge_sendMessage(sci, 2242, 2, 16);  // Folder margin width
-
-	// SCI_SETMARGINSENSITIVEN = 2246
-	ScintillaBridge_sendMessage(sci, 2246, 2, 1);  // Make folder margin clickable
-
-	// Current line highlight
-	// SCI_SETCARETLINEVISIBLE = 2096
-	ScintillaBridge_sendMessage(sci, 2096, 1, 0);
-	// SCI_SETCARETLINEBACK = 2098
-	ScintillaBridge_sendMessage(sci, 2098, 0xF0F0F0, 0);
-}
-
-- (void)setupMenuBar
-{
-	NSMenu* mainMenu = [[NSMenu alloc] init];
-
-	// Application menu
-	NSMenuItem* appMenuItem = [[NSMenuItem alloc] init];
-	NSMenu* appMenu = [[NSMenu alloc] initWithTitle:@"Notepad++"];
-	[appMenu addItemWithTitle:@"About Notepad++" action:@selector(orderFrontStandardAboutPanel:) keyEquivalent:@""];
-	[appMenu addItem:[NSMenuItem separatorItem]];
-	[appMenu addItemWithTitle:@"Quit Notepad++" action:@selector(terminate:) keyEquivalent:@"q"];
-	appMenuItem.submenu = appMenu;
-	[mainMenu addItem:appMenuItem];
-
-	// File menu
-	NSMenuItem* fileMenuItem = [[NSMenuItem alloc] init];
-	NSMenu* fileMenu = [[NSMenu alloc] initWithTitle:@"File"];
-	[fileMenu addItemWithTitle:@"New" action:@selector(newDocument:) keyEquivalent:@"n"];
-	[fileMenu addItemWithTitle:@"Open..." action:@selector(openDocument:) keyEquivalent:@"o"];
-	[fileMenu addItem:[NSMenuItem separatorItem]];
-	[fileMenu addItemWithTitle:@"Close" action:@selector(performClose:) keyEquivalent:@"w"];
-	fileMenuItem.submenu = fileMenu;
-	[mainMenu addItem:fileMenuItem];
-
-	// Edit menu
-	NSMenuItem* editMenuItem = [[NSMenuItem alloc] init];
-	NSMenu* editMenu = [[NSMenu alloc] initWithTitle:@"Edit"];
-	[editMenu addItemWithTitle:@"Undo" action:@selector(undo:) keyEquivalent:@"z"];
-	[editMenu addItemWithTitle:@"Redo" action:@selector(redo:) keyEquivalent:@"Z"];
-	[editMenu addItem:[NSMenuItem separatorItem]];
-	[editMenu addItemWithTitle:@"Cut" action:@selector(cut:) keyEquivalent:@"x"];
-	[editMenu addItemWithTitle:@"Copy" action:@selector(copy:) keyEquivalent:@"c"];
-	[editMenu addItemWithTitle:@"Paste" action:@selector(paste:) keyEquivalent:@"v"];
-	[editMenu addItemWithTitle:@"Select All" action:@selector(selectAll:) keyEquivalent:@"a"];
-	editMenuItem.submenu = editMenu;
-	[mainMenu addItem:editMenuItem];
-
-	// View menu
-	NSMenuItem* viewMenuItem = [[NSMenuItem alloc] init];
-	NSMenu* viewMenu = [[NSMenu alloc] initWithTitle:@"View"];
-	[viewMenu addItemWithTitle:@"Toggle Word Wrap" action:@selector(toggleWordWrap:) keyEquivalent:@""];
-	viewMenuItem.submenu = viewMenu;
-	[mainMenu addItem:viewMenuItem];
-
-	[NSApp setMainMenu:mainMenu];
-}
+#define IDM_FILE_NEW          41001
+#define IDM_FILE_OPEN         41002
+#define IDM_FILE_SAVE         41006
+#define IDM_FILE_SAVEAS       41008
+#define IDM_FILE_CLOSE        41003
+#define IDM_EDIT_UNDO         42001
+#define IDM_EDIT_REDO         42002
+#define IDM_EDIT_CUT          42003
+#define IDM_EDIT_COPY         42004
+#define IDM_EDIT_PASTE        42005
+#define IDM_EDIT_SELECTALL    42013
+#define IDM_VIEW_WORDWRAP     42026
+#define IDM_VIEW_LINENUMBER   42027
 
 // ============================================================
-// Menu action handlers
+// Globals
+// ============================================================
+static void* g_scintillaView = nullptr;
+static NSWindow* g_mainWindow = nil;
+static HWND g_mainHwnd = nullptr;
+static wchar_t g_currentFilePath[MAX_PATH] = {0};
+
+// SCI message IDs
+enum {
+	SCI_CLEARALL = 2004,
+	SCI_SETSAVEPOINT = 2014,
+	SCI_GOTOPOS = 2025,
+	SCI_SETTABWIDTH = 2036,
+	SCI_SETCODEPAGE = 2037,
+	SCI_STYLECLEARALL = 2050,
+	SCI_STYLESETFORE = 2051,
+	SCI_STYLESETBOLD = 2053,
+	SCI_STYLESETSIZE = 2055,
+	SCI_STYLESETFONT = 2056,
+	SCI_GETMODIFY = 2159,
+	SCI_EMPTYUNDOBUFFER = 2175,
+	SCI_SETTEXT = 2181,
+	SCI_GETTEXT = 2182,
+	SCI_GETTEXTLENGTH = 2183,
+	SCI_SETMARGINTYPEN = 2240,
+	SCI_SETMARGINWIDTHN = 2242,
+	SCI_SETMARGINMASKN = 2244,
+	SCI_SETMARGINSENSITIVEN = 2246,
+	SCI_SETWRAPMODE = 2268,
+	SCI_GETWRAPMODE = 2269,
+	SCI_SETCARETLINEVISIBLE = 2096,
+	SCI_SETCARETLINEBACK = 2098,
+	SCI_SETUSETABS = 2124,
+	SCI_SETPROPERTY = 4004,
+	SCI_SETKEYWORDS = 4005,
+	SCI_SETLEXERLANGUAGE = 4006,
+};
+
+// ============================================================
+// File operations
 // ============================================================
 
-- (void)newDocument:(id)sender
+static void openFile()
 {
-	if (self.scintillaView)
-	{
-		// SCI_CLEARALL = 2004
-		ScintillaBridge_sendMessage(self.scintillaView, 2004, 0, 0);
-		// SCI_EMPTYUNDOBUFFER = 2175
-		ScintillaBridge_sendMessage(self.scintillaView, 2175, 0, 0);
-		// SCI_SETSAVEPOINT = 2014
-		ScintillaBridge_sendMessage(self.scintillaView, 2014, 0, 0);
-	}
-}
+	OPENFILENAMEW ofn = {};
+	wchar_t filePath[MAX_PATH] = {0};
 
-- (void)openDocument:(id)sender
-{
-	NSOpenPanel* panel = [NSOpenPanel openPanel];
-	panel.allowsMultipleSelection = NO;
-	panel.canChooseDirectories = NO;
+	ofn.lStructSize = sizeof(ofn);
+	ofn.hwndOwner = g_mainHwnd;
+	ofn.lpstrFile = filePath;
+	ofn.nMaxFile = MAX_PATH;
+	ofn.lpstrTitle = L"Open File";
+	// Filter format: pairs of (description, pattern) separated by \0, terminated by \0\0
+	ofn.lpstrFilter = L"All Files\0*.*\0"
+	                   L"C/C++ Files\0*.c;*.cpp;*.cc;*.h;*.hpp\0"
+	                   L"Text Files\0*.txt\0";
+	ofn.nFilterIndex = 1;
+	ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST;
 
-	if ([panel runModal] == NSModalResponseOK)
+	if (GetOpenFileNameW(&ofn))
 	{
-		NSURL* url = panel.URL;
+		// Read the file
+		NSString* path = [[NSString alloc] initWithBytes:filePath
+		                                          length:wcslen(filePath) * sizeof(wchar_t)
+		                                        encoding:NSUTF32LittleEndianStringEncoding];
 		NSError* error = nil;
-		NSString* content = [NSString stringWithContentsOfURL:url encoding:NSUTF8StringEncoding error:&error];
-		if (content && self.scintillaView)
+		NSString* content = [NSString stringWithContentsOfFile:path
+		                                             encoding:NSUTF8StringEncoding
+		                                                error:&error];
+		if (content && g_scintillaView)
 		{
 			const char* utf8 = [content UTF8String];
-			// SCI_SETTEXT = 2181
-			ScintillaBridge_sendMessage(self.scintillaView, 2181, 0, (intptr_t)utf8);
-			// SCI_EMPTYUNDOBUFFER = 2175
-			ScintillaBridge_sendMessage(self.scintillaView, 2175, 0, 0);
-			// SCI_SETSAVEPOINT = 2014
-			ScintillaBridge_sendMessage(self.scintillaView, 2014, 0, 0);
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTEXT, 0, (intptr_t)utf8);
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_EMPTYUNDOBUFFER, 0, 0);
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSAVEPOINT, 0, 0);
 
-			[self.mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@", url.lastPathComponent]];
+			// Store current file path
+			wcscpy(g_currentFilePath, filePath);
+
+			// Update window title
+			[g_mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@",
+			                        [path lastPathComponent]]];
 		}
 		else if (error)
 		{
@@ -281,20 +119,368 @@
 	}
 }
 
-- (void)toggleWordWrap:(id)sender
+static void saveFileAs()
 {
-	if (!self.scintillaView) return;
+	OPENFILENAMEW ofn = {};
+	wchar_t filePath[MAX_PATH] = {0};
 
-	// SCI_GETWRAPMODE = 2269
-	intptr_t mode = ScintillaBridge_sendMessage(self.scintillaView, 2269, 0, 0);
-	// Toggle: 0 = none, 1 = word
-	// SCI_SETWRAPMODE = 2268
-	ScintillaBridge_sendMessage(self.scintillaView, 2268, mode == 0 ? 1 : 0, 0);
+	// Pre-fill with current file path if we have one
+	if (g_currentFilePath[0] != L'\0')
+		wcscpy(filePath, g_currentFilePath);
+
+	ofn.lStructSize = sizeof(ofn);
+	ofn.hwndOwner = g_mainHwnd;
+	ofn.lpstrFile = filePath;
+	ofn.nMaxFile = MAX_PATH;
+	ofn.lpstrTitle = L"Save File As";
+	ofn.lpstrFilter = L"All Files\0*.*\0"
+	                   L"C/C++ Files\0*.c;*.cpp;*.cc;*.h;*.hpp\0"
+	                   L"Text Files\0*.txt\0";
+	ofn.nFilterIndex = 1;
+	ofn.Flags = OFN_OVERWRITEPROMPT;
+
+	if (GetSaveFileNameW(&ofn))
+	{
+		wcscpy(g_currentFilePath, filePath);
+		// Fall through to save logic
+		// Get text from Scintilla
+		if (g_scintillaView)
+		{
+			intptr_t len = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXTLENGTH, 0, 0);
+			if (len > 0)
+			{
+				char* buf = new char[len + 1];
+				ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXT, len + 1, (intptr_t)buf);
+
+				NSString* path = [[NSString alloc] initWithBytes:filePath
+				                                          length:wcslen(filePath) * sizeof(wchar_t)
+				                                        encoding:NSUTF32LittleEndianStringEncoding];
+				NSString* content = [NSString stringWithUTF8String:buf];
+				NSError* error = nil;
+				[content writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:&error];
+
+				if (error)
+					NSLog(@"Error saving file: %@", error);
+				else
+				{
+					ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSAVEPOINT, 0, 0);
+					[g_mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@",
+					                        [path lastPathComponent]]];
+				}
+
+				delete[] buf;
+			}
+		}
+	}
+}
+
+static void saveFile()
+{
+	if (g_currentFilePath[0] == L'\0')
+	{
+		saveFileAs();
+		return;
+	}
+
+	if (!g_scintillaView) return;
+
+	intptr_t len = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXTLENGTH, 0, 0);
+	if (len >= 0)
+	{
+		char* buf = new char[len + 1];
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXT, len + 1, (intptr_t)buf);
+
+		NSString* path = [[NSString alloc] initWithBytes:g_currentFilePath
+		                                          length:wcslen(g_currentFilePath) * sizeof(wchar_t)
+		                                        encoding:NSUTF32LittleEndianStringEncoding];
+		NSString* content = [NSString stringWithUTF8String:buf];
+		NSError* error = nil;
+		[content writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:&error];
+
+		if (error)
+			NSLog(@"Error saving file: %@", error);
+		else
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSAVEPOINT, 0, 0);
+
+		delete[] buf;
+	}
 }
 
 // ============================================================
-// Window delegate
+// WndProc — dispatches WM_COMMAND from menu items
 // ============================================================
+
+static LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+	switch (msg)
+	{
+		case WM_COMMAND:
+		{
+			UINT cmdId = LOWORD(wParam);
+			switch (cmdId)
+			{
+				case IDM_FILE_NEW:
+					if (g_scintillaView)
+					{
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_CLEARALL, 0, 0);
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_EMPTYUNDOBUFFER, 0, 0);
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSAVEPOINT, 0, 0);
+						g_currentFilePath[0] = L'\0';
+						[g_mainWindow setTitle:@"Notepad++ (macOS) — Untitled"];
+					}
+					return 0;
+
+				case IDM_FILE_OPEN:
+					openFile();
+					return 0;
+
+				case IDM_FILE_SAVE:
+					saveFile();
+					return 0;
+
+				case IDM_FILE_SAVEAS:
+					saveFileAs();
+					return 0;
+
+				case IDM_FILE_CLOSE:
+					[g_mainWindow performClose:nil];
+					return 0;
+
+				case IDM_VIEW_WORDWRAP:
+					if (g_scintillaView)
+					{
+						intptr_t mode = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETWRAPMODE, 0, 0);
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_SETWRAPMODE, mode == 0 ? 1 : 0, 0);
+
+						// Update the menu item check state
+						HMENU hMenu = GetMenu(hWnd);
+						if (hMenu)
+							CheckMenuItem(hMenu, IDM_VIEW_WORDWRAP,
+							              MF_BYCOMMAND | (mode == 0 ? MF_CHECKED : MF_UNCHECKED));
+					}
+					return 0;
+
+				case IDM_VIEW_LINENUMBER:
+					if (g_scintillaView)
+					{
+						static bool showLineNumbers = true;
+						showLineNumbers = !showLineNumbers;
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_SETMARGINWIDTHN, 0,
+						                           showLineNumbers ? 50 : 0);
+
+						HMENU hMenu = GetMenu(hWnd);
+						if (hMenu)
+							CheckMenuItem(hMenu, IDM_VIEW_LINENUMBER,
+							              MF_BYCOMMAND | (showLineNumbers ? MF_CHECKED : MF_UNCHECKED));
+					}
+					return 0;
+			}
+			break;
+		}
+
+		case WM_CLOSE:
+			PostQuitMessage(0);
+			return 0;
+	}
+
+	return DefWindowProcW(hWnd, msg, wParam, lParam);
+}
+
+// ============================================================
+// Build menus using Win32 API
+// ============================================================
+
+static HMENU buildMenuBar()
+{
+	HMENU hMenuBar = CreateMenu();
+
+	// File menu
+	HMENU hFileMenu = CreatePopupMenu();
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_NEW, L"&New\tCtrl+N");
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_OPEN, L"&Open...\tCtrl+O");
+	AppendMenuW(hFileMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_SAVE, L"&Save\tCtrl+S");
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_SAVEAS, L"Save &As...\tCtrl+Shift+S");
+	AppendMenuW(hFileMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_CLOSE, L"&Close\tCtrl+W");
+	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hFileMenu), L"&File");
+
+	// Edit menu
+	HMENU hEditMenu = CreatePopupMenu();
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_UNDO, L"&Undo\tCtrl+Z");
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_REDO, L"&Redo\tCtrl+Shift+Z");
+	AppendMenuW(hEditMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_CUT, L"Cu&t\tCtrl+X");
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_COPY, L"&Copy\tCtrl+C");
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_PASTE, L"&Paste\tCtrl+V");
+	AppendMenuW(hEditMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_SELECTALL, L"Select &All\tCtrl+A");
+	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hEditMenu), L"&Edit");
+
+	// View menu
+	HMENU hViewMenu = CreatePopupMenu();
+	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_WORDWRAP, L"&Word Wrap");
+	AppendMenuW(hViewMenu, MF_STRING | MF_CHECKED, IDM_VIEW_LINENUMBER, L"&Line Numbers");
+	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hViewMenu), L"&View");
+
+	return hMenuBar;
+}
+
+// ============================================================
+// Configure Scintilla editor
+// ============================================================
+
+static void configureScintilla(void* sci)
+{
+	if (!sci) return;
+
+	ScintillaBridge_sendMessage(sci, SCI_SETCODEPAGE, 65001, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETWRAPMODE, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTABWIDTH, 4, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETUSETABS, 0, 0);
+
+	// Line numbers
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINTYPEN, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINWIDTHN, 0, 50);
+
+	// C++ lexer
+	ScintillaBridge_sendMessage(sci, SCI_SETLEXERLANGUAGE, 0, (intptr_t)"cpp");
+
+	const char* keywords = "int char float double void bool true false "
+	                        "if else for while do switch case break continue return "
+	                        "class struct enum namespace using typedef "
+	                        "const static virtual override public private protected "
+	                        "new delete nullptr sizeof typeof "
+	                        "try catch throw include define ifdef ifndef endif";
+	ScintillaBridge_sendMessage(sci, SCI_SETKEYWORDS, 0, (intptr_t)keywords);
+
+	// Default style: Menlo 13pt
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETFONT, 32, (intptr_t)"Menlo");
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETSIZE, 32, 13);
+	ScintillaBridge_sendMessage(sci, SCI_STYLECLEARALL, 0, 0);
+
+	// Syntax colors
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETFORE, 1, 0x008000);  // Comments
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETFORE, 2, 0x008000);  // Line comments
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETFORE, 4, 0xFF8000);  // Numbers
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETFORE, 5, 0x0000FF);  // Keywords
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETFORE, 6, 0x800080);  // Strings
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETFORE, 9, 0x808080);  // Preprocessor
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETBOLD, 5, 1);
+
+	// Code folding
+	ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"fold", (intptr_t)"1");
+	ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"fold.compact", (intptr_t)"0");
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINTYPEN, 2, 4);
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINMASKN, 2, 0xFE000000);
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINWIDTHN, 2, 16);
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINSENSITIVEN, 2, 1);
+
+	// Current line highlight
+	ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEVISIBLE, 1, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEBACK, 0xF0F0F0, 0);
+}
+
+// ============================================================
+// Application Delegate
+// ============================================================
+
+@interface NppAppDelegate : NSObject <NSApplicationDelegate, NSWindowDelegate>
+@end
+
+@implementation NppAppDelegate
+
+- (void)applicationDidFinishLaunching:(NSNotification*)notification
+{
+	// Register a window class with our WndProc
+	WNDCLASSEXW wc = {};
+	wc.cbSize = sizeof(wc);
+	wc.lpfnWndProc = MainWndProc;
+	wc.lpszClassName = L"Notepad++";
+	wc.hInstance = nullptr;
+	RegisterClassExW(&wc);
+
+	// Build the menu bar using Win32 APIs
+	HMENU hMenuBar = buildMenuBar();
+
+	// Create the main window using Win32 API
+	g_mainHwnd = CreateWindowExW(
+		0,
+		L"Notepad++",
+		L"Notepad++ (macOS) — Phase 2",
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT, CW_USEDEFAULT,
+		900, 700,
+		nullptr,
+		hMenuBar,
+		nullptr,
+		nullptr
+	);
+
+	if (!g_mainHwnd)
+	{
+		NSLog(@"ERROR: Failed to create main window!");
+		return;
+	}
+
+	// Get the native NSWindow from the handle registry
+	auto* info = HandleRegistry::getWindowInfo(g_mainHwnd);
+	if (info && info->nativeWindow)
+	{
+		g_mainWindow = (__bridge NSWindow*)info->nativeWindow;
+		g_mainWindow.delegate = self;
+		[g_mainWindow setMinSize:NSMakeSize(400, 300)];
+	}
+
+	// Set the menu bar via Win32 API
+	SetMenu(g_mainHwnd, hMenuBar);
+
+	// Create Scintilla editor
+	NSView* contentView = g_mainWindow.contentView;
+	g_scintillaView = ScintillaBridge_createView((__bridge void*)contentView, 0, 0, 0, 0);
+	if (!g_scintillaView)
+	{
+		NSLog(@"ERROR: Failed to create ScintillaView!");
+		return;
+	}
+
+	configureScintilla(g_scintillaView);
+
+	// Set welcome text
+	const char* welcomeText =
+		"// Welcome to Notepad++ on macOS — Phase 2!\n"
+		"//\n"
+		"// What's new in Phase 2:\n"
+		"//   - Menu bar built with Win32 APIs (CreateMenu, AppendMenuW, SetMenu)\n"
+		"//   - File Open via GetOpenFileNameW → NSOpenPanel\n"
+		"//   - File Save/SaveAs via GetSaveFileNameW → NSSavePanel\n"
+		"//   - Keyboard shortcuts via NSMenuItem keyEquivalent\n"
+		"//   - WM_COMMAND dispatch from menu → WndProc\n"
+		"//   - Real NSTimer-backed SetTimer/KillTimer\n"
+		"//   - Clipboard read/write (GetClipboardData/SetClipboardData)\n"
+		"//\n"
+		"// Try: Cmd+O to open, Cmd+S to save, Cmd+N for new file\n"
+		"\n"
+		"#include <iostream>\n"
+		"\n"
+		"int main() {\n"
+		"    std::cout << \"Hello from Notepad++ macOS!\" << std::endl;\n"
+		"    return 0;\n"
+		"}\n";
+
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTEXT, 0, (intptr_t)welcomeText);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_GOTOPOS, 0, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_EMPTYUNDOBUFFER, 0, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSAVEPOINT, 0, 0);
+
+	// Show the window using Win32 API
+	ShowWindow(g_mainHwnd, SW_SHOW);
+
+	[NSApp activateIgnoringOtherApps:YES];
+
+	NSLog(@"=== Notepad++ macOS Port — Phase 2 ===");
+	NSLog(@"Menu bar, file dialogs, and WM_COMMAND dispatch working!");
+}
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication*)sender
 {
@@ -303,8 +489,8 @@
 
 - (void)windowDidResize:(NSNotification*)notification
 {
-	if (self.scintillaView)
-		ScintillaBridge_resizeToFit(self.scintillaView);
+	if (g_scintillaView)
+		ScintillaBridge_resizeToFit(g_scintillaView);
 }
 
 @end

--- a/macos/shim/src/win32_menu.mm
+++ b/macos/shim/src/win32_menu.mm
@@ -1,75 +1,1056 @@
-// Win32 Shim: Menu function stubs for macOS
-// Phase 0: Stub implementations. Phase 2 will add real NSMenu backing.
+// Win32 Shim: Menu, Dialog, Accelerator, Clipboard, Shell, Theme implementations for macOS
+// Phase 2: Real NSMenu backing for menu APIs, NSOpenPanel/NSSavePanel for file dialogs.
 
-#import <Foundation/Foundation.h>
+#import <Cocoa/Cocoa.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+#include <vector>
 #include "windows.h"
 #include "commdlg.h"
 #include "shellapi.h"
 #include "uxtheme.h"
+#include "handle_registry.h"
 
-HMENU CreateMenu() { return reinterpret_cast<HMENU>(1); }
-HMENU CreatePopupMenu() { return reinterpret_cast<HMENU>(1); }
-BOOL DestroyMenu(HMENU hMenu) { return TRUE; }
-HMENU LoadMenuW(HINSTANCE hInstance, LPCWSTR lpMenuName) { (void)hInstance; (void)lpMenuName; return nullptr; }
-HMENU GetMenu(HWND hWnd) { return nullptr; }
-BOOL SetMenu(HWND hWnd, HMENU hMenu) { return TRUE; }
-HMENU GetSubMenu(HMENU hMenu, int nPos) { return nullptr; }
-HMENU GetSystemMenu(HWND hWnd, BOOL bRevert) { return nullptr; }
-
-BOOL AppendMenuW(HMENU hMenu, UINT uFlags, UINT_PTR uIDNewItem, LPCWSTR lpNewItem) { return TRUE; }
-BOOL InsertMenuW(HMENU hMenu, UINT uPosition, UINT uFlags, UINT_PTR uIDNewItem, LPCWSTR lpNewItem) { return TRUE; }
-BOOL InsertMenuItemW(HMENU hMenu, UINT item, BOOL fByPosition, LPCMENUITEMINFOW lpmi) { return TRUE; }
-BOOL SetMenuItemInfoW(HMENU hMenu, UINT item, BOOL fByPosition, LPCMENUITEMINFOW lpmii) { return TRUE; }
-BOOL GetMenuItemInfoW(HMENU hMenu, UINT item, BOOL fByPosition, LPMENUITEMINFOW lpmii)
+// ============================================================
+// String helper: wchar_t* (UTF-32 on macOS) → NSString*
+// ============================================================
+static NSString* WideToNSString(const wchar_t* wstr)
 {
-	if (lpmii) memset(lpmii, 0, sizeof(MENUITEMINFOW));
-	return FALSE;
+	if (!wstr) return @"";
+	size_t len = wcslen(wstr);
+	NSString* str = [[NSString alloc] initWithBytes:wstr
+	                                         length:len * sizeof(wchar_t)
+	                                       encoding:NSUTF32LittleEndianStringEncoding];
+	return str ?: @"";
 }
-BOOL RemoveMenu(HMENU hMenu, UINT uPosition, UINT uFlags) { return TRUE; }
-BOOL DeleteMenu(HMENU hMenu, UINT uPosition, UINT uFlags) { return TRUE; }
-BOOL EnableMenuItem(HMENU hMenu, UINT uIDEnableItem, UINT uEnable) { return TRUE; }
-BOOL CheckMenuItem(HMENU hMenu, UINT uIDCheckItem, UINT uCheck) { return TRUE; }
-BOOL CheckMenuRadioItem(HMENU hMenu, UINT first, UINT last, UINT check, UINT flags) { return TRUE; }
-int GetMenuItemCount(HMENU hMenu) { return 0; }
-UINT GetMenuItemID(HMENU hMenu, int nPos) { return 0; }
-BOOL TrackPopupMenu(HMENU hMenu, UINT uFlags, int x, int y, int nReserved, HWND hWnd, const RECT* prcRect) { return FALSE; }
-BOOL TrackPopupMenuEx(HMENU hMenu, UINT fuFlags, int x, int y, HWND hwnd, LPTPMPARAMS lptpm) { return FALSE; }
-BOOL DrawMenuBar(HWND hWnd) { return TRUE; }
+
+// Convert NSString to wchar_t buffer (UTF-32LE on macOS)
+static void NSStringToWide(NSString* str, wchar_t* buffer, size_t maxChars)
+{
+	if (!buffer || maxChars == 0) return;
+	if (!str || str.length == 0)
+	{
+		buffer[0] = L'\0';
+		return;
+	}
+	NSData* data = [str dataUsingEncoding:NSUTF32LittleEndianStringEncoding];
+	size_t charCount = data.length / sizeof(wchar_t);
+	size_t copyLen = (charCount < maxChars - 1) ? charCount : maxChars - 1;
+	memcpy(buffer, data.bytes, copyLen * sizeof(wchar_t));
+	buffer[copyLen] = L'\0';
+}
+
+// Clean Win32 menu text: strip '&' accelerator markers and '\t' shortcut suffix
+static NSString* cleanMenuText(const wchar_t* wstr)
+{
+	if (!wstr) return @"";
+	NSString* raw = WideToNSString(wstr);
+	NSMutableString* result = [NSMutableString string];
+	for (NSUInteger i = 0; i < raw.length; ++i)
+	{
+		unichar c = [raw characterAtIndex:i];
+		if (c == '&')
+		{
+			if (i + 1 < raw.length && [raw characterAtIndex:i + 1] == '&')
+			{
+				[result appendString:@"&"];
+				++i;
+			}
+			// else skip single &
+		}
+		else if (c == '\t')
+		{
+			break; // Keyboard shortcut text follows — stop here
+		}
+		else
+		{
+			[result appendFormat:@"%C", c];
+		}
+	}
+	return result;
+}
+
+// Extract keyboard shortcut text after '\t' in menu text
+static NSString* extractShortcutText(const wchar_t* wstr)
+{
+	if (!wstr) return nil;
+	NSString* raw = WideToNSString(wstr);
+	NSRange tabRange = [raw rangeOfString:@"\t"];
+	if (tabRange.location != NSNotFound && tabRange.location + 1 < raw.length)
+		return [raw substringFromIndex:tabRange.location + 1];
+	return nil;
+}
+
+// Parse shortcut text like "Ctrl+O", "Ctrl+Shift+S", "F5" and set on NSMenuItem
+static void setKeyEquivalentFromText(NSMenuItem* item, NSString* shortcutText)
+{
+	if (!shortcutText || shortcutText.length == 0) return;
+
+	NSUInteger modifiers = 0;
+	NSString* key = @"";
+
+	NSArray<NSString*>* parts = [shortcutText componentsSeparatedByString:@"+"];
+	for (NSString* part in parts)
+	{
+		NSString* p = [part stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+		if ([p caseInsensitiveCompare:@"Ctrl"] == NSOrderedSame)
+			modifiers |= NSEventModifierFlagCommand; // Ctrl → Cmd on macOS
+		else if ([p caseInsensitiveCompare:@"Alt"] == NSOrderedSame)
+			modifiers |= NSEventModifierFlagOption;
+		else if ([p caseInsensitiveCompare:@"Shift"] == NSOrderedSame)
+			modifiers |= NSEventModifierFlagShift;
+		else
+		{
+			// Map function keys and special keys
+			if ([p caseInsensitiveCompare:@"F1"] == NSOrderedSame) key = [NSString stringWithFormat:@"%C", (unichar)NSF1FunctionKey];
+			else if ([p caseInsensitiveCompare:@"F2"] == NSOrderedSame) key = [NSString stringWithFormat:@"%C", (unichar)NSF2FunctionKey];
+			else if ([p caseInsensitiveCompare:@"F3"] == NSOrderedSame) key = [NSString stringWithFormat:@"%C", (unichar)NSF3FunctionKey];
+			else if ([p caseInsensitiveCompare:@"F4"] == NSOrderedSame) key = [NSString stringWithFormat:@"%C", (unichar)NSF4FunctionKey];
+			else if ([p caseInsensitiveCompare:@"F5"] == NSOrderedSame) key = [NSString stringWithFormat:@"%C", (unichar)NSF5FunctionKey];
+			else if ([p caseInsensitiveCompare:@"F6"] == NSOrderedSame) key = [NSString stringWithFormat:@"%C", (unichar)NSF6FunctionKey];
+			else if ([p caseInsensitiveCompare:@"F7"] == NSOrderedSame) key = [NSString stringWithFormat:@"%C", (unichar)NSF7FunctionKey];
+			else if ([p caseInsensitiveCompare:@"F8"] == NSOrderedSame) key = [NSString stringWithFormat:@"%C", (unichar)NSF8FunctionKey];
+			else if ([p caseInsensitiveCompare:@"F9"] == NSOrderedSame) key = [NSString stringWithFormat:@"%C", (unichar)NSF9FunctionKey];
+			else if ([p caseInsensitiveCompare:@"F10"] == NSOrderedSame) key = [NSString stringWithFormat:@"%C", (unichar)NSF10FunctionKey];
+			else if ([p caseInsensitiveCompare:@"F11"] == NSOrderedSame) key = [NSString stringWithFormat:@"%C", (unichar)NSF11FunctionKey];
+			else if ([p caseInsensitiveCompare:@"F12"] == NSOrderedSame) key = [NSString stringWithFormat:@"%C", (unichar)NSF12FunctionKey];
+			else if ([p caseInsensitiveCompare:@"Del"] == NSOrderedSame || [p caseInsensitiveCompare:@"Delete"] == NSOrderedSame)
+				key = [NSString stringWithFormat:@"%C", (unichar)NSDeleteFunctionKey];
+			else if ([p caseInsensitiveCompare:@"Enter"] == NSOrderedSame || [p caseInsensitiveCompare:@"Return"] == NSOrderedSame)
+				key = @"\r";
+			else if ([p caseInsensitiveCompare:@"Esc"] == NSOrderedSame || [p caseInsensitiveCompare:@"Escape"] == NSOrderedSame)
+				key = [NSString stringWithFormat:@"%C", (unichar)27];
+			else if ([p caseInsensitiveCompare:@"Tab"] == NSOrderedSame)
+				key = @"\t";
+			else if ([p caseInsensitiveCompare:@"Home"] == NSOrderedSame)
+				key = [NSString stringWithFormat:@"%C", (unichar)NSHomeFunctionKey];
+			else if ([p caseInsensitiveCompare:@"End"] == NSOrderedSame)
+				key = [NSString stringWithFormat:@"%C", (unichar)NSEndFunctionKey];
+			else if ([p caseInsensitiveCompare:@"PageUp"] == NSOrderedSame)
+				key = [NSString stringWithFormat:@"%C", (unichar)NSPageUpFunctionKey];
+			else if ([p caseInsensitiveCompare:@"PageDown"] == NSOrderedSame)
+				key = [NSString stringWithFormat:@"%C", (unichar)NSPageDownFunctionKey];
+			else
+				key = [p lowercaseString];
+		}
+	}
+
+	if (key.length > 0)
+	{
+		[item setKeyEquivalent:key];
+		[item setKeyEquivalentModifierMask:modifiers];
+	}
+}
+
+// ============================================================
+// Menu Target: dispatches NSMenuItem clicks as WM_COMMAND
+// ============================================================
+
+@interface Win32MenuTarget : NSObject
++ (instancetype)shared;
+- (void)menuItemClicked:(NSMenuItem*)sender;
+@end
+
+@implementation Win32MenuTarget
+
++ (instancetype)shared
+{
+	static Win32MenuTarget* instance = nil;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		instance = [[Win32MenuTarget alloc] init];
+	});
+	return instance;
+}
+
+- (void)menuItemClicked:(NSMenuItem*)sender
+{
+	UINT cmdId = static_cast<UINT>([sender tag]);
+	if (cmdId == 0) return;
+
+	// Dispatch WM_COMMAND to the main window
+	HWND mainWnd = HandleRegistry::getMainWindow();
+	if (mainWnd)
+	{
+		auto* info = HandleRegistry::getWindowInfo(mainWnd);
+		if (info && info->wndProc)
+		{
+			info->wndProc(mainWnd, WM_COMMAND, MAKEWPARAM(cmdId, 0), 0);
+			return;
+		}
+	}
+
+	// Fallback: try SendMessage
+	if (mainWnd)
+		SendMessageW(mainWnd, WM_COMMAND, MAKEWPARAM(cmdId, 0), 0);
+}
+
+@end
+
+// ============================================================
+// Menu Registry: HMENU → NSMenu* mapping
+// ============================================================
+
+static NSMutableDictionary<NSNumber*, NSMenu*>* s_menuMap = nil;
+static uintptr_t s_nextMenuHandle = 0x20000;
+
+// Per-window menu mapping: HWND → HMENU
+static NSMutableDictionary<NSNumber*, NSNumber*>* s_windowMenuMap = nil;
+
+static void ensureMenuMaps()
+{
+	if (!s_menuMap)
+		s_menuMap = [NSMutableDictionary dictionary];
+	if (!s_windowMenuMap)
+		s_windowMenuMap = [NSMutableDictionary dictionary];
+}
+
+static HMENU allocHmenu(NSMenu* menu)
+{
+	ensureMenuMaps();
+	HMENU h = reinterpret_cast<HMENU>(s_nextMenuHandle++);
+	s_menuMap[@(reinterpret_cast<uintptr_t>(h))] = menu;
+	return h;
+}
+
+static NSMenu* resolveMenu(HMENU h)
+{
+	ensureMenuMaps();
+	if (!h) return nil;
+	return s_menuMap[@(reinterpret_cast<uintptr_t>(h))];
+}
+
+static HMENU findHmenuForNSMenu(NSMenu* menu)
+{
+	ensureMenuMaps();
+	if (!menu) return nullptr;
+	for (NSNumber* key in s_menuMap)
+	{
+		if (s_menuMap[key] == menu)
+			return reinterpret_cast<HMENU>([key unsignedLongValue]);
+	}
+	return nullptr;
+}
+
+// ============================================================
+// Menu item helper: find item by command ID or position
+// ============================================================
+
+static NSMenuItem* findMenuItem(NSMenu* menu, UINT uItem, UINT uFlags)
+{
+	if (!menu) return nil;
+	if (uFlags & MF_BYPOSITION)
+	{
+		if (static_cast<int>(uItem) < [menu numberOfItems])
+			return [menu itemAtIndex:uItem];
+		return nil;
+	}
+	// By command ID
+	for (NSInteger i = 0; i < [menu numberOfItems]; ++i)
+	{
+		NSMenuItem* item = [menu itemAtIndex:i];
+		if (static_cast<UINT>([item tag]) == uItem)
+			return item;
+	}
+	return nil;
+}
+
+// Recursively find item by command ID in menu and all submenus
+static NSMenuItem* findMenuItemRecursive(NSMenu* menu, UINT cmdId)
+{
+	if (!menu) return nil;
+	for (NSInteger i = 0; i < [menu numberOfItems]; ++i)
+	{
+		NSMenuItem* item = [menu itemAtIndex:i];
+		if (static_cast<UINT>([item tag]) == cmdId)
+			return item;
+		if ([item hasSubmenu])
+		{
+			NSMenuItem* found = findMenuItemRecursive([item submenu], cmdId);
+			if (found) return found;
+		}
+	}
+	return nil;
+}
+
+// ============================================================
+// Menu API implementations
+// ============================================================
+
+HMENU CreateMenu()
+{
+	@autoreleasepool {
+		NSMenu* menu = [[NSMenu alloc] init];
+		[menu setAutoenablesItems:NO];
+		return allocHmenu(menu);
+	}
+}
+
+HMENU CreatePopupMenu()
+{
+	return CreateMenu();
+}
+
+BOOL DestroyMenu(HMENU hMenu)
+{
+	ensureMenuMaps();
+	NSNumber* key = @(reinterpret_cast<uintptr_t>(hMenu));
+	if (s_menuMap[key])
+	{
+		[s_menuMap removeObjectForKey:key];
+		return TRUE;
+	}
+	return TRUE;
+}
+
+HMENU LoadMenuW(HINSTANCE hInstance, LPCWSTR lpMenuName)
+{
+	// Can't load from resources on macOS. Return a valid empty menu
+	// so the N++ code can populate it dynamically.
+	return CreateMenu();
+}
+
+HMENU GetMenu(HWND hWnd)
+{
+	ensureMenuMaps();
+	NSNumber* key = @(reinterpret_cast<uintptr_t>(hWnd));
+	NSNumber* hmenuVal = s_windowMenuMap[key];
+	if (hmenuVal)
+		return reinterpret_cast<HMENU>([hmenuVal unsignedLongValue]);
+	return nullptr;
+}
+
+BOOL SetMenu(HWND hWnd, HMENU hMenu)
+{
+	ensureMenuMaps();
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu) return FALSE;
+
+	// Store the window → menu mapping
+	s_windowMenuMap[@(reinterpret_cast<uintptr_t>(hWnd))] = @(reinterpret_cast<uintptr_t>(hMenu));
+
+	// On macOS, we need to wrap the menu items under a main menu with an app menu
+	NSMenu* mainMenu = [[NSMenu alloc] init];
+	[mainMenu setAutoenablesItems:NO];
+
+	// Add application menu (About, Quit)
+	NSMenuItem* appMenuItem = [[NSMenuItem alloc] init];
+	NSMenu* appMenu = [[NSMenu alloc] initWithTitle:@"Notepad++"];
+	[appMenu addItemWithTitle:@"About Notepad++" action:@selector(orderFrontStandardAboutPanel:) keyEquivalent:@""];
+	[appMenu addItem:[NSMenuItem separatorItem]];
+	NSMenuItem* quitItem = [appMenu addItemWithTitle:@"Quit Notepad++" action:@selector(terminate:) keyEquivalent:@"q"];
+	(void)quitItem;
+	appMenuItem.submenu = appMenu;
+	[mainMenu addItem:appMenuItem];
+
+	// Add all items from the Win32 menu
+	// Each top-level item in hMenu becomes a top-level menu item
+	while ([menu numberOfItems] > 0)
+	{
+		NSMenuItem* item = [menu itemAtIndex:0];
+		[menu removeItemAtIndex:0];
+		[mainMenu addItem:item];
+	}
+
+	[NSApp setMainMenu:mainMenu];
+	return TRUE;
+}
+
+HMENU GetSubMenu(HMENU hMenu, int nPos)
+{
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu || nPos < 0 || nPos >= [menu numberOfItems])
+		return nullptr;
+
+	NSMenuItem* item = [menu itemAtIndex:nPos];
+	if ([item hasSubmenu])
+	{
+		NSMenu* submenu = [item submenu];
+		// Find or create HMENU for this submenu
+		HMENU h = findHmenuForNSMenu(submenu);
+		if (!h)
+			h = allocHmenu(submenu);
+		return h;
+	}
+	return nullptr;
+}
+
+HMENU GetSystemMenu(HWND hWnd, BOOL bRevert)
+{
+	return nullptr;
+}
+
+// ============================================================
+// Menu item insertion
+// ============================================================
+
+static NSMenuItem* createMenuItemFromFlags(UINT uFlags, UINT_PTR uIDNewItem, LPCWSTR lpNewItem)
+{
+	@autoreleasepool {
+		if (uFlags & MF_SEPARATOR)
+			return [NSMenuItem separatorItem];
+
+		NSString* title = cleanMenuText(lpNewItem);
+		NSMenuItem* item = [[NSMenuItem alloc] initWithTitle:title
+		                                             action:@selector(menuItemClicked:)
+		                                      keyEquivalent:@""];
+		item.target = [Win32MenuTarget shared];
+
+		if (uFlags & MF_POPUP)
+		{
+			// uIDNewItem is HMENU of submenu
+			HMENU subHmenu = reinterpret_cast<HMENU>(uIDNewItem);
+			NSMenu* submenu = resolveMenu(subHmenu);
+			if (submenu)
+			{
+				[submenu setTitle:title];
+				item.submenu = submenu;
+			}
+			item.action = nil;
+			item.target = nil;
+			item.tag = 0;
+		}
+		else
+		{
+			item.tag = static_cast<NSInteger>(uIDNewItem);
+		}
+
+		// Parse keyboard shortcut from menu text
+		NSString* shortcut = extractShortcutText(lpNewItem);
+		if (shortcut)
+			setKeyEquivalentFromText(item, shortcut);
+
+		if (uFlags & MF_CHECKED)
+			item.state = NSControlStateValueOn;
+
+		if (uFlags & (MF_DISABLED | MF_GRAYED))
+			item.enabled = NO;
+
+		return item;
+	}
+}
+
+BOOL AppendMenuW(HMENU hMenu, UINT uFlags, UINT_PTR uIDNewItem, LPCWSTR lpNewItem)
+{
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu) return FALSE;
+
+	NSMenuItem* item = createMenuItemFromFlags(uFlags, uIDNewItem, lpNewItem);
+	if (!item) return FALSE;
+
+	[menu addItem:item];
+	return TRUE;
+}
+
+BOOL InsertMenuW(HMENU hMenu, UINT uPosition, UINT uFlags, UINT_PTR uIDNewItem, LPCWSTR lpNewItem)
+{
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu) return FALSE;
+
+	NSMenuItem* item = createMenuItemFromFlags(uFlags, uIDNewItem, lpNewItem);
+	if (!item) return FALSE;
+
+	if (uFlags & MF_BYPOSITION)
+	{
+		NSInteger pos = static_cast<NSInteger>(uPosition);
+		if (pos > [menu numberOfItems]) pos = [menu numberOfItems];
+		[menu insertItem:item atIndex:pos];
+	}
+	else
+	{
+		// By command: insert before the item with this command ID
+		NSInteger idx = -1;
+		for (NSInteger i = 0; i < [menu numberOfItems]; ++i)
+		{
+			if (static_cast<UINT>([[menu itemAtIndex:i] tag]) == uPosition)
+			{
+				idx = i;
+				break;
+			}
+		}
+		if (idx >= 0)
+			[menu insertItem:item atIndex:idx];
+		else
+			[menu addItem:item]; // fallback: append
+	}
+	return TRUE;
+}
+
+BOOL InsertMenuItemW(HMENU hMenu, UINT item, BOOL fByPosition, LPCMENUITEMINFOW lpmi)
+{
+	if (!lpmi) return FALSE;
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu) return FALSE;
+
+	@autoreleasepool {
+		NSMenuItem* menuItem = nil;
+
+		// Determine type
+		bool isSeparator = false;
+		if (lpmi->fMask & MIIM_FTYPE)
+			isSeparator = (lpmi->fType & MFT_SEPARATOR) != 0;
+		else if (lpmi->fMask & MIIM_TYPE)
+			isSeparator = (lpmi->fType & MFT_SEPARATOR) != 0;
+
+		if (isSeparator)
+		{
+			menuItem = [NSMenuItem separatorItem];
+		}
+		else
+		{
+			NSString* title = @"";
+			if ((lpmi->fMask & MIIM_STRING) || (lpmi->fMask & MIIM_TYPE))
+			{
+				if (lpmi->dwTypeData)
+					title = cleanMenuText(lpmi->dwTypeData);
+			}
+
+			menuItem = [[NSMenuItem alloc] initWithTitle:title
+			                                      action:@selector(menuItemClicked:)
+			                               keyEquivalent:@""];
+			menuItem.target = [Win32MenuTarget shared];
+
+			// Command ID
+			if (lpmi->fMask & MIIM_ID)
+				menuItem.tag = static_cast<NSInteger>(lpmi->wID);
+
+			// Submenu
+			if (lpmi->fMask & MIIM_SUBMENU)
+			{
+				NSMenu* submenu = resolveMenu(lpmi->hSubMenu);
+				if (submenu)
+				{
+					[submenu setTitle:title];
+					menuItem.submenu = submenu;
+					menuItem.action = nil;
+					menuItem.target = nil;
+				}
+			}
+
+			// State
+			if (lpmi->fMask & MIIM_STATE)
+			{
+				if (lpmi->fState & MFS_CHECKED)
+					menuItem.state = NSControlStateValueOn;
+				if (lpmi->fState & MFS_DISABLED)
+					menuItem.enabled = NO;
+			}
+
+			// Parse shortcut from text
+			if (lpmi->dwTypeData)
+			{
+				NSString* shortcut = extractShortcutText(lpmi->dwTypeData);
+				if (shortcut)
+					setKeyEquivalentFromText(menuItem, shortcut);
+			}
+
+			// Item data
+			if (lpmi->fMask & MIIM_DATA)
+				menuItem.representedObject = @(lpmi->dwItemData);
+		}
+
+		// Insert at position
+		if (fByPosition)
+		{
+			NSInteger pos = static_cast<NSInteger>(item);
+			if (pos > [menu numberOfItems]) pos = [menu numberOfItems];
+			[menu insertItem:menuItem atIndex:pos];
+		}
+		else
+		{
+			// Insert before the item with this command ID
+			NSInteger idx = -1;
+			for (NSInteger i = 0; i < [menu numberOfItems]; ++i)
+			{
+				if (static_cast<UINT>([[menu itemAtIndex:i] tag]) == item)
+				{
+					idx = i;
+					break;
+				}
+			}
+			if (idx >= 0)
+				[menu insertItem:menuItem atIndex:idx];
+			else
+				[menu addItem:menuItem];
+		}
+
+		return TRUE;
+	}
+}
+
+BOOL SetMenuItemInfoW(HMENU hMenu, UINT uItem, BOOL fByPosition, LPCMENUITEMINFOW lpmii)
+{
+	if (!lpmii) return FALSE;
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu) return FALSE;
+
+	NSMenuItem* menuItem = findMenuItem(menu, uItem, fByPosition ? MF_BYPOSITION : MF_BYCOMMAND);
+	if (!menuItem) return FALSE;
+
+	@autoreleasepool {
+		if ((lpmii->fMask & MIIM_STRING) || (lpmii->fMask & MIIM_TYPE))
+		{
+			if (lpmii->dwTypeData)
+			{
+				menuItem.title = cleanMenuText(lpmii->dwTypeData);
+				NSString* shortcut = extractShortcutText(lpmii->dwTypeData);
+				if (shortcut)
+					setKeyEquivalentFromText(menuItem, shortcut);
+			}
+		}
+
+		if (lpmii->fMask & MIIM_ID)
+			menuItem.tag = static_cast<NSInteger>(lpmii->wID);
+
+		if (lpmii->fMask & MIIM_STATE)
+		{
+			menuItem.state = (lpmii->fState & MFS_CHECKED) ? NSControlStateValueOn : NSControlStateValueOff;
+			menuItem.enabled = !(lpmii->fState & MFS_DISABLED);
+		}
+
+		if (lpmii->fMask & MIIM_SUBMENU)
+		{
+			NSMenu* submenu = resolveMenu(lpmii->hSubMenu);
+			menuItem.submenu = submenu;
+			if (submenu)
+			{
+				menuItem.action = nil;
+				menuItem.target = nil;
+			}
+		}
+
+		if (lpmii->fMask & MIIM_DATA)
+			menuItem.representedObject = @(lpmii->dwItemData);
+
+		return TRUE;
+	}
+}
+
+BOOL GetMenuItemInfoW(HMENU hMenu, UINT uItem, BOOL fByPosition, LPMENUITEMINFOW lpmii)
+{
+	if (!lpmii) return FALSE;
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu) return FALSE;
+
+	NSMenuItem* menuItem = findMenuItem(menu, uItem, fByPosition ? MF_BYPOSITION : MF_BYCOMMAND);
+	if (!menuItem) return FALSE;
+
+	if (lpmii->fMask & MIIM_ID)
+		lpmii->wID = static_cast<UINT>([menuItem tag]);
+
+	if (lpmii->fMask & MIIM_STATE)
+	{
+		lpmii->fState = 0;
+		if (menuItem.state == NSControlStateValueOn)
+			lpmii->fState |= MFS_CHECKED;
+		if (!menuItem.enabled)
+			lpmii->fState |= MFS_DISABLED;
+	}
+
+	if (lpmii->fMask & MIIM_SUBMENU)
+	{
+		if ([menuItem hasSubmenu])
+			lpmii->hSubMenu = findHmenuForNSMenu([menuItem submenu]);
+		else
+			lpmii->hSubMenu = nullptr;
+	}
+
+	if ((lpmii->fMask & MIIM_STRING) || (lpmii->fMask & MIIM_TYPE))
+	{
+		if (lpmii->dwTypeData && lpmii->cch > 0)
+		{
+			NSStringToWide(menuItem.title, lpmii->dwTypeData, lpmii->cch);
+			lpmii->cch = static_cast<UINT>(menuItem.title.length);
+		}
+		else
+		{
+			lpmii->cch = static_cast<UINT>(menuItem.title.length);
+		}
+	}
+
+	if (lpmii->fMask & MIIM_FTYPE)
+	{
+		lpmii->fType = menuItem.isSeparatorItem ? MFT_SEPARATOR : MFT_STRING;
+	}
+
+	if (lpmii->fMask & MIIM_DATA)
+	{
+		if ([menuItem.representedObject isKindOfClass:[NSNumber class]])
+			lpmii->dwItemData = [(NSNumber*)menuItem.representedObject unsignedLongValue];
+		else
+			lpmii->dwItemData = 0;
+	}
+
+	return TRUE;
+}
+
+BOOL RemoveMenu(HMENU hMenu, UINT uPosition, UINT uFlags)
+{
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu) return FALSE;
+
+	NSMenuItem* item = findMenuItem(menu, uPosition, uFlags);
+	if (!item) return FALSE;
+
+	[menu removeItem:item];
+	return TRUE;
+}
+
+BOOL DeleteMenu(HMENU hMenu, UINT uPosition, UINT uFlags)
+{
+	// DeleteMenu is like RemoveMenu but also destroys submenus
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu) return FALSE;
+
+	NSMenuItem* item = findMenuItem(menu, uPosition, uFlags);
+	if (!item) return FALSE;
+
+	if ([item hasSubmenu])
+	{
+		HMENU subH = findHmenuForNSMenu([item submenu]);
+		if (subH) DestroyMenu(subH);
+	}
+
+	[menu removeItem:item];
+	return TRUE;
+}
+
+BOOL EnableMenuItem(HMENU hMenu, UINT uIDEnableItem, UINT uEnable)
+{
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu) return static_cast<BOOL>(-1);
+
+	// Check both the direct menu and recursively
+	NSMenuItem* item = nullptr;
+	if (uEnable & MF_BYPOSITION)
+		item = findMenuItem(menu, uIDEnableItem, MF_BYPOSITION);
+	else
+		item = findMenuItemRecursive(menu, uIDEnableItem);
+
+	if (!item) return static_cast<BOOL>(-1);
+
+	BOOL wasEnabled = item.enabled;
+	BOOL enable = !((uEnable & MF_DISABLED) || (uEnable & MF_GRAYED));
+	item.enabled = enable;
+
+	return wasEnabled ? MF_ENABLED : MF_GRAYED;
+}
+
+BOOL CheckMenuItem(HMENU hMenu, UINT uIDCheckItem, UINT uCheck)
+{
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu) return static_cast<BOOL>(-1);
+
+	NSMenuItem* item = nullptr;
+	if (uCheck & MF_BYPOSITION)
+		item = findMenuItem(menu, uIDCheckItem, MF_BYPOSITION);
+	else
+		item = findMenuItemRecursive(menu, uIDCheckItem);
+
+	if (!item) return static_cast<BOOL>(-1);
+
+	DWORD prevState = (item.state == NSControlStateValueOn) ? MF_CHECKED : MF_UNCHECKED;
+	item.state = (uCheck & MF_CHECKED) ? NSControlStateValueOn : NSControlStateValueOff;
+	return prevState;
+}
+
+BOOL CheckMenuRadioItem(HMENU hMenu, UINT first, UINT last, UINT check, UINT flags)
+{
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu) return FALSE;
+
+	for (UINT id = first; id <= last; ++id)
+	{
+		NSMenuItem* item = findMenuItem(menu, id, flags);
+		if (item)
+			item.state = (id == check) ? NSControlStateValueOn : NSControlStateValueOff;
+	}
+	return TRUE;
+}
+
+int GetMenuItemCount(HMENU hMenu)
+{
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu) return -1;
+	return static_cast<int>([menu numberOfItems]);
+}
+
+UINT GetMenuItemID(HMENU hMenu, int nPos)
+{
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu || nPos < 0 || nPos >= [menu numberOfItems])
+		return static_cast<UINT>(-1);
+
+	NSMenuItem* item = [menu itemAtIndex:nPos];
+	if ([item hasSubmenu])
+		return static_cast<UINT>(-1);
+	return static_cast<UINT>([item tag]);
+}
+
+BOOL TrackPopupMenu(HMENU hMenu, UINT uFlags, int x, int y, int nReserved, HWND hWnd, const RECT* prcRect)
+{
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu) return FALSE;
+
+	@autoreleasepool {
+		// Convert screen coordinates to Cocoa coordinates
+		NSRect screenFrame = [[NSScreen mainScreen] frame];
+		NSPoint point = NSMakePoint(x, screenFrame.size.height - y);
+
+		// Find the NSView for the given HWND
+		NSView* view = nil;
+		auto* info = HandleRegistry::getWindowInfo(hWnd);
+		if (info && info->nativeView)
+			view = (__bridge NSView*)info->nativeView;
+
+		if (view)
+		{
+			// Convert screen point to view coordinates
+			NSWindow* window = [view window];
+			if (window)
+			{
+				NSPoint windowPt = [window convertPointFromScreen:point];
+				NSPoint viewPt = [view convertPoint:windowPt fromView:nil];
+				[menu popUpMenuPositioningItem:nil atLocation:viewPt inView:view];
+			}
+			else
+			{
+				[menu popUpMenuPositioningItem:nil atLocation:point inView:nil];
+			}
+		}
+		else
+		{
+			[menu popUpMenuPositioningItem:nil atLocation:point inView:nil];
+		}
+	}
+	return TRUE;
+}
+
+BOOL TrackPopupMenuEx(HMENU hMenu, UINT fuFlags, int x, int y, HWND hwnd, LPTPMPARAMS lptpm)
+{
+	return TrackPopupMenu(hMenu, fuFlags, x, y, 0, hwnd, nullptr);
+}
+
+BOOL DrawMenuBar(HWND hWnd)
+{
+	// On macOS, the menu bar auto-updates
+	return TRUE;
+}
+
 int GetMenuStringW(HMENU hMenu, UINT uIDItem, LPWSTR lpString, int cchMax, UINT flags)
 {
-	if (lpString && cchMax > 0) lpString[0] = L'\0';
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu)
+	{
+		if (lpString && cchMax > 0) lpString[0] = L'\0';
+		return 0;
+	}
+
+	NSMenuItem* item = findMenuItem(menu, uIDItem, flags);
+	if (!item)
+	{
+		if (lpString && cchMax > 0) lpString[0] = L'\0';
+		return 0;
+	}
+
+	if (lpString && cchMax > 0)
+	{
+		NSStringToWide(item.title, lpString, static_cast<size_t>(cchMax));
+		return static_cast<int>(wcslen(lpString));
+	}
+	return static_cast<int>(item.title.length);
+}
+
+UINT GetMenuState(HMENU hMenu, UINT uId, UINT uFlags)
+{
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu) return static_cast<UINT>(-1);
+
+	NSMenuItem* item = findMenuItem(menu, uId, uFlags);
+	if (!item) return static_cast<UINT>(-1);
+
+	UINT state = 0;
+	if (item.state == NSControlStateValueOn) state |= MF_CHECKED;
+	if (!item.enabled) state |= MF_GRAYED;
+	if (item.isSeparatorItem) state |= MF_SEPARATOR;
+	if ([item hasSubmenu])
+		state |= MF_POPUP;
+	return state;
+}
+
+BOOL ModifyMenuW(HMENU hMenu, UINT uPosition, UINT uFlags, UINT_PTR uIDNewItem, LPCWSTR lpNewItem)
+{
+	NSMenu* menu = resolveMenu(hMenu);
+	if (!menu) return FALSE;
+
+	// Find the existing item
+	NSMenuItem* oldItem = findMenuItem(menu, uPosition, uFlags);
+	if (!oldItem) return FALSE;
+
+	NSInteger idx = [menu indexOfItem:oldItem];
+	if (idx == -1) return FALSE;
+
+	// Remove old and insert new at same position
+	[menu removeItemAtIndex:idx];
+
+	NSMenuItem* newItem = createMenuItemFromFlags(uFlags, uIDNewItem, lpNewItem);
+	if (!newItem) return FALSE;
+
+	[menu insertItem:newItem atIndex:idx];
+	return TRUE;
+}
+
+// ============================================================
+// Accelerators
+// ============================================================
+
+struct AccelTableData
+{
+	std::vector<ACCEL> entries;
+};
+
+HACCEL LoadAcceleratorsW(HINSTANCE hInstance, LPCWSTR lpTableName)
+{
+	// Can't load from resources; return nullptr
+	return nullptr;
+}
+
+int TranslateAcceleratorW(HWND hWnd, HACCEL hAccTable, LPMSG lpMsg)
+{
+	// On macOS, accelerators are handled by NSMenuItem keyEquivalents
+	// and the Cocoa event system. This is a no-op.
 	return 0;
 }
-UINT GetMenuState(HMENU hMenu, UINT uId, UINT uFlags) { return 0; }
-BOOL ModifyMenuW(HMENU hMenu, UINT uPosition, UINT uFlags, UINT_PTR uIDNewItem, LPCWSTR lpNewItem) { return TRUE; }
+
+HACCEL CreateAcceleratorTableW(LPACCEL paccel, int cAccel)
+{
+	if (!paccel || cAccel <= 0) return nullptr;
+
+	auto* table = new AccelTableData();
+	table->entries.assign(paccel, paccel + cAccel);
+	return reinterpret_cast<HACCEL>(table);
+}
+
+BOOL DestroyAcceleratorTable(HACCEL hAccel)
+{
+	if (hAccel)
+	{
+		auto* table = reinterpret_cast<AccelTableData*>(hAccel);
+		delete table;
+	}
+	return TRUE;
+}
 
 // ============================================================
-// Accelerators (stubs)
+// Clipboard
 // ============================================================
-HACCEL LoadAcceleratorsW(HINSTANCE hInstance, LPCWSTR lpTableName) { return nullptr; }
-int TranslateAcceleratorW(HWND hWnd, HACCEL hAccTable, LPMSG lpMsg) { return 0; }
-HACCEL CreateAcceleratorTableW(LPACCEL paccel, int cAccel) { return nullptr; }
-BOOL DestroyAcceleratorTable(HACCEL hAccel) { return TRUE; }
 
-// ============================================================
-// Clipboard (stubs)
-// ============================================================
 BOOL OpenClipboard(HWND hWndNewOwner) { return TRUE; }
 BOOL CloseClipboard() { return TRUE; }
-BOOL EmptyClipboard() { return TRUE; }
-HANDLE SetClipboardData(UINT uFormat, HANDLE hMem) { return hMem; }
-HANDLE GetClipboardData(UINT uFormat) { return nullptr; }
-BOOL IsClipboardFormatAvailable(UINT format) { return FALSE; }
-int CountClipboardFormats() { return 0; }
+
+BOOL EmptyClipboard()
+{
+	@autoreleasepool {
+		[[NSPasteboard generalPasteboard] clearContents];
+	}
+	return TRUE;
+}
+
+HANDLE SetClipboardData(UINT uFormat, HANDLE hMem)
+{
+	if (!hMem) return nullptr;
+	@autoreleasepool {
+		if (uFormat == CF_UNICODETEXT)
+		{
+			const wchar_t* wstr = static_cast<const wchar_t*>(hMem);
+			NSString* str = WideToNSString(wstr);
+			[[NSPasteboard generalPasteboard] clearContents];
+			[[NSPasteboard generalPasteboard] setString:str forType:NSPasteboardTypeString];
+		}
+		else if (uFormat == CF_TEXT)
+		{
+			const char* cstr = static_cast<const char*>(hMem);
+			NSString* str = [NSString stringWithUTF8String:cstr];
+			[[NSPasteboard generalPasteboard] clearContents];
+			[[NSPasteboard generalPasteboard] setString:str forType:NSPasteboardTypeString];
+		}
+	}
+	return hMem;
+}
+
+HANDLE GetClipboardData(UINT uFormat)
+{
+	@autoreleasepool {
+		NSPasteboard* pb = [NSPasteboard generalPasteboard];
+		NSString* str = [pb stringForType:NSPasteboardTypeString];
+		if (!str) return nullptr;
+
+		if (uFormat == CF_UNICODETEXT)
+		{
+			// Return a wide string buffer (caller is responsible for GlobalFree)
+			NSData* data = [str dataUsingEncoding:NSUTF32LittleEndianStringEncoding];
+			size_t bufSize = data.length + sizeof(wchar_t); // +null terminator
+			void* buf = GlobalAlloc(GMEM_FIXED, bufSize);
+			memcpy(buf, data.bytes, data.length);
+			memset(static_cast<char*>(buf) + data.length, 0, sizeof(wchar_t));
+			return buf;
+		}
+		else if (uFormat == CF_TEXT)
+		{
+			const char* utf8 = [str UTF8String];
+			size_t len = strlen(utf8) + 1;
+			void* buf = GlobalAlloc(GMEM_FIXED, len);
+			memcpy(buf, utf8, len);
+			return buf;
+		}
+	}
+	return nullptr;
+}
+
+BOOL IsClipboardFormatAvailable(UINT format)
+{
+	@autoreleasepool {
+		NSPasteboard* pb = [NSPasteboard generalPasteboard];
+		if (format == CF_UNICODETEXT || format == CF_TEXT)
+			return [pb stringForType:NSPasteboardTypeString] != nil;
+	}
+	return FALSE;
+}
+
+int CountClipboardFormats()
+{
+	@autoreleasepool {
+		return static_cast<int>([[[NSPasteboard generalPasteboard] types] count]);
+	}
+}
+
 UINT EnumClipboardFormats(UINT format) { return 0; }
 HWND GetClipboardOwner() { return nullptr; }
 
 // ============================================================
-// Shell API stubs
+// Shell API
 // ============================================================
+
 HINSTANCE ShellExecuteW(HWND hwnd, LPCWSTR lpOperation, LPCWSTR lpFile,
                         LPCWSTR lpParameters, LPCWSTR lpDirectory, INT nShowCmd)
 {
+	@autoreleasepool {
+		NSString* filePath = WideToNSString(lpFile);
+		if (filePath.length > 0)
+		{
+			NSURL* url = nil;
+			if ([filePath hasPrefix:@"http://"] || [filePath hasPrefix:@"https://"] ||
+			    [filePath hasPrefix:@"ftp://"] || [filePath hasPrefix:@"mailto:"])
+			{
+				url = [NSURL URLWithString:filePath];
+			}
+			else
+			{
+				url = [NSURL fileURLWithPath:filePath];
+			}
+			if (url)
+				[[NSWorkspace sharedWorkspace] openURL:url];
+		}
+	}
 	return reinterpret_cast<HINSTANCE>(33); // > 32 means success
 }
 
@@ -77,7 +1058,19 @@ HINSTANCE ShellExecuteW(HWND hwnd, LPCWSTR lpOperation, LPCWSTR lpFile,
 HINSTANCE ShellExecuteW(HWND hwnd, LPCWSTR lpOperation, const char* lpFile,
                         LPCWSTR lpParameters, LPCWSTR lpDirectory, INT nShowCmd)
 {
-	(void)hwnd; (void)lpOperation; (void)lpFile; (void)lpParameters; (void)lpDirectory; (void)nShowCmd;
+	@autoreleasepool {
+		if (lpFile)
+		{
+			NSString* filePath = [NSString stringWithUTF8String:lpFile];
+			NSURL* url = nil;
+			if ([filePath hasPrefix:@"http://"] || [filePath hasPrefix:@"https://"])
+				url = [NSURL URLWithString:filePath];
+			else
+				url = [NSURL fileURLWithPath:filePath];
+			if (url)
+				[[NSWorkspace sharedWorkspace] openURL:url];
+		}
+	}
 	return reinterpret_cast<HINSTANCE>(33);
 }
 
@@ -93,11 +1086,262 @@ BOOL Shell_NotifyIconW(DWORD dwMessage, PNOTIFYICONDATAW lpData) { return TRUE; 
 HICON ExtractIconW(HINSTANCE hInst, LPCWSTR lpszExeFileName, UINT nIconIndex) { return nullptr; }
 
 // ============================================================
-// Common dialog stubs
+// Common Dialogs: File Open/Save
 // ============================================================
-BOOL GetOpenFileNameW(LPOPENFILENAMEW lpofn) { return FALSE; }
-BOOL GetSaveFileNameW(LPOPENFILENAMEW lpofn) { return FALSE; }
-BOOL ChooseColorW(LPCHOOSECOLORW lpcc) { return FALSE; }
+
+// Parse Win32 filter string: "Desc\0*.ext;*.ext2\0Desc2\0*.ext3\0\0"
+static NSArray<NSArray<NSString*>*>* parseFilterPairs(const wchar_t* filter)
+{
+	NSMutableArray<NSArray<NSString*>*>* pairs = [NSMutableArray array];
+	if (!filter) return pairs;
+
+	const wchar_t* p = filter;
+	while (*p)
+	{
+		NSString* desc = WideToNSString(p);
+		p += wcslen(p) + 1;
+		if (!*p) break;
+		NSString* patterns = WideToNSString(p);
+		p += wcslen(p) + 1;
+		[pairs addObject:@[desc, patterns]];
+	}
+	return pairs;
+}
+
+// Extract file extensions from pattern string like "*.cpp;*.h;*.hpp"
+static NSArray<NSString*>* extractExtensions(NSString* patterns)
+{
+	NSMutableArray<NSString*>* exts = [NSMutableArray array];
+	NSArray<NSString*>* parts = [patterns componentsSeparatedByString:@";"];
+	for (NSString* part in parts)
+	{
+		NSString* p = [part stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+		if ([p isEqualToString:@"*.*"])
+			return @[]; // All files
+		if ([p hasPrefix:@"*."])
+		{
+			NSString* ext = [p substringFromIndex:2];
+			if (ext.length > 0)
+				[exts addObject:ext];
+		}
+	}
+	return exts;
+}
+
+BOOL GetOpenFileNameW(LPOPENFILENAMEW lpofn)
+{
+	if (!lpofn) return FALSE;
+
+	@autoreleasepool {
+		NSOpenPanel* panel = [NSOpenPanel openPanel];
+		[panel setCanChooseFiles:YES];
+		[panel setCanChooseDirectories:NO];
+		[panel setAllowsMultipleSelection:(lpofn->Flags & OFN_ALLOWMULTISELECT) != 0];
+
+		// Title
+		if (lpofn->lpstrTitle)
+			[panel setTitle:WideToNSString(lpofn->lpstrTitle)];
+
+		// Initial directory
+		if (lpofn->lpstrInitialDir)
+			[panel setDirectoryURL:[NSURL fileURLWithPath:WideToNSString(lpofn->lpstrInitialDir)]];
+
+		// File type filter
+		NSArray<NSArray<NSString*>*>* filterPairs = parseFilterPairs(lpofn->lpstrFilter);
+		if (filterPairs.count > 0)
+		{
+			// Use the filter at nFilterIndex (1-based) or first filter
+			NSUInteger filterIdx = (lpofn->nFilterIndex > 0) ? lpofn->nFilterIndex - 1 : 0;
+			if (filterIdx < filterPairs.count)
+			{
+				NSArray<NSString*>* exts = extractExtensions(filterPairs[filterIdx][1]);
+				if (exts.count > 0)
+				{
+					NSMutableArray<UTType*>* types = [NSMutableArray array];
+					for (NSString* ext in exts)
+					{
+						UTType* type = [UTType typeWithFilenameExtension:ext];
+						if (type) [types addObject:type];
+					}
+					if (types.count > 0)
+						[panel setAllowedContentTypes:types];
+				}
+			}
+		}
+
+		// Default extension
+		if (lpofn->lpstrDefExt)
+		{
+			NSString* defExt = WideToNSString(lpofn->lpstrDefExt);
+			if (defExt.length > 0)
+			{
+				UTType* defType = [UTType typeWithFilenameExtension:defExt];
+				if (defType && panel.allowedContentTypes.count == 0)
+					[panel setAllowedContentTypes:@[defType]];
+			}
+		}
+
+		NSModalResponse response = [panel runModal];
+		if (response != NSModalResponseOK)
+			return FALSE;
+
+		NSURL* url = panel.URL;
+		if (!url) return FALSE;
+
+		NSString* path = [url path];
+		if (lpofn->lpstrFile && lpofn->nMaxFile > 0)
+		{
+			NSStringToWide(path, lpofn->lpstrFile, lpofn->nMaxFile);
+
+			// Set nFileOffset and nFileExtension
+			NSString* fileName = [path lastPathComponent];
+			NSString* dirPath = [path stringByDeletingLastPathComponent];
+			lpofn->nFileOffset = static_cast<WORD>(dirPath.length + 1);
+			NSRange dotRange = [fileName rangeOfString:@"." options:NSBackwardsSearch];
+			if (dotRange.location != NSNotFound)
+				lpofn->nFileExtension = static_cast<WORD>(lpofn->nFileOffset + dotRange.location + 1);
+			else
+				lpofn->nFileExtension = 0;
+		}
+
+		if (lpofn->lpstrFileTitle && lpofn->nMaxFileTitle > 0)
+		{
+			NSString* fileName = [path lastPathComponent];
+			NSStringToWide(fileName, lpofn->lpstrFileTitle, lpofn->nMaxFileTitle);
+		}
+
+		return TRUE;
+	}
+}
+
+BOOL GetSaveFileNameW(LPOPENFILENAMEW lpofn)
+{
+	if (!lpofn) return FALSE;
+
+	@autoreleasepool {
+		NSSavePanel* panel = [NSSavePanel savePanel];
+
+		// Title
+		if (lpofn->lpstrTitle)
+			[panel setTitle:WideToNSString(lpofn->lpstrTitle)];
+
+		// Initial directory
+		if (lpofn->lpstrInitialDir)
+			[panel setDirectoryURL:[NSURL fileURLWithPath:WideToNSString(lpofn->lpstrInitialDir)]];
+
+		// Default filename
+		if (lpofn->lpstrFile && lpofn->lpstrFile[0] != L'\0')
+		{
+			NSString* path = WideToNSString(lpofn->lpstrFile);
+			NSString* fileName = [path lastPathComponent];
+			if (fileName.length > 0)
+				[panel setNameFieldStringValue:fileName];
+		}
+
+		// Overwrite prompt
+		if (!(lpofn->Flags & OFN_OVERWRITEPROMPT))
+			[panel setCanCreateDirectories:YES];
+
+		// File type filter
+		NSArray<NSArray<NSString*>*>* filterPairs = parseFilterPairs(lpofn->lpstrFilter);
+		if (filterPairs.count > 0)
+		{
+			NSUInteger filterIdx = (lpofn->nFilterIndex > 0) ? lpofn->nFilterIndex - 1 : 0;
+			if (filterIdx < filterPairs.count)
+			{
+				NSArray<NSString*>* exts = extractExtensions(filterPairs[filterIdx][1]);
+				if (exts.count > 0)
+				{
+					NSMutableArray<UTType*>* types = [NSMutableArray array];
+					for (NSString* ext in exts)
+					{
+						UTType* type = [UTType typeWithFilenameExtension:ext];
+						if (type) [types addObject:type];
+					}
+					if (types.count > 0)
+						[panel setAllowedContentTypes:types];
+				}
+			}
+		}
+
+		// Default extension
+		if (lpofn->lpstrDefExt)
+		{
+			NSString* defExt = WideToNSString(lpofn->lpstrDefExt);
+			if (defExt.length > 0)
+			{
+				UTType* defType = [UTType typeWithFilenameExtension:defExt];
+				if (defType && panel.allowedContentTypes.count == 0)
+					[panel setAllowedContentTypes:@[defType]];
+			}
+		}
+
+		NSModalResponse response = [panel runModal];
+		if (response != NSModalResponseOK)
+			return FALSE;
+
+		NSURL* url = panel.URL;
+		if (!url) return FALSE;
+
+		NSString* path = [url path];
+		if (lpofn->lpstrFile && lpofn->nMaxFile > 0)
+		{
+			NSStringToWide(path, lpofn->lpstrFile, lpofn->nMaxFile);
+
+			NSString* fileName = [path lastPathComponent];
+			NSString* dirPath = [path stringByDeletingLastPathComponent];
+			lpofn->nFileOffset = static_cast<WORD>(dirPath.length + 1);
+			NSRange dotRange = [fileName rangeOfString:@"." options:NSBackwardsSearch];
+			if (dotRange.location != NSNotFound)
+				lpofn->nFileExtension = static_cast<WORD>(lpofn->nFileOffset + dotRange.location + 1);
+			else
+				lpofn->nFileExtension = 0;
+		}
+
+		if (lpofn->lpstrFileTitle && lpofn->nMaxFileTitle > 0)
+		{
+			NSString* fileName = [path lastPathComponent];
+			NSStringToWide(fileName, lpofn->lpstrFileTitle, lpofn->nMaxFileTitle);
+		}
+
+		return TRUE;
+	}
+}
+
+BOOL ChooseColorW(LPCHOOSECOLORW lpcc)
+{
+	if (!lpcc) return FALSE;
+
+	@autoreleasepool {
+		NSColorPanel* panel = [NSColorPanel sharedColorPanel];
+
+		// Set initial color if CC_RGBINIT
+		if (lpcc->Flags & CC_RGBINIT)
+		{
+			COLORREF cr = lpcc->rgbResult;
+			CGFloat r = (cr & 0xFF) / 255.0;
+			CGFloat g = ((cr >> 8) & 0xFF) / 255.0;
+			CGFloat b = ((cr >> 16) & 0xFF) / 255.0;
+			[panel setColor:[NSColor colorWithRed:r green:g blue:b alpha:1.0]];
+		}
+
+		[panel setIsVisible:YES];
+		[panel makeKeyAndOrderFront:nil];
+
+		// Run a modal session to wait for user to close the panel
+		// For simplicity, just show the panel non-modally and return current color
+		NSColor* color = [[panel color] colorUsingColorSpace:[NSColorSpace sRGBColorSpace]];
+		if (color)
+		{
+			int r = static_cast<int>([color redComponent] * 255);
+			int g = static_cast<int>([color greenComponent] * 255);
+			int b = static_cast<int>([color blueComponent] * 255);
+			lpcc->rgbResult = RGB(r, g, b);
+		}
+		return TRUE;
+	}
+}
+
 BOOL ChooseFontW(LPCHOOSEFONTW lpcf) { return FALSE; }
 BOOL PrintDlgW(LPPRINTDLGW lppd) { return FALSE; }
 HWND FindTextW(LPFINDREPLACEW lpfr) { return nullptr; }

--- a/macos/shim/src/win32_misc.mm
+++ b/macos/shim/src/win32_misc.mm
@@ -769,60 +769,7 @@ BOOL ChangeClipboardChain(HWND hWndRemove, HWND hWndNewNext)
 	return TRUE;
 }
 
-BOOL OpenClipboard(HWND hWndNewOwner)
-{
-	return TRUE;
-}
-
-BOOL CloseClipboard()
-{
-	return TRUE;
-}
-
-BOOL EmptyClipboard()
-{
-	[[NSPasteboard generalPasteboard] clearContents];
-	return TRUE;
-}
-
-HANDLE SetClipboardData(UINT uFormat, HANDLE hMem)
-{
-	if (uFormat == CF_UNICODETEXT && hMem) {
-		const wchar_t* wstr = static_cast<const wchar_t*>(hMem);
-		NSString* str = [[NSString alloc] initWithBytes:wstr
-		                                         length:wcslen(wstr) * sizeof(wchar_t)
-		                                       encoding:NSUTF32LittleEndianStringEncoding];
-		[[NSPasteboard generalPasteboard] setString:str forType:NSPasteboardTypeString];
-	}
-	return hMem;
-}
-
-HANDLE GetClipboardData(UINT uFormat)
-{
-	// Stub - real implementation would convert NSPasteboard data to Win32 format
-	return nullptr;
-}
-
-BOOL IsClipboardFormatAvailable(UINT format)
-{
-	if (format == CF_UNICODETEXT || format == CF_TEXT) {
-		NSString* str = [[NSPasteboard generalPasteboard] stringForType:NSPasteboardTypeString];
-		return str != nil ? TRUE : FALSE;
-	}
-	return FALSE;
-}
-
-int CountClipboardFormats()
-{
-	return static_cast<int>([[[NSPasteboard generalPasteboard] types] count]);
-}
-
-UINT EnumClipboardFormats(UINT format)
-{
-	return 0;
-}
-
-HWND GetClipboardOwner()
-{
-	return nullptr;
-}
+// Clipboard functions (OpenClipboard, CloseClipboard, EmptyClipboard,
+// SetClipboardData, GetClipboardData, IsClipboardFormatAvailable,
+// CountClipboardFormats, EnumClipboardFormats, GetClipboardOwner)
+// are implemented in win32_menu.mm

--- a/macos/shim/src/win32_window.mm
+++ b/macos/shim/src/win32_window.mm
@@ -747,13 +747,99 @@ HANDLE LoadImageW(HINSTANCE hInst, LPCWSTR name, UINT type, int cx, int cy, UINT
 // ============================================================
 // Timer
 // ============================================================
-UINT_PTR SetTimer(HWND hWnd, UINT_PTR nIDEvent, UINT uElapse, TIMERPROC lpTimerFunc)
+// Timer registry: maps (hwnd, timerID) → NSTimer
+// Using a ObjC helper to bridge the timer callback
+
+@interface Win32TimerHelper : NSObject
+@property (assign) HWND hwnd;
+@property (assign) UINT_PTR timerID;
+@property (assign) TIMERPROC timerProc;
+- (void)timerFired:(NSTimer*)timer;
+@end
+
+@implementation Win32TimerHelper
+- (void)timerFired:(NSTimer*)timer
 {
-	// TODO Phase 2: NSTimer-based implementation
-	return nIDEvent;
+	if (self.timerProc)
+	{
+		self.timerProc(self.hwnd, WM_TIMER, self.timerID, 0);
+	}
+	else
+	{
+		// Send WM_TIMER to the window's WndProc
+		auto* info = HandleRegistry::getWindowInfo(self.hwnd);
+		if (info && info->wndProc)
+			info->wndProc(self.hwnd, WM_TIMER, self.timerID, 0);
+	}
+}
+@end
+
+static NSMutableDictionary<NSString*, NSTimer*>* s_timers = nil;
+static NSMutableDictionary<NSString*, Win32TimerHelper*>* s_timerHelpers = nil;
+
+static NSString* timerKey(HWND hwnd, UINT_PTR id)
+{
+	return [NSString stringWithFormat:@"%lx_%lx",
+	        (unsigned long)(uintptr_t)hwnd, (unsigned long)id];
 }
 
-BOOL KillTimer(HWND hWnd, UINT_PTR uIDEvent) { return TRUE; }
+UINT_PTR SetTimer(HWND hWnd, UINT_PTR nIDEvent, UINT uElapse, TIMERPROC lpTimerFunc)
+{
+	@autoreleasepool {
+		if (!s_timers)
+		{
+			s_timers = [NSMutableDictionary dictionary];
+			s_timerHelpers = [NSMutableDictionary dictionary];
+		}
+
+		NSString* key = timerKey(hWnd, nIDEvent);
+
+		// Kill existing timer with same key
+		NSTimer* existing = s_timers[key];
+		if (existing)
+		{
+			[existing invalidate];
+			[s_timers removeObjectForKey:key];
+			[s_timerHelpers removeObjectForKey:key];
+		}
+
+		Win32TimerHelper* helper = [[Win32TimerHelper alloc] init];
+		helper.hwnd = hWnd;
+		helper.timerID = nIDEvent;
+		helper.timerProc = lpTimerFunc;
+
+		NSTimeInterval interval = uElapse / 1000.0;
+		if (interval < 0.001) interval = 0.001;
+
+		NSTimer* timer = [NSTimer scheduledTimerWithTimeInterval:interval
+		                                                 target:helper
+		                                               selector:@selector(timerFired:)
+		                                               userInfo:nil
+		                                                repeats:YES];
+		s_timers[key] = timer;
+		s_timerHelpers[key] = helper;
+
+		return nIDEvent;
+	}
+}
+
+BOOL KillTimer(HWND hWnd, UINT_PTR uIDEvent)
+{
+	@autoreleasepool {
+		if (!s_timers) return FALSE;
+
+		NSString* key = timerKey(hWnd, uIDEvent);
+		NSTimer* timer = s_timers[key];
+		if (timer)
+		{
+			[timer invalidate];
+			[s_timers removeObjectForKey:key];
+			[s_timerHelpers removeObjectForKey:key];
+			return TRUE;
+		}
+		return FALSE;
+	}
+}
 
 // ============================================================
 // MessageBox


### PR DESCRIPTION
## Summary
- Implement Win32 menu APIs (CreateMenu, AppendMenuW, SetMenu) backed by NSMenu with WM_COMMAND dispatch to WndProc
- Add file open/save dialogs via NSOpenPanel/NSSavePanel (GetOpenFileNameW/GetSaveFileNameW)
- Implement SetTimer/KillTimer backed by NSTimer, clipboard via NSPasteboard
- Rename build target from npp_phase1_app to npp_phase2_app

## Test plan
- [ ] Build with `cmake --build . --target npp_phase2_app`
- [ ] Verify menu bar appears with File/Edit/View menus
- [ ] Test File > Open and File > Save dialogs
- [ ] Test clipboard copy/paste operations
- [ ] Verify timer-based functionality works

🤖 Generated with [Claude Code](https://claude.com/claude-code)