### PR TITLE
Add Phase 3: tabs, status bar, multi-document editing

### DIFF
--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -314,9 +314,43 @@ target_compile_options(npp_phase2_app PRIVATE
     -Wno-deprecated-declarations
 )
 
+# ============================================================
+# Phase 3: Tabs + Multi-Document App
+# ============================================================
+# Tab control (SysTabControl32), status bar (msctls_statusbar32),
+# WM_NOTIFY dispatch, file monitoring via FSEvents, multi-document editing.
+add_executable(npp_phase3_app
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/main_phase3.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/file_monitor_mac.mm"
+)
+target_include_directories(npp_phase3_app PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform"
+    "${SHIM_INCLUDE_DIR}"
+    "${SCINTILLA_INCLUDE_DIR}"
+    "${LEXILLA_INCLUDE_DIR}"
+)
+target_link_libraries(npp_phase3_app
+    win32shim
+    scintilla_bridge
+    Scintilla
+    Lexilla
+    pugixml
+    uchardet
+    "-framework Foundation"
+    "-framework AppKit"
+    "-framework QuartzCore"
+    "-framework UniformTypeIdentifiers"
+    "-framework CoreServices"
+)
+target_compile_options(npp_phase3_app PRIVATE
+    -fobjc-arc
+    -Wno-deprecated-declarations
+)
+
 message(STATUS "=== Notepad++ macOS Port ===")
 message(STATUS "Phase 0: Shim compilation test (npp_phase0_test)")
 message(STATUS "Phase 2: File I/O + Menus app (npp_phase2_app)")
+message(STATUS "Phase 3: Tabs + Multi-Document app (npp_phase3_app)")
 message(STATUS "Shim headers: ${SHIM_INCLUDE_DIR}")
 message(STATUS "Scintilla: ${SCINTILLA_DIR}")
 message(STATUS "Lexilla: ${LEXILLA_DIR}")

--- a/macos/platform/file_monitor_mac.h
+++ b/macos/platform/file_monitor_mac.h
@@ -1,0 +1,48 @@
+#pragma once
+// File Monitor for macOS — FSEvents-based replacement for ReadDirectoryChanges
+// Watches directories for file changes and provides a queue-based interface.
+
+#ifdef __APPLE__
+
+#include <string>
+#include <functional>
+
+// Callback type: receives action (added/removed/modified/renamed) and file path
+enum class FileMonitorAction
+{
+	Added,
+	Removed,
+	Modified,
+	RenamedOld,
+	RenamedNew
+};
+
+using FileMonitorCallback = std::function<void(FileMonitorAction action, const std::wstring& path)>;
+
+class FileMonitorMac
+{
+public:
+	FileMonitorMac();
+	~FileMonitorMac();
+
+	// Start watching a directory. Multiple directories can be watched.
+	bool addDirectory(const std::wstring& path);
+
+	// Stop watching a directory.
+	void removeDirectory(const std::wstring& path);
+
+	// Set callback for immediate notification (called on FSEvents thread).
+	void setCallback(FileMonitorCallback callback);
+
+	// Pop the next event from the queue (thread-safe). Returns false if empty.
+	bool pop(FileMonitorAction& action, std::wstring& path);
+
+	// Stop all monitoring and clean up.
+	void terminate();
+
+	// Public so the FSEvents C callback can access it
+	struct Impl;
+	Impl* m_impl;
+};
+
+#endif // __APPLE__

--- a/macos/platform/file_monitor_mac.mm
+++ b/macos/platform/file_monitor_mac.mm
@@ -1,0 +1,185 @@
+// File Monitor for macOS — FSEvents implementation
+// Watches directories for file changes using Apple's FSEvents API.
+
+#import <Foundation/Foundation.h>
+#include <CoreServices/CoreServices.h>
+#include "file_monitor_mac.h"
+
+#include <mutex>
+#include <queue>
+#include <vector>
+#include <string>
+
+// Helper: wchar_t (UTF-32) → NSString → std::string (UTF-8)
+static std::string WideToUTF8(const std::wstring& ws)
+{
+	if (ws.empty()) return "";
+	NSString* ns = [[NSString alloc] initWithBytes:ws.data()
+	                                        length:ws.size() * sizeof(wchar_t)
+	                                      encoding:NSUTF32LittleEndianStringEncoding];
+	return ns ? std::string([ns UTF8String]) : "";
+}
+
+// Helper: UTF-8 → wchar_t (UTF-32)
+static std::wstring UTF8ToWide(const char* utf8)
+{
+	if (!utf8) return L"";
+	NSString* ns = [NSString stringWithUTF8String:utf8];
+	if (!ns) return L"";
+	NSData* data = [ns dataUsingEncoding:NSUTF32LittleEndianStringEncoding];
+	if (!data) return L"";
+	std::wstring result(reinterpret_cast<const wchar_t*>(data.bytes),
+	                     data.length / sizeof(wchar_t));
+	return result;
+}
+
+struct FileMonitorMac::Impl
+{
+	std::mutex mutex;
+	std::queue<std::pair<FileMonitorAction, std::wstring>> eventQueue;
+	FileMonitorCallback callback;
+	std::vector<FSEventStreamRef> streams;
+	std::vector<std::wstring> watchedPaths;
+	bool terminated = false;
+};
+
+// FSEvents callback
+static void fseventsCallback(ConstFSEventStreamRef streamRef,
+                              void* clientCallBackInfo,
+                              size_t numEvents,
+                              void* eventPaths,
+                              const FSEventStreamEventFlags eventFlags[],
+                              const FSEventStreamEventId eventIds[])
+{
+	auto* impl = static_cast<FileMonitorMac::Impl*>(clientCallBackInfo);
+	char** paths = static_cast<char**>(eventPaths);
+
+	for (size_t i = 0; i < numEvents; ++i)
+	{
+		FileMonitorAction action;
+		FSEventStreamEventFlags flags = eventFlags[i];
+
+		if (flags & kFSEventStreamEventFlagItemCreated)
+			action = FileMonitorAction::Added;
+		else if (flags & kFSEventStreamEventFlagItemRemoved)
+			action = FileMonitorAction::Removed;
+		else if (flags & kFSEventStreamEventFlagItemRenamed)
+			action = FileMonitorAction::RenamedNew;
+		else if (flags & kFSEventStreamEventFlagItemModified)
+			action = FileMonitorAction::Modified;
+		else
+			action = FileMonitorAction::Modified; // default
+
+		std::wstring widePath = UTF8ToWide(paths[i]);
+
+		{
+			std::lock_guard<std::mutex> lock(impl->mutex);
+			impl->eventQueue.push({action, widePath});
+		}
+
+		if (impl->callback)
+			impl->callback(action, widePath);
+	}
+}
+
+FileMonitorMac::FileMonitorMac()
+	: m_impl(new Impl)
+{
+}
+
+FileMonitorMac::~FileMonitorMac()
+{
+	terminate();
+	delete m_impl;
+}
+
+bool FileMonitorMac::addDirectory(const std::wstring& path)
+{
+	std::lock_guard<std::mutex> lock(m_impl->mutex);
+	if (m_impl->terminated) return false;
+
+	std::string utf8Path = WideToUTF8(path);
+	if (utf8Path.empty()) return false;
+
+	NSString* nsPath = [NSString stringWithUTF8String:utf8Path.c_str()];
+	CFStringRef cfPath = (__bridge CFStringRef)nsPath;
+	CFArrayRef pathsToWatch = CFArrayCreate(nullptr, (const void**)&cfPath, 1, &kCFTypeArrayCallBacks);
+
+	FSEventStreamContext context = {};
+	context.info = m_impl;
+
+	FSEventStreamRef stream = FSEventStreamCreate(
+		nullptr,
+		&fseventsCallback,
+		&context,
+		pathsToWatch,
+		kFSEventStreamEventIdSinceNow,
+		0.5, // latency in seconds
+		kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagUseCFTypes
+	);
+
+	CFRelease(pathsToWatch);
+
+	if (!stream) return false;
+
+	FSEventStreamScheduleWithRunLoop(stream, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+	FSEventStreamStart(stream);
+
+	m_impl->streams.push_back(stream);
+	m_impl->watchedPaths.push_back(path);
+
+	return true;
+}
+
+void FileMonitorMac::removeDirectory(const std::wstring& path)
+{
+	std::lock_guard<std::mutex> lock(m_impl->mutex);
+
+	for (size_t i = 0; i < m_impl->watchedPaths.size(); ++i)
+	{
+		if (m_impl->watchedPaths[i] == path)
+		{
+			FSEventStreamStop(m_impl->streams[i]);
+			FSEventStreamInvalidate(m_impl->streams[i]);
+			FSEventStreamRelease(m_impl->streams[i]);
+
+			m_impl->streams.erase(m_impl->streams.begin() + i);
+			m_impl->watchedPaths.erase(m_impl->watchedPaths.begin() + i);
+			break;
+		}
+	}
+}
+
+void FileMonitorMac::setCallback(FileMonitorCallback callback)
+{
+	std::lock_guard<std::mutex> lock(m_impl->mutex);
+	m_impl->callback = std::move(callback);
+}
+
+bool FileMonitorMac::pop(FileMonitorAction& action, std::wstring& path)
+{
+	std::lock_guard<std::mutex> lock(m_impl->mutex);
+	if (m_impl->eventQueue.empty()) return false;
+
+	auto& front = m_impl->eventQueue.front();
+	action = front.first;
+	path = front.second;
+	m_impl->eventQueue.pop();
+	return true;
+}
+
+void FileMonitorMac::terminate()
+{
+	std::lock_guard<std::mutex> lock(m_impl->mutex);
+	if (m_impl->terminated) return;
+	m_impl->terminated = true;
+
+	for (auto stream : m_impl->streams)
+	{
+		FSEventStreamStop(stream);
+		FSEventStreamInvalidate(stream);
+		FSEventStreamRelease(stream);
+	}
+	m_impl->streams.clear();
+	m_impl->watchedPaths.clear();
+}

--- a/macos/platform/main_phase3.mm
+++ b/macos/platform/main_phase3.mm
@@ -1,0 +1,849 @@
+// Notepad++ macOS Port — Phase 3 Entry Point
+// Demonstrates: Tabbed multi-document editing with tab control (SysTabControl32),
+// status bar (msctls_statusbar32), WM_NOTIFY/TCN_SELCHANGE dispatch,
+// file monitoring (FSEvents), and periodic timer updates.
+//
+// Builds on Phase 2: menus, file dialogs, WM_COMMAND, timers, clipboard.
+
+#import <Cocoa/Cocoa.h>
+#include "windows.h"
+#include "commctrl.h"
+#include "commdlg.h"
+#include "handle_registry.h"
+#include "scintilla_bridge.h"
+#include "file_monitor_mac.h"
+
+// ============================================================
+// Command IDs (matching Notepad++ IDM_* convention)
+// ============================================================
+#define IDM_FILE_NEW          41001
+#define IDM_FILE_OPEN         41002
+#define IDM_FILE_SAVE         41006
+#define IDM_FILE_SAVEAS       41008
+#define IDM_FILE_CLOSE        41003
+#define IDM_FILE_CLOSEALL     41004
+#define IDM_EDIT_UNDO         42001
+#define IDM_EDIT_REDO         42002
+#define IDM_EDIT_CUT          42003
+#define IDM_EDIT_COPY         42004
+#define IDM_EDIT_PASTE        42005
+#define IDM_EDIT_SELECTALL    42013
+#define IDM_VIEW_WORDWRAP     42026
+#define IDM_VIEW_LINENUMBER   42027
+
+// Control IDs
+#define IDC_TABBAR       1001
+#define IDC_STATUSBAR    1002
+
+// Timer ID
+#define IDT_STATUSBAR    5001
+
+// ============================================================
+// SCI message IDs
+// ============================================================
+enum {
+	SCI_CLEARALL = 2004,
+	SCI_SETSAVEPOINT = 2014,
+	SCI_GETLENGTH = 2006,
+	SCI_GOTOPOS = 2025,
+	SCI_GETCURRENTPOS = 2008,
+	SCI_LINEFROMPOSITION = 2166,
+	SCI_GETCOLUMN = 2129,
+	SCI_GETLINECOUNT = 2154,
+	SCI_SETTABWIDTH = 2036,
+	SCI_SETCODEPAGE = 2037,
+	SCI_STYLECLEARALL = 2050,
+	SCI_STYLESETFORE = 2051,
+	SCI_STYLESETBOLD = 2053,
+	SCI_STYLESETSIZE = 2055,
+	SCI_STYLESETFONT = 2056,
+	SCI_GETMODIFY = 2159,
+	SCI_EMPTYUNDOBUFFER = 2175,
+	SCI_SETTEXT = 2181,
+	SCI_GETTEXT = 2182,
+	SCI_GETTEXTLENGTH = 2183,
+	SCI_SETMARGINTYPEN = 2240,
+	SCI_SETMARGINWIDTHN = 2242,
+	SCI_SETMARGINMASKN = 2244,
+	SCI_SETMARGINSENSITIVEN = 2246,
+	SCI_SETWRAPMODE = 2268,
+	SCI_GETWRAPMODE = 2269,
+	SCI_SETCARETLINEVISIBLE = 2096,
+	SCI_SETCARETLINEBACK = 2098,
+	SCI_SETUSETABS = 2124,
+	SCI_SETPROPERTY = 4004,
+	SCI_SETKEYWORDS = 4005,
+	SCI_SETLEXERLANGUAGE = 4006,
+	SCI_SETFIRSTVISIBLELINE = 2613,
+	SCI_GETFIRSTVISIBLELINE = 2152,
+	SCI_SETSEL = 2160,
+	SCI_GETANCHOR = 2009,
+};
+
+// ============================================================
+// Document data — per-tab state
+// ============================================================
+
+struct DocumentData
+{
+	std::wstring filePath;
+	std::wstring title = L"Untitled";
+	std::string content;         // UTF-8 text
+	intptr_t cursorPos = 0;
+	intptr_t anchorPos = 0;
+	intptr_t firstVisibleLine = 0;
+	bool modified = false;
+};
+
+// ============================================================
+// Globals
+// ============================================================
+static void* g_scintillaView = nullptr;
+static NSWindow* g_mainWindow = nil;
+static HWND g_mainHwnd = nullptr;
+static HWND g_tabHwnd = nullptr;
+static HWND g_statusBarHwnd = nullptr;
+static std::vector<DocumentData> g_documents;
+static int g_activeTab = -1;
+static FileMonitorMac* g_fileMonitor = nullptr;
+
+// ============================================================
+// Helper: Save Scintilla state to current document
+// ============================================================
+static void saveScintillaState()
+{
+	if (g_activeTab < 0 || g_activeTab >= static_cast<int>(g_documents.size()))
+		return;
+	if (!g_scintillaView) return;
+
+	auto& doc = g_documents[g_activeTab];
+
+	// Save text content
+	intptr_t len = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXTLENGTH, 0, 0);
+	if (len >= 0)
+	{
+		doc.content.resize(len + 1);
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXT, len + 1,
+		                            (intptr_t)doc.content.data());
+		doc.content.resize(len); // remove null terminator from string
+	}
+
+	// Save cursor/scroll position
+	doc.cursorPos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCURRENTPOS, 0, 0);
+	doc.anchorPos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETANCHOR, 0, 0);
+	doc.firstVisibleLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETFIRSTVISIBLELINE, 0, 0);
+	doc.modified = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETMODIFY, 0, 0) != 0;
+}
+
+// ============================================================
+// Helper: Restore Scintilla state from a document
+// ============================================================
+static void restoreScintillaState(int tabIndex)
+{
+	if (tabIndex < 0 || tabIndex >= static_cast<int>(g_documents.size()))
+		return;
+	if (!g_scintillaView) return;
+
+	const auto& doc = g_documents[tabIndex];
+
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTEXT, 0,
+	                            (intptr_t)doc.content.c_str());
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETFIRSTVISIBLELINE,
+	                            doc.firstVisibleLine, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEL,
+	                            doc.anchorPos, doc.cursorPos);
+
+	if (!doc.modified)
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSAVEPOINT, 0, 0);
+
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_EMPTYUNDOBUFFER, 0, 0);
+}
+
+// ============================================================
+// Helper: Switch to a tab
+// ============================================================
+static void switchToTab(int tabIndex)
+{
+	if (tabIndex < 0 || tabIndex >= static_cast<int>(g_documents.size()))
+		return;
+	if (tabIndex == g_activeTab)
+		return;
+
+	// Save current tab state
+	saveScintillaState();
+
+	// Switch
+	g_activeTab = tabIndex;
+	SendMessageW(g_tabHwnd, TCM_SETCURSEL, tabIndex, 0);
+
+	// Restore new tab state
+	restoreScintillaState(tabIndex);
+
+	// Update title
+	const auto& doc = g_documents[tabIndex];
+	NSString* title = [[NSString alloc] initWithBytes:doc.title.data()
+	                                           length:doc.title.size() * sizeof(wchar_t)
+	                                         encoding:NSUTF32LittleEndianStringEncoding];
+	[g_mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@", title]];
+}
+
+// ============================================================
+// Helper: Add a new tab
+// ============================================================
+static int addNewTab(const std::wstring& title, const std::string& content,
+                      const std::wstring& filePath = L"")
+{
+	// Save current state
+	saveScintillaState();
+
+	DocumentData doc;
+	doc.title = title;
+	doc.content = content;
+	doc.filePath = filePath;
+	g_documents.push_back(doc);
+
+	int newIndex = static_cast<int>(g_documents.size()) - 1;
+
+	// Insert tab item
+	TCITEMW tcItem = {};
+	tcItem.mask = TCIF_TEXT;
+	wchar_t titleBuf[256];
+	wcsncpy(titleBuf, title.c_str(), 255);
+	titleBuf[255] = L'\0';
+	tcItem.pszText = titleBuf;
+	SendMessageW(g_tabHwnd, TCM_INSERTITEMW, newIndex, reinterpret_cast<LPARAM>(&tcItem));
+
+	// Switch to the new tab
+	g_activeTab = newIndex;
+	SendMessageW(g_tabHwnd, TCM_SETCURSEL, newIndex, 0);
+
+	// Load content into Scintilla
+	if (g_scintillaView)
+	{
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTEXT, 0, (intptr_t)content.c_str());
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_GOTOPOS, 0, 0);
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_EMPTYUNDOBUFFER, 0, 0);
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSAVEPOINT, 0, 0);
+	}
+
+	// Update window title
+	NSString* nsTitle = [[NSString alloc] initWithBytes:title.data()
+	                                            length:title.size() * sizeof(wchar_t)
+	                                          encoding:NSUTF32LittleEndianStringEncoding];
+	[g_mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@", nsTitle]];
+
+	return newIndex;
+}
+
+// ============================================================
+// Helper: Close a tab
+// ============================================================
+static void closeTab(int tabIndex)
+{
+	if (tabIndex < 0 || tabIndex >= static_cast<int>(g_documents.size()))
+		return;
+
+	// Don't close the last tab
+	if (g_documents.size() <= 1)
+	{
+		// Instead, clear it
+		g_documents[0] = DocumentData();
+		if (g_scintillaView)
+		{
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_CLEARALL, 0, 0);
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_EMPTYUNDOBUFFER, 0, 0);
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSAVEPOINT, 0, 0);
+		}
+
+		// Update tab text
+		TCITEMW tcItem = {};
+		tcItem.mask = TCIF_TEXT;
+		wchar_t title[] = L"Untitled";
+		tcItem.pszText = title;
+		SendMessageW(g_tabHwnd, TCM_SETITEMW, 0, reinterpret_cast<LPARAM>(&tcItem));
+		[g_mainWindow setTitle:@"Notepad++ — Untitled"];
+		return;
+	}
+
+	// Remove the tab
+	SendMessageW(g_tabHwnd, TCM_DELETEITEM, tabIndex, 0);
+	g_documents.erase(g_documents.begin() + tabIndex);
+
+	// Adjust active tab
+	if (g_activeTab >= static_cast<int>(g_documents.size()))
+		g_activeTab = static_cast<int>(g_documents.size()) - 1;
+	if (g_activeTab == tabIndex && g_activeTab > 0)
+		--g_activeTab;
+
+	SendMessageW(g_tabHwnd, TCM_SETCURSEL, g_activeTab, 0);
+	restoreScintillaState(g_activeTab);
+
+	const auto& doc = g_documents[g_activeTab];
+	NSString* title = [[NSString alloc] initWithBytes:doc.title.data()
+	                                           length:doc.title.size() * sizeof(wchar_t)
+	                                         encoding:NSUTF32LittleEndianStringEncoding];
+	[g_mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@", title]];
+}
+
+// ============================================================
+// Update status bar with current editor state
+// ============================================================
+static void updateStatusBar()
+{
+	if (!g_scintillaView || !g_statusBarHwnd) return;
+
+	intptr_t pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCURRENTPOS, 0, 0);
+	intptr_t line = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, pos, 0);
+	intptr_t col = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCOLUMN, pos, 0);
+	intptr_t lineCount = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINECOUNT, 0, 0);
+	intptr_t docLen = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLENGTH, 0, 0);
+
+	// Part 0: Line/Col
+	wchar_t buf[128];
+	swprintf(buf, 128, L"Ln %ld, Col %ld", (long)(line + 1), (long)(col + 1));
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 0, reinterpret_cast<LPARAM>(buf));
+
+	// Part 1: Document info
+	swprintf(buf, 128, L"%ld lines, %ld bytes", (long)lineCount, (long)docLen);
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 1, reinterpret_cast<LPARAM>(buf));
+
+	// Part 2: Encoding
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 2, reinterpret_cast<LPARAM>(L"UTF-8"));
+
+	// Part 3: Tab/doc count
+	swprintf(buf, 128, L"Doc %d/%d", g_activeTab + 1, (int)g_documents.size());
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 3, reinterpret_cast<LPARAM>(buf));
+}
+
+// ============================================================
+// File operations
+// ============================================================
+
+static NSString* WideToNSString(const wchar_t* wstr)
+{
+	if (!wstr) return @"";
+	size_t len = wcslen(wstr);
+	NSString* str = [[NSString alloc] initWithBytes:wstr
+	                                         length:len * sizeof(wchar_t)
+	                                       encoding:NSUTF32LittleEndianStringEncoding];
+	return str ?: @"";
+}
+
+static void openFile()
+{
+	OPENFILENAMEW ofn = {};
+	wchar_t filePath[MAX_PATH] = {0};
+
+	ofn.lStructSize = sizeof(ofn);
+	ofn.hwndOwner = g_mainHwnd;
+	ofn.lpstrFile = filePath;
+	ofn.nMaxFile = MAX_PATH;
+	ofn.lpstrTitle = L"Open File";
+	ofn.lpstrFilter = L"All Files\0*.*\0"
+	                   L"C/C++ Files\0*.c;*.cpp;*.cc;*.h;*.hpp\0"
+	                   L"Text Files\0*.txt\0";
+	ofn.nFilterIndex = 1;
+	ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST;
+
+	if (GetOpenFileNameW(&ofn))
+	{
+		NSString* path = WideToNSString(filePath);
+		NSError* error = nil;
+		NSString* content = [NSString stringWithContentsOfFile:path
+		                                             encoding:NSUTF8StringEncoding
+		                                                error:&error];
+		if (content)
+		{
+			std::wstring wpath(filePath);
+			std::wstring title = wpath;
+			// Extract filename from path
+			size_t lastSlash = title.rfind(L'/');
+			if (lastSlash != std::wstring::npos)
+				title = title.substr(lastSlash + 1);
+
+			addNewTab(title, std::string([content UTF8String]), wpath);
+
+			// Start monitoring the file's directory
+			if (g_fileMonitor)
+			{
+				std::wstring dir = wpath.substr(0, wpath.rfind(L'/'));
+				g_fileMonitor->addDirectory(dir);
+			}
+		}
+		else if (error)
+		{
+			NSLog(@"Error opening file: %@", error);
+		}
+	}
+}
+
+static void saveCurrentFile()
+{
+	if (g_activeTab < 0 || g_activeTab >= static_cast<int>(g_documents.size()))
+		return;
+
+	auto& doc = g_documents[g_activeTab];
+
+	if (doc.filePath.empty())
+	{
+		// Save As
+		OPENFILENAMEW ofn = {};
+		wchar_t filePath[MAX_PATH] = {0};
+
+		ofn.lStructSize = sizeof(ofn);
+		ofn.hwndOwner = g_mainHwnd;
+		ofn.lpstrFile = filePath;
+		ofn.nMaxFile = MAX_PATH;
+		ofn.lpstrTitle = L"Save File As";
+		ofn.lpstrFilter = L"All Files\0*.*\0";
+		ofn.nFilterIndex = 1;
+		ofn.Flags = OFN_OVERWRITEPROMPT;
+
+		if (!GetSaveFileNameW(&ofn))
+			return;
+
+		doc.filePath = filePath;
+		doc.title = doc.filePath;
+		size_t lastSlash = doc.title.rfind(L'/');
+		if (lastSlash != std::wstring::npos)
+			doc.title = doc.title.substr(lastSlash + 1);
+
+		// Update tab text
+		TCITEMW tcItem = {};
+		tcItem.mask = TCIF_TEXT;
+		wchar_t titleBuf[256];
+		wcsncpy(titleBuf, doc.title.c_str(), 255);
+		titleBuf[255] = L'\0';
+		tcItem.pszText = titleBuf;
+		SendMessageW(g_tabHwnd, TCM_SETITEMW, g_activeTab, reinterpret_cast<LPARAM>(&tcItem));
+	}
+
+	// Get text from Scintilla
+	if (!g_scintillaView) return;
+
+	intptr_t len = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXTLENGTH, 0, 0);
+	if (len >= 0)
+	{
+		char* buf = new char[len + 1];
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXT, len + 1, (intptr_t)buf);
+
+		NSString* path = WideToNSString(doc.filePath.c_str());
+		NSString* content = [NSString stringWithUTF8String:buf];
+		NSError* error = nil;
+		[content writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:&error];
+
+		if (error)
+			NSLog(@"Error saving file: %@", error);
+		else
+		{
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSAVEPOINT, 0, 0);
+			NSString* nsTitle = WideToNSString(doc.title.c_str());
+			[g_mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@", nsTitle]];
+		}
+
+		delete[] buf;
+	}
+}
+
+// ============================================================
+// WndProc
+// ============================================================
+
+static LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+	switch (msg)
+	{
+		case WM_COMMAND:
+		{
+			UINT cmdId = LOWORD(wParam);
+			switch (cmdId)
+			{
+				case IDM_FILE_NEW:
+					addNewTab(L"Untitled", "");
+					return 0;
+
+				case IDM_FILE_OPEN:
+					openFile();
+					return 0;
+
+				case IDM_FILE_SAVE:
+					saveCurrentFile();
+					return 0;
+
+				case IDM_FILE_CLOSE:
+					closeTab(g_activeTab);
+					return 0;
+
+				case IDM_FILE_CLOSEALL:
+					while (g_documents.size() > 1)
+						closeTab(static_cast<int>(g_documents.size()) - 1);
+					closeTab(0); // clears the last tab
+					return 0;
+
+				case IDM_VIEW_WORDWRAP:
+					if (g_scintillaView)
+					{
+						intptr_t mode = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETWRAPMODE, 0, 0);
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_SETWRAPMODE, mode == 0 ? 1 : 0, 0);
+						HMENU hMenu = GetMenu(hWnd);
+						if (hMenu)
+							CheckMenuItem(hMenu, IDM_VIEW_WORDWRAP,
+							              MF_BYCOMMAND | (mode == 0 ? MF_CHECKED : MF_UNCHECKED));
+					}
+					return 0;
+
+				case IDM_VIEW_LINENUMBER:
+					if (g_scintillaView)
+					{
+						static bool showLineNumbers = true;
+						showLineNumbers = !showLineNumbers;
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_SETMARGINWIDTHN, 0,
+						                           showLineNumbers ? 50 : 0);
+						HMENU hMenu = GetMenu(hWnd);
+						if (hMenu)
+							CheckMenuItem(hMenu, IDM_VIEW_LINENUMBER,
+							              MF_BYCOMMAND | (showLineNumbers ? MF_CHECKED : MF_UNCHECKED));
+					}
+					return 0;
+			}
+			break;
+		}
+
+		case WM_NOTIFY:
+		{
+			NMHDR* pNmhdr = reinterpret_cast<NMHDR*>(lParam);
+			if (pNmhdr && pNmhdr->code == TCN_SELCHANGE)
+			{
+				// Tab selection changed
+				int newSel = static_cast<int>(SendMessageW(g_tabHwnd, TCM_GETCURSEL, 0, 0));
+				if (newSel != g_activeTab && newSel >= 0)
+					switchToTab(newSel);
+				return 0;
+			}
+			break;
+		}
+
+		case WM_TIMER:
+		{
+			if (wParam == IDT_STATUSBAR)
+			{
+				updateStatusBar();
+				return 0;
+			}
+			break;
+		}
+
+		case WM_SIZE:
+		{
+			// Re-layout: tab bar at top, status bar at bottom, Scintilla fills middle
+			if (g_scintillaView)
+				ScintillaBridge_resizeToFit(g_scintillaView);
+			return 0;
+		}
+
+		case WM_CLOSE:
+			KillTimer(hWnd, IDT_STATUSBAR);
+			PostQuitMessage(0);
+			return 0;
+	}
+
+	return DefWindowProcW(hWnd, msg, wParam, lParam);
+}
+
+// ============================================================
+// Build menus
+// ============================================================
+
+static HMENU buildMenuBar()
+{
+	HMENU hMenuBar = CreateMenu();
+
+	HMENU hFileMenu = CreatePopupMenu();
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_NEW, L"&New\tCtrl+N");
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_OPEN, L"&Open...\tCtrl+O");
+	AppendMenuW(hFileMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_SAVE, L"&Save\tCtrl+S");
+	AppendMenuW(hFileMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_CLOSE, L"&Close\tCtrl+W");
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_CLOSEALL, L"Close &All");
+	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hFileMenu), L"&File");
+
+	HMENU hEditMenu = CreatePopupMenu();
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_UNDO, L"&Undo\tCtrl+Z");
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_REDO, L"&Redo\tCtrl+Shift+Z");
+	AppendMenuW(hEditMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_CUT, L"Cu&t\tCtrl+X");
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_COPY, L"&Copy\tCtrl+C");
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_PASTE, L"&Paste\tCtrl+V");
+	AppendMenuW(hEditMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_SELECTALL, L"Select &All\tCtrl+A");
+	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hEditMenu), L"&Edit");
+
+	HMENU hViewMenu = CreatePopupMenu();
+	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_WORDWRAP, L"&Word Wrap");
+	AppendMenuW(hViewMenu, MF_STRING | MF_CHECKED, IDM_VIEW_LINENUMBER, L"&Line Numbers");
+	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hViewMenu), L"&View");
+
+	return hMenuBar;
+}
+
+// ============================================================
+// Configure Scintilla
+// ============================================================
+
+static void configureScintilla(void* sci)
+{
+	if (!sci) return;
+
+	ScintillaBridge_sendMessage(sci, SCI_SETCODEPAGE, 65001, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETWRAPMODE, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTABWIDTH, 4, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETUSETABS, 0, 0);
+
+	// Line numbers
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINTYPEN, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINWIDTHN, 0, 50);
+
+	// C++ lexer
+	ScintillaBridge_sendMessage(sci, SCI_SETLEXERLANGUAGE, 0, (intptr_t)"cpp");
+
+	const char* keywords = "int char float double void bool true false "
+	                        "if else for while do switch case break continue return "
+	                        "class struct enum namespace using typedef "
+	                        "const static virtual override public private protected "
+	                        "new delete nullptr sizeof typeof "
+	                        "try catch throw include define ifdef ifndef endif";
+	ScintillaBridge_sendMessage(sci, SCI_SETKEYWORDS, 0, (intptr_t)keywords);
+
+	// Default style: Menlo 13pt
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETFONT, 32, (intptr_t)"Menlo");
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETSIZE, 32, 13);
+	ScintillaBridge_sendMessage(sci, SCI_STYLECLEARALL, 0, 0);
+
+	// Syntax colors
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETFORE, 1, 0x008000);
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETFORE, 2, 0x008000);
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETFORE, 4, 0xFF8000);
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETFORE, 5, 0x0000FF);
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETFORE, 6, 0x800080);
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETFORE, 9, 0x808080);
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETBOLD, 5, 1);
+
+	// Code folding
+	ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"fold", (intptr_t)"1");
+	ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"fold.compact", (intptr_t)"0");
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINTYPEN, 2, 4);
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINMASKN, 2, 0xFE000000);
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINWIDTHN, 2, 16);
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINSENSITIVEN, 2, 1);
+
+	// Current line highlight
+	ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEVISIBLE, 1, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEBACK, 0xF0F0F0, 0);
+}
+
+// ============================================================
+// Application Delegate
+// ============================================================
+
+@interface NppPhase3Delegate : NSObject <NSApplicationDelegate, NSWindowDelegate>
+@end
+
+@implementation NppPhase3Delegate
+
+- (void)applicationDidFinishLaunching:(NSNotification*)notification
+{
+	// Register window class
+	WNDCLASSEXW wc = {};
+	wc.cbSize = sizeof(wc);
+	wc.lpfnWndProc = MainWndProc;
+	wc.lpszClassName = L"Notepad++Phase3";
+	RegisterClassExW(&wc);
+
+	// Build menu bar
+	HMENU hMenuBar = buildMenuBar();
+
+	// Create main window
+	g_mainHwnd = CreateWindowExW(
+		0, L"Notepad++Phase3", L"Notepad++ (macOS) — Phase 3",
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT, CW_USEDEFAULT, 1000, 750,
+		nullptr, hMenuBar, nullptr, nullptr
+	);
+
+	if (!g_mainHwnd)
+	{
+		NSLog(@"ERROR: Failed to create main window!");
+		return;
+	}
+
+	auto* mainInfo = HandleRegistry::getWindowInfo(g_mainHwnd);
+	if (mainInfo && mainInfo->nativeWindow)
+	{
+		g_mainWindow = (__bridge NSWindow*)mainInfo->nativeWindow;
+		g_mainWindow.delegate = self;
+		[g_mainWindow setMinSize:NSMakeSize(500, 400)];
+	}
+
+	SetMenu(g_mainHwnd, hMenuBar);
+
+	NSView* contentView = g_mainWindow.contentView;
+
+	// Create tab control at top using Win32 API
+	g_tabHwnd = CreateWindowExW(
+		0, L"SysTabControl32", L"",
+		WS_CHILD | WS_VISIBLE | TCS_FOCUSNEVER,
+		0, 0,
+		static_cast<int>(contentView.bounds.size.width), 28,
+		g_mainHwnd,
+		reinterpret_cast<HMENU>(IDC_TABBAR),
+		nullptr, nullptr
+	);
+
+	// Create status bar at bottom using Win32 API
+	g_statusBarHwnd = CreateWindowExW(
+		0, L"msctls_statusbar32", L"",
+		WS_CHILD | WS_VISIBLE | SBARS_SIZEGRIP,
+		0, 0, 0, 0,
+		g_mainHwnd,
+		reinterpret_cast<HMENU>(IDC_STATUSBAR),
+		nullptr, nullptr
+	);
+
+	// Set up status bar parts
+	int parts[] = {200, 400, 500, -1};
+	SendMessageW(g_statusBarHwnd, SB_SETPARTS, 4, reinterpret_cast<LPARAM>(parts));
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 0, reinterpret_cast<LPARAM>(L"Ln 1, Col 1"));
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 1, reinterpret_cast<LPARAM>(L"0 lines"));
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 2, reinterpret_cast<LPARAM>(L"UTF-8"));
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 3, reinterpret_cast<LPARAM>(L"Ready"));
+
+	// Create Scintilla editor in the middle area
+	// Calculate area between tab bar and status bar
+	CGFloat tabHeight = 28;
+	CGFloat statusHeight = 22;
+	CGFloat editorY = tabHeight;
+	CGFloat editorHeight = contentView.bounds.size.height - tabHeight - statusHeight;
+
+	// Position status bar at bottom
+	if (g_statusBarHwnd)
+	{
+		auto* sbInfo = HandleRegistry::getWindowInfo(g_statusBarHwnd);
+		if (sbInfo && sbInfo->nativeView)
+		{
+			NSView* sbView = (__bridge NSView*)sbInfo->nativeView;
+			sbView.frame = NSMakeRect(0, 0, contentView.bounds.size.width, statusHeight);
+			sbView.autoresizingMask = NSViewWidthSizable | NSViewMaxYMargin;
+		}
+	}
+
+	// Create a container view for Scintilla (between tab bar and status bar)
+	NSRect editorFrame = NSMakeRect(0, statusHeight, contentView.bounds.size.width, editorHeight);
+	NSView* editorContainer = [[NSView alloc] initWithFrame:editorFrame];
+	editorContainer.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+	[contentView addSubview:editorContainer];
+
+	g_scintillaView = ScintillaBridge_createView((__bridge void*)editorContainer, 0, 0, 0, 0);
+	if (!g_scintillaView)
+	{
+		NSLog(@"ERROR: Failed to create ScintillaView!");
+		return;
+	}
+
+	configureScintilla(g_scintillaView);
+
+	// Create first document tab
+	const char* welcomeText =
+		"// Welcome to Notepad++ on macOS — Phase 3!\n"
+		"//\n"
+		"// What's new in Phase 3:\n"
+		"//   - Tab control (SysTabControl32 → NSSegmentedControl)\n"
+		"//   - Multi-document editing with per-tab state\n"
+		"//   - Status bar showing line/col, doc info, encoding\n"
+		"//   - WM_NOTIFY/TCN_SELCHANGE dispatch for tab switching\n"
+		"//   - File monitoring via FSEvents\n"
+		"//   - Periodic timer for status bar updates\n"
+		"//\n"
+		"// Try:\n"
+		"//   Cmd+N for new tab\n"
+		"//   Cmd+O to open file (creates new tab)\n"
+		"//   Cmd+W to close current tab\n"
+		"//   Click tabs to switch between documents\n"
+		"\n"
+		"#include <iostream>\n"
+		"\n"
+		"int main() {\n"
+		"    std::cout << \"Hello from Notepad++ macOS — Phase 3!\" << std::endl;\n"
+		"    return 0;\n"
+		"}\n";
+
+	addNewTab(L"Welcome", std::string(welcomeText));
+
+	// Start status bar update timer (500ms interval)
+	SetTimer(g_mainHwnd, IDT_STATUSBAR, 500, nullptr);
+
+	// Initialize file monitor
+	g_fileMonitor = new FileMonitorMac();
+
+	// Show the window
+	ShowWindow(g_mainHwnd, SW_SHOW);
+	[NSApp activateIgnoringOtherApps:YES];
+
+	NSLog(@"=== Notepad++ macOS Port — Phase 3 ===");
+	NSLog(@"Tabs, status bar, multi-document editing, and file monitoring working!");
+}
+
+- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication*)sender
+{
+	return YES;
+}
+
+- (void)applicationWillTerminate:(NSNotification*)notification
+{
+	if (g_fileMonitor)
+	{
+		g_fileMonitor->terminate();
+		delete g_fileMonitor;
+		g_fileMonitor = nullptr;
+	}
+}
+
+- (void)windowDidResize:(NSNotification*)notification
+{
+	if (g_scintillaView)
+		ScintillaBridge_resizeToFit(g_scintillaView);
+
+	// Resize tab bar width
+	if (g_tabHwnd && g_mainWindow)
+	{
+		auto* tabInfo = HandleRegistry::getWindowInfo(g_tabHwnd);
+		if (tabInfo && tabInfo->nativeView)
+		{
+			NSView* tabView = (__bridge NSView*)tabInfo->nativeView;
+			NSRect f = tabView.frame;
+			f.size.width = g_mainWindow.contentView.bounds.size.width;
+			tabView.frame = f;
+		}
+	}
+}
+
+@end
+
+// ============================================================
+// Entry point
+// ============================================================
+
+int main(int argc, const char* argv[])
+{
+	@autoreleasepool
+	{
+		NSApplication* app = [NSApplication sharedApplication];
+		[app setActivationPolicy:NSApplicationActivationPolicyRegular];
+
+		NppPhase3Delegate* delegate = [[NppPhase3Delegate alloc] init];
+		app.delegate = delegate;
+
+		[app run];
+	}
+	return 0;
+}

--- a/macos/shim/include/commctrl.h
+++ b/macos/shim/include/commctrl.h
@@ -1738,21 +1738,17 @@ inline HRESULT LoadIconWithScaleDown(HINSTANCE hinst, LPCWSTR pszName, int cx, i
 	(BOOL)SendMessage((hwnd), BCM_GETIDEALSIZE, 0, (LPARAM)(psize))
 
 // ============================================================
-// Progress bar messages
+// Progress bar messages (extended)
 // ============================================================
-#define PBM_SETRANGE    (WM_USER + 1)
-#define PBM_SETPOS      (WM_USER + 2)
-#define PBM_DELTAPOS    (WM_USER + 3)
-#define PBM_SETSTEP     (WM_USER + 4)
-#define PBM_STEPIT      (WM_USER + 5)
-#define PBM_SETRANGE32  (WM_USER + 6)
-#define PBM_GETRANGE    (WM_USER + 7)
-#define PBM_GETPOS      (WM_USER + 8)
-#define PBM_SETBARCOLOR (WM_USER + 9)
-#define PBM_SETBKCOLOR  0x2001
+#ifndef PBM_SETMARQUEE
 #define PBM_SETMARQUEE  (WM_USER + 10)
+#endif
+#ifndef PBM_SETSTATE
 #define PBM_SETSTATE    (WM_USER + 16)
+#endif
+#ifndef PBM_GETSTATE
 #define PBM_GETSTATE    (WM_USER + 17)
+#endif
 
 #define PBST_NORMAL  0x0001
 #define PBST_ERROR   0x0002

--- a/macos/shim/include/handle_registry.h
+++ b/macos/shim/include/handle_registry.h
@@ -14,6 +14,9 @@
 // We rely on windows.h (our shim) being included before this header.
 // The shim defines HWND, WNDPROC, DWORD, HINSTANCE, LPARAM, LONG_PTR, etc.
 
+// Forward-declare ControlType (defined in win32_controls_impl.h)
+enum class ControlType;
+
 namespace HandleRegistry {
 
 struct WindowInfo
@@ -32,6 +35,7 @@ struct WindowInfo
 	std::wstring windowName;
 	bool isScintilla = false;
 	LPARAM createParam = 0;        // lpParam from CreateWindowEx
+	ControlType controlType = static_cast<ControlType>(0); // ControlType::None
 };
 
 // Registered window class info (from RegisterClass/RegisterClassEx)

--- a/macos/shim/include/win32_controls_impl.h
+++ b/macos/shim/include/win32_controls_impl.h
@@ -1,0 +1,47 @@
+#pragma once
+// Win32 Controls Implementation Interface
+// Routes control creation and messages for known control classes:
+//   SysTabControl32, msctls_statusbar32, ToolbarWindow32, ReBarWindow32, tooltips_class32
+//
+// This header is included by win32_window.mm and win32_message.mm to
+// intercept CreateWindowEx and SendMessage for control class names.
+
+#ifdef __APPLE__
+
+#include <string>
+
+// Control type enum stored in HandleRegistry::WindowInfo
+enum class ControlType
+{
+	None = 0,
+	TabControl,
+	StatusBar,
+	Toolbar,
+	ReBar,
+	Tooltip,
+	ListView,
+	TreeView
+};
+
+// Check if className is a known common control class
+bool Win32Controls_IsControlClass(const std::wstring& className);
+
+// Determine control type from class name
+ControlType Win32Controls_GetControlType(const std::wstring& className);
+
+// Create a control, returning the native NSView* (as void*) to store in WindowInfo.
+// Called from CreateWindowExW when IsControlClass returns true.
+void* Win32Controls_CreateControl(ControlType type, void* parentView,
+                                   int x, int y, int width, int height,
+                                   unsigned long style, unsigned long exStyle);
+
+// Handle a control-specific message (TCM_*, SB_*, TB_*, RB_*, etc.)
+// Returns true if the message was handled. result is set to the return value.
+bool Win32Controls_HandleMessage(void* hwnd, ControlType type,
+                                  unsigned int msg, uintptr_t wParam, intptr_t lParam,
+                                  intptr_t& result);
+
+// Destroy a control and clean up associated data.
+void Win32Controls_DestroyControl(void* hwnd, ControlType type);
+
+#endif // __APPLE__

--- a/macos/shim/src/win32_controls.mm
+++ b/macos/shim/src/win32_controls.mm
@@ -1,0 +1,1463 @@
+// Win32 Controls Shim: Tab, StatusBar, Toolbar, ReBar, ImageList for macOS
+// Phase 3: Real NSView-backed tab control and status bar.
+// Toolbar and ReBar are data-only (N++ does custom drawing).
+
+#import <Cocoa/Cocoa.h>
+#include "windows.h"
+#include "commctrl.h"
+#include "handle_registry.h"
+#include "win32_controls_impl.h"
+
+#include <unordered_map>
+#include <vector>
+#include <string>
+#include <algorithm>
+
+// ============================================================
+// Forward helpers
+// ============================================================
+static NSString* WideToNS(const wchar_t* wstr)
+{
+	if (!wstr) return @"";
+	size_t len = wcslen(wstr);
+	NSString* s = [[NSString alloc] initWithBytes:wstr
+	                                       length:len * sizeof(wchar_t)
+	                                     encoding:NSUTF32LittleEndianStringEncoding];
+	return s ?: @"";
+}
+
+// ============================================================
+// Control type detection
+// ============================================================
+
+bool Win32Controls_IsControlClass(const std::wstring& className)
+{
+	return Win32Controls_GetControlType(className) != ControlType::None;
+}
+
+ControlType Win32Controls_GetControlType(const std::wstring& className)
+{
+	if (className == L"SysTabControl32") return ControlType::TabControl;
+	if (className == L"msctls_statusbar32") return ControlType::StatusBar;
+	if (className == L"ToolbarWindow32") return ControlType::Toolbar;
+	if (className == L"ReBarWindow32") return ControlType::ReBar;
+	if (className == L"tooltips_class32") return ControlType::Tooltip;
+	if (className == L"SysListView32") return ControlType::ListView;
+	if (className == L"SysTreeView32") return ControlType::TreeView;
+	return ControlType::None;
+}
+
+// ============================================================
+// Tab Control data
+// ============================================================
+
+struct TabItemData
+{
+	std::wstring text;
+	int image = -1;
+	LPARAM lParam = 0;
+};
+
+struct TabControlData
+{
+	std::vector<TabItemData> items;
+	int currentSel = -1;
+	HWND hwnd = nullptr;
+	HWND parent = nullptr;
+};
+
+static std::unordered_map<uintptr_t, TabControlData> s_tabControls;
+
+// ============================================================
+// ObjC helper: Routes NSSegmentedControl selection → WM_NOTIFY/TCN_SELCHANGE
+// ============================================================
+
+@interface Win32TabTarget : NSObject
+@property (assign) HWND tabHwnd;
+- (void)tabSelectionChanged:(id)sender;
+@end
+
+@implementation Win32TabTarget
+- (void)tabSelectionChanged:(id)sender
+{
+	NSSegmentedControl* seg = (NSSegmentedControl*)sender;
+	uintptr_t key = reinterpret_cast<uintptr_t>(self.tabHwnd);
+	auto it = s_tabControls.find(key);
+	if (it == s_tabControls.end()) return;
+
+	int newSel = static_cast<int>([seg selectedSegment]);
+	int oldSel = it->second.currentSel;
+	it->second.currentSel = newSel;
+
+	// Send WM_NOTIFY with TCN_SELCHANGE to the parent
+	HWND parentHwnd = it->second.parent;
+	if (parentHwnd)
+	{
+		auto* parentInfo = HandleRegistry::getWindowInfo(parentHwnd);
+		if (parentInfo && parentInfo->wndProc)
+		{
+			NMHDR nmhdr;
+			nmhdr.hwndFrom = self.tabHwnd;
+			nmhdr.idFrom = static_cast<UINT_PTR>(
+				HandleRegistry::getWindowInfo(self.tabHwnd)->controlId);
+			nmhdr.code = TCN_SELCHANGE;
+			parentInfo->wndProc(parentHwnd, WM_NOTIFY, nmhdr.idFrom,
+			                    reinterpret_cast<LPARAM>(&nmhdr));
+		}
+	}
+}
+@end
+
+// Global map of tab targets (prevent deallocation under ARC)
+static NSMutableDictionary<NSNumber*, Win32TabTarget*>* s_tabTargets = nil;
+
+// ============================================================
+// StatusBar data
+// ============================================================
+
+// Custom NSView that draws a simple status bar with partitions
+@interface Win32StatusBarView : NSView
+@property (strong) NSMutableArray<NSString*>* partTexts;
+@property (strong) NSMutableArray<NSNumber*>* partWidths;
+@property (assign) int partCount;
+@end
+
+@implementation Win32StatusBarView
+
+- (instancetype)initWithFrame:(NSRect)frame
+{
+	self = [super initWithFrame:frame];
+	if (self)
+	{
+		_partTexts = [NSMutableArray array];
+		_partWidths = [NSMutableArray array];
+		_partCount = 0;
+	}
+	return self;
+}
+
+- (BOOL)isFlipped
+{
+	return YES; // Use top-left origin like Win32
+}
+
+- (void)drawRect:(NSRect)dirtyRect
+{
+	// Background
+	[[NSColor windowBackgroundColor] setFill];
+	NSRectFill(self.bounds);
+
+	// Top border line
+	[[NSColor separatorColor] setStroke];
+	NSBezierPath* topLine = [NSBezierPath bezierPath];
+	[topLine moveToPoint:NSMakePoint(0, 0)];
+	[topLine lineToPoint:NSMakePoint(self.bounds.size.width, 0)];
+	[topLine stroke];
+
+	if (_partCount == 0) return;
+
+	NSDictionary* attrs = @{
+		NSFontAttributeName: [NSFont systemFontOfSize:11],
+		NSForegroundColorAttributeName: [NSColor labelColor]
+	};
+
+	CGFloat x = 4;
+	CGFloat totalWidth = self.bounds.size.width;
+
+	for (int i = 0; i < _partCount; ++i)
+	{
+		// Calculate part width
+		CGFloat partWidth;
+		if (i < (int)_partWidths.count)
+		{
+			int w = _partWidths[i].intValue;
+			if (w < 0 || i == _partCount - 1)
+				partWidth = totalWidth - x; // last part or -1 fills remaining
+			else
+				partWidth = w;
+		}
+		else
+		{
+			partWidth = totalWidth - x;
+		}
+
+		// Draw separator
+		if (i > 0)
+		{
+			[[NSColor separatorColor] setStroke];
+			NSBezierPath* sep = [NSBezierPath bezierPath];
+			[sep moveToPoint:NSMakePoint(x - 2, 3)];
+			[sep lineToPoint:NSMakePoint(x - 2, self.bounds.size.height - 3)];
+			[sep stroke];
+		}
+
+		// Draw text
+		if (i < (int)_partTexts.count)
+		{
+			NSString* text = _partTexts[i];
+			if (text.length > 0)
+			{
+				NSRect textRect = NSMakeRect(x + 2, 2, partWidth - 6,
+				                             self.bounds.size.height - 4);
+				[text drawInRect:textRect withAttributes:attrs];
+			}
+		}
+
+		x += partWidth;
+	}
+}
+
+@end
+
+struct StatusBarData
+{
+	HWND hwnd = nullptr;
+	std::vector<int> partWidths;
+	std::vector<std::wstring> partTexts;
+};
+
+static std::unordered_map<uintptr_t, StatusBarData> s_statusBars;
+
+// ============================================================
+// Toolbar data (data-only, no visual rendering)
+// ============================================================
+
+struct ToolbarButtonData
+{
+	int iBitmap = 0;
+	int idCommand = 0;
+	BYTE fsState = TBSTATE_ENABLED;
+	BYTE fsStyle = TBSTYLE_BUTTON;
+	DWORD_PTR dwData = 0;
+	INT_PTR iString = 0;
+};
+
+struct ToolbarData
+{
+	HWND hwnd = nullptr;
+	std::vector<ToolbarButtonData> buttons;
+	int buttonSizeCx = 24;
+	int buttonSizeCy = 22;
+};
+
+static std::unordered_map<uintptr_t, ToolbarData> s_toolBars;
+
+// ============================================================
+// ReBar data (data-only)
+// ============================================================
+
+struct ReBarBandData
+{
+	UINT fMask = 0;
+	UINT fStyle = 0;
+	HWND hwndChild = nullptr;
+	UINT cxMinChild = 0;
+	UINT cyMinChild = 0;
+	UINT cx = 0;
+	UINT wID = 0;
+	std::wstring text;
+};
+
+struct ReBarData
+{
+	HWND hwnd = nullptr;
+	std::vector<ReBarBandData> bands;
+};
+
+static std::unordered_map<uintptr_t, ReBarData> s_reBars;
+
+// ============================================================
+// Control creation
+// ============================================================
+
+void* Win32Controls_CreateControl(ControlType type, void* parentView,
+                                   int x, int y, int width, int height,
+                                   unsigned long style, unsigned long exStyle)
+{
+	NSView* parent = (__bridge NSView*)parentView;
+	if (!parent) return nullptr;
+
+	CGFloat parentH = parent.bounds.size.height;
+
+	switch (type)
+	{
+		case ControlType::TabControl:
+		{
+			// NSSegmentedControl for tabs
+			NSRect frame = NSMakeRect(x, parentH - y - height, width, 28);
+			NSSegmentedControl* seg = [[NSSegmentedControl alloc] initWithFrame:frame];
+			seg.segmentStyle = NSSegmentStyleAutomatic;
+			seg.trackingMode = NSSegmentSwitchTrackingSelectOne;
+			seg.segmentCount = 0;
+			seg.autoresizingMask = NSViewWidthSizable | NSViewMinYMargin;
+			[parent addSubview:seg];
+			return (__bridge void*)seg;
+		}
+
+		case ControlType::StatusBar:
+		{
+			// Custom status bar view at bottom
+			CGFloat barHeight = 22;
+			NSRect frame = NSMakeRect(0, 0, parent.bounds.size.width, barHeight);
+			Win32StatusBarView* bar = [[Win32StatusBarView alloc] initWithFrame:frame];
+			bar.autoresizingMask = NSViewWidthSizable | NSViewMaxYMargin;
+			[parent addSubview:bar];
+			return (__bridge void*)bar;
+		}
+
+		case ControlType::Toolbar:
+		case ControlType::ReBar:
+		case ControlType::Tooltip:
+		case ControlType::ListView:
+		case ControlType::TreeView:
+		{
+			// Data-only: create a hidden placeholder view
+			NSRect frame = NSMakeRect(x, parentH - y - height, width, height);
+			NSView* view = [[NSView alloc] initWithFrame:frame];
+			[view setHidden:YES];
+			[parent addSubview:view];
+			return (__bridge void*)view;
+		}
+
+		default:
+			return nullptr;
+	}
+}
+
+// ============================================================
+// Tab control message handling
+// ============================================================
+
+static bool HandleTabMessage(HWND hwnd, unsigned int msg, uintptr_t wParam, intptr_t lParam,
+                              intptr_t& result)
+{
+	uintptr_t key = reinterpret_cast<uintptr_t>(hwnd);
+	auto it = s_tabControls.find(key);
+	if (it == s_tabControls.end()) return false;
+
+	auto& tab = it->second;
+	auto* info = HandleRegistry::getWindowInfo(hwnd);
+	NSSegmentedControl* seg = info ? (__bridge NSSegmentedControl*)info->nativeView : nil;
+
+	switch (msg)
+	{
+		case TCM_INSERTITEMW:
+		{
+			int index = static_cast<int>(wParam);
+			const TCITEMW* pItem = reinterpret_cast<const TCITEMW*>(lParam);
+			if (!pItem) { result = -1; return true; }
+
+			TabItemData item;
+			if (pItem->mask & TCIF_TEXT && pItem->pszText)
+				item.text = pItem->pszText;
+			if (pItem->mask & TCIF_IMAGE)
+				item.image = pItem->iImage;
+			if (pItem->mask & TCIF_PARAM)
+				item.lParam = pItem->lParam;
+
+			if (index < 0 || index > static_cast<int>(tab.items.size()))
+				index = static_cast<int>(tab.items.size());
+
+			tab.items.insert(tab.items.begin() + index, item);
+
+			// Update NSSegmentedControl
+			if (seg)
+			{
+				seg.segmentCount = static_cast<NSInteger>(tab.items.size());
+				for (int i = 0; i < static_cast<int>(tab.items.size()); ++i)
+				{
+					[seg setLabel:WideToNS(tab.items[i].text.c_str()) forSegment:i];
+					[seg setWidth:0 forSegment:i]; // auto-size
+				}
+
+				if (tab.currentSel < 0 && !tab.items.empty())
+				{
+					tab.currentSel = 0;
+					seg.selectedSegment = 0;
+				}
+			}
+
+			result = index;
+			return true;
+		}
+
+		case TCM_DELETEITEM:
+		{
+			int index = static_cast<int>(wParam);
+			if (index < 0 || index >= static_cast<int>(tab.items.size()))
+			{
+				result = FALSE;
+				return true;
+			}
+
+			tab.items.erase(tab.items.begin() + index);
+
+			if (seg)
+			{
+				seg.segmentCount = static_cast<NSInteger>(tab.items.size());
+				for (int i = 0; i < static_cast<int>(tab.items.size()); ++i)
+					[seg setLabel:WideToNS(tab.items[i].text.c_str()) forSegment:i];
+			}
+
+			if (tab.currentSel >= static_cast<int>(tab.items.size()))
+				tab.currentSel = tab.items.empty() ? -1 : static_cast<int>(tab.items.size()) - 1;
+
+			if (seg && tab.currentSel >= 0)
+				seg.selectedSegment = tab.currentSel;
+
+			result = TRUE;
+			return true;
+		}
+
+		case TCM_DELETEALLITEMS:
+		{
+			tab.items.clear();
+			tab.currentSel = -1;
+			if (seg) seg.segmentCount = 0;
+			result = TRUE;
+			return true;
+		}
+
+		case TCM_GETCURSEL:
+			result = tab.currentSel;
+			return true;
+
+		case TCM_SETCURSEL:
+		{
+			int index = static_cast<int>(wParam);
+			int oldSel = tab.currentSel;
+
+			if (index >= 0 && index < static_cast<int>(tab.items.size()))
+			{
+				tab.currentSel = index;
+				if (seg) seg.selectedSegment = index;
+			}
+
+			result = oldSel;
+			return true;
+		}
+
+		case TCM_GETITEMCOUNT:
+			result = static_cast<intptr_t>(tab.items.size());
+			return true;
+
+		case TCM_GETITEMW:
+		{
+			int index = static_cast<int>(wParam);
+			TCITEMW* pItem = reinterpret_cast<TCITEMW*>(lParam);
+			if (!pItem || index < 0 || index >= static_cast<int>(tab.items.size()))
+			{
+				result = FALSE;
+				return true;
+			}
+
+			const auto& item = tab.items[index];
+			if (pItem->mask & TCIF_TEXT && pItem->pszText && pItem->cchTextMax > 0)
+			{
+				int maxCopy = pItem->cchTextMax - 1;
+				int len = (std::min)(maxCopy, static_cast<int>(item.text.size()));
+				wcsncpy(pItem->pszText, item.text.c_str(), len);
+				pItem->pszText[len] = L'\0';
+			}
+			if (pItem->mask & TCIF_IMAGE)
+				pItem->iImage = item.image;
+			if (pItem->mask & TCIF_PARAM)
+				pItem->lParam = item.lParam;
+
+			result = TRUE;
+			return true;
+		}
+
+		case TCM_SETITEMW:
+		{
+			int index = static_cast<int>(wParam);
+			const TCITEMW* pItem = reinterpret_cast<const TCITEMW*>(lParam);
+			if (!pItem || index < 0 || index >= static_cast<int>(tab.items.size()))
+			{
+				result = FALSE;
+				return true;
+			}
+
+			auto& item = tab.items[index];
+			if (pItem->mask & TCIF_TEXT && pItem->pszText)
+			{
+				item.text = pItem->pszText;
+				if (seg)
+					[seg setLabel:WideToNS(item.text.c_str()) forSegment:index];
+			}
+			if (pItem->mask & TCIF_IMAGE)
+				item.image = pItem->iImage;
+			if (pItem->mask & TCIF_PARAM)
+				item.lParam = pItem->lParam;
+
+			result = TRUE;
+			return true;
+		}
+
+		case TCM_GETITEMRECT:
+		{
+			int index = static_cast<int>(wParam);
+			RECT* pRect = reinterpret_cast<RECT*>(lParam);
+			if (!pRect || !seg || index < 0 || index >= static_cast<int>(tab.items.size()))
+			{
+				result = FALSE;
+				return true;
+			}
+
+			// Approximate: divide evenly
+			CGFloat segWidth = seg.frame.size.width / (std::max)(1, (int)tab.items.size());
+			pRect->left = static_cast<LONG>(index * segWidth);
+			pRect->top = 0;
+			pRect->right = static_cast<LONG>((index + 1) * segWidth);
+			pRect->bottom = static_cast<LONG>(seg.frame.size.height);
+			result = TRUE;
+			return true;
+		}
+
+		case TCM_ADJUSTRECT:
+		{
+			// wParam TRUE = given window rect, return display rect
+			// wParam FALSE = given display rect, return window rect
+			// For simplicity, just shrink/expand by tab bar height
+			RECT* pRect = reinterpret_cast<RECT*>(lParam);
+			if (pRect)
+			{
+				if (wParam) // larger
+					pRect->top += 28; // tab bar height
+				else
+					pRect->top -= 28;
+			}
+			result = 0;
+			return true;
+		}
+
+		case TCM_SETITEMSIZE:
+		case TCM_SETPADDING:
+		case TCM_SETIMAGELIST:
+		case TCM_GETIMAGELIST:
+		case TCM_SETMINTABWIDTH:
+		case TCM_SETEXTENDEDSTYLE:
+		case TCM_GETEXTENDEDSTYLE:
+		case TCM_HIGHLIGHTITEM:
+		case TCM_GETTOOLTIPS:
+		case TCM_SETTOOLTIPS:
+		case TCM_GETROWCOUNT:
+		case TCM_GETCURFOCUS:
+		case TCM_SETCURFOCUS:
+			result = 0;
+			return true;
+
+		case TCM_HITTEST:
+		{
+			TCHITTESTINFO* pHitTest = reinterpret_cast<TCHITTESTINFO*>(lParam);
+			if (!pHitTest || !seg)
+			{
+				result = -1;
+				return true;
+			}
+			// Simple hit test: check which segment the point falls in
+			CGFloat segWidth = seg.frame.size.width / (std::max)(1, (int)tab.items.size());
+			int hitIndex = static_cast<int>(pHitTest->pt.x / segWidth);
+			if (hitIndex >= 0 && hitIndex < static_cast<int>(tab.items.size()))
+			{
+				pHitTest->flags = TCHT_ONITEMLABEL;
+				result = hitIndex;
+			}
+			else
+			{
+				pHitTest->flags = TCHT_NOWHERE;
+				result = -1;
+			}
+			return true;
+		}
+	}
+
+	return false;
+}
+
+// ============================================================
+// StatusBar message handling
+// ============================================================
+
+static bool HandleStatusBarMessage(HWND hwnd, unsigned int msg, uintptr_t wParam, intptr_t lParam,
+                                    intptr_t& result)
+{
+	uintptr_t key = reinterpret_cast<uintptr_t>(hwnd);
+	auto it = s_statusBars.find(key);
+	if (it == s_statusBars.end()) return false;
+
+	auto& sb = it->second;
+	auto* info = HandleRegistry::getWindowInfo(hwnd);
+	Win32StatusBarView* barView = info ? (__bridge Win32StatusBarView*)info->nativeView : nil;
+
+	switch (msg)
+	{
+		case SB_SETPARTS:
+		{
+			int count = static_cast<int>(wParam);
+			const int* widths = reinterpret_cast<const int*>(lParam);
+			sb.partWidths.clear();
+			sb.partTexts.resize(count);
+
+			if (barView)
+			{
+				barView.partCount = count;
+				[barView.partWidths removeAllObjects];
+				[barView.partTexts removeAllObjects];
+			}
+
+			for (int i = 0; i < count; ++i)
+			{
+				sb.partWidths.push_back(widths ? widths[i] : -1);
+				if (barView)
+				{
+					[barView.partWidths addObject:@(widths ? widths[i] : -1)];
+					[barView.partTexts addObject:@""];
+				}
+			}
+
+			if (barView) [barView setNeedsDisplay:YES];
+			result = TRUE;
+			return true;
+		}
+
+		case SB_SETTEXTW:
+		{
+			int part = static_cast<int>(wParam & 0xFF);
+			// bits 8-15 are drawing type (SBT_OWNERDRAW etc.)
+			const wchar_t* text = reinterpret_cast<const wchar_t*>(lParam);
+
+			if (part >= 0 && part < static_cast<int>(sb.partTexts.size()))
+			{
+				sb.partTexts[part] = text ? text : L"";
+				if (barView && part < (int)barView.partTexts.count)
+				{
+					barView.partTexts[part] = WideToNS(text);
+					[barView setNeedsDisplay:YES];
+				}
+			}
+			result = TRUE;
+			return true;
+		}
+
+		case SB_GETTEXTW:
+		{
+			int part = static_cast<int>(wParam);
+			wchar_t* buf = reinterpret_cast<wchar_t*>(lParam);
+			if (part >= 0 && part < static_cast<int>(sb.partTexts.size()) && buf)
+			{
+				wcscpy(buf, sb.partTexts[part].c_str());
+				result = static_cast<intptr_t>(sb.partTexts[part].size());
+			}
+			else
+			{
+				result = 0;
+			}
+			return true;
+		}
+
+		case SB_GETTEXTLENGTHW:
+		{
+			int part = static_cast<int>(wParam);
+			if (part >= 0 && part < static_cast<int>(sb.partTexts.size()))
+				result = static_cast<intptr_t>(sb.partTexts[part].size());
+			else
+				result = 0;
+			return true;
+		}
+
+		case SB_GETPARTS:
+		{
+			int maxParts = static_cast<int>(wParam);
+			int* widths = reinterpret_cast<int*>(lParam);
+			int count = static_cast<int>(sb.partWidths.size());
+			if (widths)
+			{
+				int n = (std::min)(maxParts, count);
+				for (int i = 0; i < n; ++i)
+					widths[i] = sb.partWidths[i];
+			}
+			result = count;
+			return true;
+		}
+
+		case SB_GETRECT:
+		{
+			int part = static_cast<int>(wParam);
+			RECT* pRect = reinterpret_cast<RECT*>(lParam);
+			if (pRect && barView)
+			{
+				CGFloat x = 0;
+				for (int i = 0; i < part && i < static_cast<int>(sb.partWidths.size()); ++i)
+				{
+					int w = sb.partWidths[i];
+					x += (w > 0) ? w : (barView.bounds.size.width - x);
+				}
+				int w = (part < static_cast<int>(sb.partWidths.size())) ? sb.partWidths[part] : -1;
+				CGFloat width = (w > 0) ? w : (barView.bounds.size.width - x);
+				pRect->left = static_cast<LONG>(x);
+				pRect->top = 0;
+				pRect->right = static_cast<LONG>(x + width);
+				pRect->bottom = static_cast<LONG>(barView.bounds.size.height);
+				result = TRUE;
+			}
+			else
+			{
+				result = FALSE;
+			}
+			return true;
+		}
+
+		case SB_SETMINHEIGHT:
+		{
+			if (barView)
+			{
+				CGFloat h = static_cast<CGFloat>(wParam);
+				NSRect f = barView.frame;
+				f.size.height = h;
+				barView.frame = f;
+			}
+			result = 0;
+			return true;
+		}
+
+		case SB_SIMPLE:
+		case SB_ISSIMPLE:
+		case SB_SETICON:
+		case SB_SETTIPTEXTW:
+		case SB_GETTIPTEXTW:
+		case SB_GETBORDERS:
+			result = 0;
+			return true;
+	}
+
+	return false;
+}
+
+// ============================================================
+// Toolbar message handling (data-only)
+// ============================================================
+
+static bool HandleToolbarMessage(HWND hwnd, unsigned int msg, uintptr_t wParam, intptr_t lParam,
+                                  intptr_t& result)
+{
+	uintptr_t key = reinterpret_cast<uintptr_t>(hwnd);
+	auto it = s_toolBars.find(key);
+	if (it == s_toolBars.end()) return false;
+
+	auto& tb = it->second;
+
+	switch (msg)
+	{
+		case TB_BUTTONSTRUCTSIZE:
+			result = 0;
+			return true;
+
+		case TB_ADDBUTTONS:
+		{
+			int count = static_cast<int>(wParam);
+			const TBBUTTON* buttons = reinterpret_cast<const TBBUTTON*>(lParam);
+			if (buttons)
+			{
+				for (int i = 0; i < count; ++i)
+				{
+					ToolbarButtonData btn;
+					btn.iBitmap = buttons[i].iBitmap;
+					btn.idCommand = buttons[i].idCommand;
+					btn.fsState = buttons[i].fsState;
+					btn.fsStyle = buttons[i].fsStyle;
+					btn.dwData = buttons[i].dwData;
+					btn.iString = buttons[i].iString;
+					tb.buttons.push_back(btn);
+				}
+			}
+			result = TRUE;
+			return true;
+		}
+
+		case TB_INSERTBUTTONW:
+		{
+			int index = static_cast<int>(wParam);
+			const TBBUTTON* pBtn = reinterpret_cast<const TBBUTTON*>(lParam);
+			if (pBtn)
+			{
+				ToolbarButtonData btn;
+				btn.iBitmap = pBtn->iBitmap;
+				btn.idCommand = pBtn->idCommand;
+				btn.fsState = pBtn->fsState;
+				btn.fsStyle = pBtn->fsStyle;
+				btn.dwData = pBtn->dwData;
+				btn.iString = pBtn->iString;
+
+				if (index < 0 || index > static_cast<int>(tb.buttons.size()))
+					index = static_cast<int>(tb.buttons.size());
+				tb.buttons.insert(tb.buttons.begin() + index, btn);
+			}
+			result = TRUE;
+			return true;
+		}
+
+		case TB_DELETEBUTTON:
+		{
+			int index = static_cast<int>(wParam);
+			if (index >= 0 && index < static_cast<int>(tb.buttons.size()))
+			{
+				tb.buttons.erase(tb.buttons.begin() + index);
+				result = TRUE;
+			}
+			else
+			{
+				result = FALSE;
+			}
+			return true;
+		}
+
+		case TB_BUTTONCOUNT:
+			result = static_cast<intptr_t>(tb.buttons.size());
+			return true;
+
+		case TB_GETBUTTON:
+		{
+			int index = static_cast<int>(wParam);
+			TBBUTTON* pBtn = reinterpret_cast<TBBUTTON*>(lParam);
+			if (pBtn && index >= 0 && index < static_cast<int>(tb.buttons.size()))
+			{
+				const auto& btn = tb.buttons[index];
+				pBtn->iBitmap = btn.iBitmap;
+				pBtn->idCommand = btn.idCommand;
+				pBtn->fsState = btn.fsState;
+				pBtn->fsStyle = btn.fsStyle;
+				pBtn->dwData = btn.dwData;
+				pBtn->iString = btn.iString;
+				result = TRUE;
+			}
+			else
+			{
+				result = FALSE;
+			}
+			return true;
+		}
+
+		case TB_COMMANDTOINDEX:
+		{
+			int cmdId = static_cast<int>(wParam);
+			for (int i = 0; i < static_cast<int>(tb.buttons.size()); ++i)
+			{
+				if (tb.buttons[i].idCommand == cmdId)
+				{
+					result = i;
+					return true;
+				}
+			}
+			result = -1;
+			return true;
+		}
+
+		case TB_ENABLEBUTTON:
+		{
+			int cmdId = static_cast<int>(wParam);
+			bool enable = lParam != 0;
+			for (auto& btn : tb.buttons)
+			{
+				if (btn.idCommand == cmdId)
+				{
+					if (enable)
+						btn.fsState |= TBSTATE_ENABLED;
+					else
+						btn.fsState &= ~TBSTATE_ENABLED;
+					break;
+				}
+			}
+			result = TRUE;
+			return true;
+		}
+
+		case TB_CHECKBUTTON:
+		{
+			int cmdId = static_cast<int>(wParam);
+			bool check = lParam != 0;
+			for (auto& btn : tb.buttons)
+			{
+				if (btn.idCommand == cmdId)
+				{
+					if (check)
+						btn.fsState |= TBSTATE_CHECKED;
+					else
+						btn.fsState &= ~TBSTATE_CHECKED;
+					break;
+				}
+			}
+			result = TRUE;
+			return true;
+		}
+
+		case TB_HIDEBUTTON:
+		{
+			int cmdId = static_cast<int>(wParam);
+			bool hide = lParam != 0;
+			for (auto& btn : tb.buttons)
+			{
+				if (btn.idCommand == cmdId)
+				{
+					if (hide)
+						btn.fsState |= TBSTATE_HIDDEN;
+					else
+						btn.fsState &= ~TBSTATE_HIDDEN;
+					break;
+				}
+			}
+			result = TRUE;
+			return true;
+		}
+
+		case TB_ISBUTTONENABLED:
+		{
+			int cmdId = static_cast<int>(wParam);
+			for (const auto& btn : tb.buttons)
+			{
+				if (btn.idCommand == cmdId)
+				{
+					result = (btn.fsState & TBSTATE_ENABLED) ? TRUE : FALSE;
+					return true;
+				}
+			}
+			result = FALSE;
+			return true;
+		}
+
+		case TB_ISBUTTONCHECKED:
+		{
+			int cmdId = static_cast<int>(wParam);
+			for (const auto& btn : tb.buttons)
+			{
+				if (btn.idCommand == cmdId)
+				{
+					result = (btn.fsState & TBSTATE_CHECKED) ? TRUE : FALSE;
+					return true;
+				}
+			}
+			result = FALSE;
+			return true;
+		}
+
+		case TB_ISBUTTONHIDDEN:
+		{
+			int cmdId = static_cast<int>(wParam);
+			for (const auto& btn : tb.buttons)
+			{
+				if (btn.idCommand == cmdId)
+				{
+					result = (btn.fsState & TBSTATE_HIDDEN) ? TRUE : FALSE;
+					return true;
+				}
+			}
+			result = FALSE;
+			return true;
+		}
+
+		case TB_GETSTATE:
+		{
+			int cmdId = static_cast<int>(wParam);
+			for (const auto& btn : tb.buttons)
+			{
+				if (btn.idCommand == cmdId)
+				{
+					result = btn.fsState;
+					return true;
+				}
+			}
+			result = -1;
+			return true;
+		}
+
+		case TB_SETSTATE:
+		{
+			int cmdId = static_cast<int>(wParam);
+			BYTE newState = static_cast<BYTE>(LOWORD(lParam));
+			for (auto& btn : tb.buttons)
+			{
+				if (btn.idCommand == cmdId)
+				{
+					btn.fsState = newState;
+					break;
+				}
+			}
+			result = TRUE;
+			return true;
+		}
+
+		case TB_SETBUTTONSIZE:
+		{
+			tb.buttonSizeCx = LOWORD(lParam);
+			tb.buttonSizeCy = HIWORD(lParam);
+			result = TRUE;
+			return true;
+		}
+
+		case TB_GETBUTTONSIZE:
+			result = MAKELONG(tb.buttonSizeCx, tb.buttonSizeCy);
+			return true;
+
+		case TB_SETBITMAPSIZE:
+		case TB_SETIMAGELIST:
+		case TB_GETIMAGELIST:
+		case TB_SETHOTIMAGELIST:
+		case TB_SETDISABLEDIMAGELIST:
+		case TB_AUTOSIZE:
+		case TB_SETMAXTEXTROWS:
+		case TB_GETTOOLTIPS:
+		case TB_SETTOOLTIPS:
+		case TB_SETPARENT:
+		case TB_SETEXTENDEDSTYLE:
+		case TB_GETEXTENDEDSTYLE:
+		case TB_ADDBITMAP:
+		case TB_SETDRAWTEXTFLAGS:
+		case TB_SETPADDING:
+		case TB_GETPADDING:
+		case TB_SETCMDID:
+		case TB_CUSTOMIZE:
+		case TB_SAVERESTORE:
+		case TB_PRESSBUTTON:
+		case TB_INDETERMINATE:
+		case TB_ISBUTTONPRESSED:
+		case TB_SETROWS:
+		case TB_GETROWS:
+		case TB_GETBITMAPFLAGS:
+			result = 0;
+			return true;
+
+		case TB_GETITEMRECT:
+		case TB_GETRECT:
+		{
+			RECT* pRect = reinterpret_cast<RECT*>(lParam);
+			if (pRect)
+			{
+				int index = (msg == TB_COMMANDTOINDEX) ? static_cast<int>(wParam) : static_cast<int>(wParam);
+				pRect->left = index * tb.buttonSizeCx;
+				pRect->top = 0;
+				pRect->right = pRect->left + tb.buttonSizeCx;
+				pRect->bottom = tb.buttonSizeCy;
+			}
+			result = TRUE;
+			return true;
+		}
+
+		case TB_GETBUTTONINFOW:
+		case TB_SETBUTTONINFOW:
+			result = -1;
+			return true;
+
+		case TB_GETITEMDROPDOWNRECT:
+		{
+			RECT* pRect = reinterpret_cast<RECT*>(lParam);
+			if (pRect)
+				memset(pRect, 0, sizeof(RECT));
+			result = FALSE;
+			return true;
+		}
+	}
+
+	return false;
+}
+
+// ============================================================
+// ReBar message handling (data-only)
+// ============================================================
+
+static bool HandleReBarMessage(HWND hwnd, unsigned int msg, uintptr_t wParam, intptr_t lParam,
+                                intptr_t& result)
+{
+	uintptr_t key = reinterpret_cast<uintptr_t>(hwnd);
+	auto it = s_reBars.find(key);
+	if (it == s_reBars.end()) return false;
+
+	auto& rb = it->second;
+
+	switch (msg)
+	{
+		case RB_INSERTBANDW:
+		{
+			const REBARBANDINFOW* pBand = reinterpret_cast<const REBARBANDINFOW*>(lParam);
+			if (pBand)
+			{
+				ReBarBandData band;
+				band.fMask = pBand->fMask;
+				band.fStyle = pBand->fStyle;
+				if (pBand->fMask & RBBIM_CHILD) band.hwndChild = pBand->hwndChild;
+				if (pBand->fMask & RBBIM_CHILDSIZE) { band.cxMinChild = pBand->cxMinChild; band.cyMinChild = pBand->cyMinChild; }
+				if (pBand->fMask & RBBIM_SIZE) band.cx = pBand->cx;
+				if (pBand->fMask & RBBIM_ID) band.wID = pBand->wID;
+				if (pBand->fMask & RBBIM_TEXT && pBand->lpText) band.text = pBand->lpText;
+
+				int index = static_cast<int>(wParam);
+				if (index < 0 || index > static_cast<int>(rb.bands.size()))
+					index = static_cast<int>(rb.bands.size());
+				rb.bands.insert(rb.bands.begin() + index, band);
+			}
+			result = TRUE;
+			return true;
+		}
+
+		case RB_DELETEBAND:
+		{
+			int index = static_cast<int>(wParam);
+			if (index >= 0 && index < static_cast<int>(rb.bands.size()))
+			{
+				rb.bands.erase(rb.bands.begin() + index);
+				result = TRUE;
+			}
+			else
+			{
+				result = FALSE;
+			}
+			return true;
+		}
+
+		case RB_GETBANDCOUNT:
+			result = static_cast<intptr_t>(rb.bands.size());
+			return true;
+
+		case RB_SETBANDINFOW:
+		{
+			int index = static_cast<int>(wParam);
+			const REBARBANDINFOW* pBand = reinterpret_cast<const REBARBANDINFOW*>(lParam);
+			if (pBand && index >= 0 && index < static_cast<int>(rb.bands.size()))
+			{
+				auto& band = rb.bands[index];
+				if (pBand->fMask & RBBIM_STYLE) band.fStyle = pBand->fStyle;
+				if (pBand->fMask & RBBIM_CHILD) band.hwndChild = pBand->hwndChild;
+				if (pBand->fMask & RBBIM_CHILDSIZE) { band.cxMinChild = pBand->cxMinChild; band.cyMinChild = pBand->cyMinChild; }
+				if (pBand->fMask & RBBIM_SIZE) band.cx = pBand->cx;
+				if (pBand->fMask & RBBIM_ID) band.wID = pBand->wID;
+				if (pBand->fMask & RBBIM_TEXT && pBand->lpText) band.text = pBand->lpText;
+				result = TRUE;
+			}
+			else
+			{
+				result = FALSE;
+			}
+			return true;
+		}
+
+		case RB_GETBANDINFOW:
+		{
+			int index = static_cast<int>(wParam);
+			REBARBANDINFOW* pBand = reinterpret_cast<REBARBANDINFOW*>(lParam);
+			if (pBand && index >= 0 && index < static_cast<int>(rb.bands.size()))
+			{
+				const auto& band = rb.bands[index];
+				if (pBand->fMask & RBBIM_STYLE) pBand->fStyle = band.fStyle;
+				if (pBand->fMask & RBBIM_CHILD) pBand->hwndChild = band.hwndChild;
+				if (pBand->fMask & RBBIM_CHILDSIZE) { pBand->cxMinChild = band.cxMinChild; pBand->cyMinChild = band.cyMinChild; }
+				if (pBand->fMask & RBBIM_SIZE) pBand->cx = band.cx;
+				if (pBand->fMask & RBBIM_ID) pBand->wID = band.wID;
+				result = TRUE;
+			}
+			else
+			{
+				result = FALSE;
+			}
+			return true;
+		}
+
+		case RB_IDTOINDEX:
+		{
+			UINT id = static_cast<UINT>(wParam);
+			for (int i = 0; i < static_cast<int>(rb.bands.size()); ++i)
+			{
+				if (rb.bands[i].wID == id)
+				{
+					result = i;
+					return true;
+				}
+			}
+			result = -1;
+			return true;
+		}
+
+		case RB_SHOWBAND:
+		{
+			int index = static_cast<int>(wParam);
+			if (index >= 0 && index < static_cast<int>(rb.bands.size()))
+			{
+				if (lParam)
+					rb.bands[index].fStyle &= ~RBBS_HIDDEN;
+				else
+					rb.bands[index].fStyle |= RBBS_HIDDEN;
+			}
+			result = TRUE;
+			return true;
+		}
+
+		case RB_SETBARINFO:
+		case RB_GETBARINFO:
+		case RB_GETROWCOUNT:
+		case RB_GETROWHEIGHT:
+		case RB_SIZETORECT:
+		case RB_SETBKCOLOR:
+		case RB_GETBKCOLOR:
+		case RB_SETTEXTCOLOR:
+		case RB_GETTEXTCOLOR:
+		case RB_MOVEBAND:
+		case RB_GETBARHEIGHT:
+			result = 0;
+			return true;
+	}
+
+	return false;
+}
+
+// ============================================================
+// Dispatcher
+// ============================================================
+
+bool Win32Controls_HandleMessage(void* hwndVoid, ControlType type,
+                                  unsigned int msg, uintptr_t wParam, intptr_t lParam,
+                                  intptr_t& result)
+{
+	HWND hwnd = reinterpret_cast<HWND>(hwndVoid);
+
+	switch (type)
+	{
+		case ControlType::TabControl:
+			return HandleTabMessage(hwnd, msg, wParam, lParam, result);
+		case ControlType::StatusBar:
+			return HandleStatusBarMessage(hwnd, msg, wParam, lParam, result);
+		case ControlType::Toolbar:
+			return HandleToolbarMessage(hwnd, msg, wParam, lParam, result);
+		case ControlType::ReBar:
+			return HandleReBarMessage(hwnd, msg, wParam, lParam, result);
+		default:
+			return false;
+	}
+}
+
+// ============================================================
+// Control lifecycle management
+// ============================================================
+
+void Win32Controls_DestroyControl(void* hwndVoid, ControlType type)
+{
+	uintptr_t key = reinterpret_cast<uintptr_t>(hwndVoid);
+
+	switch (type)
+	{
+		case ControlType::TabControl:
+		{
+			s_tabControls.erase(key);
+			NSNumber* num = @(key);
+			[s_tabTargets removeObjectForKey:num];
+			break;
+		}
+		case ControlType::StatusBar:
+			s_statusBars.erase(key);
+			break;
+		case ControlType::Toolbar:
+			s_toolBars.erase(key);
+			break;
+		case ControlType::ReBar:
+			s_reBars.erase(key);
+			break;
+		default:
+			break;
+	}
+}
+
+// Called from CreateWindowExW after the HWND is created and registered
+// to initialize per-control data structures.
+void Win32Controls_InitControl(HWND hwnd, ControlType type, HWND parent)
+{
+	uintptr_t key = reinterpret_cast<uintptr_t>(hwnd);
+
+	switch (type)
+	{
+		case ControlType::TabControl:
+		{
+			TabControlData data;
+			data.hwnd = hwnd;
+			data.parent = parent;
+			s_tabControls[key] = data;
+
+			// Set up action target for the NSSegmentedControl
+			auto* info = HandleRegistry::getWindowInfo(hwnd);
+			if (info && info->nativeView)
+			{
+				if (!s_tabTargets)
+					s_tabTargets = [NSMutableDictionary dictionary];
+
+				Win32TabTarget* target = [[Win32TabTarget alloc] init];
+				target.tabHwnd = hwnd;
+
+				NSSegmentedControl* seg = (__bridge NSSegmentedControl*)info->nativeView;
+				seg.target = target;
+				seg.action = @selector(tabSelectionChanged:);
+
+				s_tabTargets[@(key)] = target;
+			}
+			break;
+		}
+		case ControlType::StatusBar:
+		{
+			StatusBarData data;
+			data.hwnd = hwnd;
+			s_statusBars[key] = data;
+			break;
+		}
+		case ControlType::Toolbar:
+		{
+			ToolbarData data;
+			data.hwnd = hwnd;
+			s_toolBars[key] = data;
+			break;
+		}
+		case ControlType::ReBar:
+		{
+			ReBarData data;
+			data.hwnd = hwnd;
+			s_reBars[key] = data;
+			break;
+		}
+		default:
+			break;
+	}
+}
+
+// ============================================================
+// ImageList stubs (count-tracking only)
+// ============================================================
+
+struct ImageListData
+{
+	int cx = 0;
+	int cy = 0;
+	UINT flags = 0;
+	int count = 0;
+};
+
+static std::unordered_map<uintptr_t, ImageListData> s_imageLists;
+static uintptr_t s_nextImageList = 0x30000;
+
+HIMAGELIST ImageList_Create(int cx, int cy, UINT flags, int cInitial, int cGrow)
+{
+	HIMAGELIST himl = reinterpret_cast<HIMAGELIST>(s_nextImageList++);
+	ImageListData data;
+	data.cx = cx;
+	data.cy = cy;
+	data.flags = flags;
+	data.count = 0;
+	s_imageLists[reinterpret_cast<uintptr_t>(himl)] = data;
+	return himl;
+}
+
+BOOL ImageList_Destroy(HIMAGELIST himl)
+{
+	s_imageLists.erase(reinterpret_cast<uintptr_t>(himl));
+	return TRUE;
+}
+
+int ImageList_Add(HIMAGELIST himl, HBITMAP hbmImage, HBITMAP hbmMask)
+{
+	auto it = s_imageLists.find(reinterpret_cast<uintptr_t>(himl));
+	if (it != s_imageLists.end())
+		return it->second.count++;
+	return -1;
+}
+
+int ImageList_AddMasked(HIMAGELIST himl, HBITMAP hbmImage, COLORREF crMask)
+{
+	return ImageList_Add(himl, hbmImage, nullptr);
+}
+
+int ImageList_ReplaceIcon(HIMAGELIST himl, int i, HICON hicon)
+{
+	auto it = s_imageLists.find(reinterpret_cast<uintptr_t>(himl));
+	if (it == s_imageLists.end()) return -1;
+
+	if (i == -1) // append
+		return it->second.count++;
+	return i;
+}
+
+BOOL ImageList_Remove(HIMAGELIST himl, int i)
+{
+	auto it = s_imageLists.find(reinterpret_cast<uintptr_t>(himl));
+	if (it == s_imageLists.end()) return FALSE;
+
+	if (i == -1) // remove all
+		it->second.count = 0;
+	else if (it->second.count > 0)
+		--it->second.count;
+
+	return TRUE;
+}
+
+int ImageList_GetImageCount(HIMAGELIST himl)
+{
+	auto it = s_imageLists.find(reinterpret_cast<uintptr_t>(himl));
+	return (it != s_imageLists.end()) ? it->second.count : 0;
+}
+
+BOOL ImageList_SetImageCount(HIMAGELIST himl, UINT uNewCount)
+{
+	auto it = s_imageLists.find(reinterpret_cast<uintptr_t>(himl));
+	if (it != s_imageLists.end())
+	{
+		it->second.count = static_cast<int>(uNewCount);
+		return TRUE;
+	}
+	return FALSE;
+}
+
+BOOL ImageList_Draw(HIMAGELIST himl, int i, HDC hdcDst, int x, int y, UINT fStyle)
+{
+	return TRUE; // stub
+}
+
+BOOL ImageList_DrawEx(HIMAGELIST himl, int i, HDC hdcDst, int x, int y, int dx, int dy,
+                       COLORREF rgbBk, COLORREF rgbFg, UINT fStyle)
+{
+	return TRUE; // stub
+}
+
+BOOL ImageList_SetIconSize(HIMAGELIST himl, int cx, int cy)
+{
+	auto it = s_imageLists.find(reinterpret_cast<uintptr_t>(himl));
+	if (it != s_imageLists.end())
+	{
+		it->second.cx = cx;
+		it->second.cy = cy;
+		return TRUE;
+	}
+	return FALSE;
+}
+
+HICON ImageList_GetIcon(HIMAGELIST himl, int i, UINT flags)
+{
+	return nullptr;
+}
+
+BOOL ImageList_GetIconSize(HIMAGELIST himl, int* cx, int* cy)
+{
+	auto it = s_imageLists.find(reinterpret_cast<uintptr_t>(himl));
+	if (it != s_imageLists.end())
+	{
+		if (cx) *cx = it->second.cx;
+		if (cy) *cy = it->second.cy;
+		return TRUE;
+	}
+	return FALSE;
+}
+
+BOOL ImageList_GetImageInfo(HIMAGELIST himl, int i, IMAGEINFO* pImageInfo)
+{
+	if (pImageInfo) memset(pImageInfo, 0, sizeof(IMAGEINFO));
+	return FALSE;
+}
+
+BOOL ImageList_BeginDrag(HIMAGELIST himlTrack, int iTrack, int dxHotspot, int dyHotspot) { return TRUE; }
+BOOL ImageList_DragEnter(HWND hwndLock, int x, int y) { return TRUE; }
+BOOL ImageList_DragMove(int x, int y) { return TRUE; }
+BOOL ImageList_DragShowNolock(BOOL fShow) { return TRUE; }
+BOOL ImageList_DragLeave(HWND hwndLock) { return TRUE; }
+void ImageList_EndDrag() {}
+HIMAGELIST ImageList_Merge(HIMAGELIST himl1, int i1, HIMAGELIST himl2, int i2, int dx, int dy) { return nullptr; }

--- a/macos/shim/src/win32_message.mm
+++ b/macos/shim/src/win32_message.mm
@@ -4,7 +4,9 @@
 
 #import <Cocoa/Cocoa.h>
 #include "windows.h"
+#include "commctrl.h"
 #include "handle_registry.h"
+#include "win32_controls_impl.h"
 #include "scintilla_bridge.h"
 
 // Scintilla messages start at SCI_START (2000)
@@ -30,6 +32,18 @@ LRESULT SendMessageW(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 			ScintillaBridge_sendMessage(info->nativeView, Msg,
 			                           static_cast<uintptr_t>(wParam),
 			                           static_cast<intptr_t>(lParam)));
+	}
+
+	// Common control messages: route to control handler
+	if (info->controlType != ControlType::None)
+	{
+		intptr_t controlResult = 0;
+		if (Win32Controls_HandleMessage(reinterpret_cast<void*>(hWnd), info->controlType,
+		                                 Msg, static_cast<uintptr_t>(wParam),
+		                                 static_cast<intptr_t>(lParam), controlResult))
+		{
+			return static_cast<LRESULT>(controlResult);
+		}
 	}
 
 	// Regular Win32 messages: dispatch to WndProc

--- a/macos/shim/src/win32_window.mm
+++ b/macos/shim/src/win32_window.mm
@@ -5,7 +5,11 @@
 #include "windows.h"
 #include "commctrl.h"
 #include "handle_registry.h"
+#include "win32_controls_impl.h"
 #include "scintilla_bridge.h"
+
+// Forward declaration for control init (defined in win32_controls.mm)
+void Win32Controls_InitControl(HWND hwnd, ControlType type, HWND parent);
 
 // ============================================================
 // Window class registration
@@ -184,7 +188,18 @@ HWND CreateWindowExW(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName,
 				parentView = parentInfo->nativeView;
 		}
 
-		if (parentView)
+		// Check if this is a known common control class
+		ControlType ctrlType = Win32Controls_GetControlType(className);
+		if (ctrlType != ControlType::None && parentView)
+		{
+			info.controlType = ctrlType;
+
+			void* ctrlView = Win32Controls_CreateControl(
+				ctrlType, parentView, X, Y, nWidth, nHeight, dwStyle, dwExStyle);
+			if (ctrlView)
+				info.nativeView = ctrlView;
+		}
+		else if (parentView)
 		{
 			NSView* parent = (__bridge NSView*)parentView;
 			CGFloat parentH = parent.bounds.size.height;
@@ -197,6 +212,10 @@ HWND CreateWindowExW(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName,
 		}
 
 		HWND hwnd = HandleRegistry::createWindow(info);
+
+		// Initialize control data structures after HWND is assigned
+		if (ctrlType != ControlType::None)
+			Win32Controls_InitControl(hwnd, ctrlType, hWndParent);
 
 		// Send WM_CREATE
 		if (info.wndProc)


### PR DESCRIPTION
## Summary
- **Tab control shim**: `SysTabControl32` → `NSSegmentedControl` with full TCM_* message handling and WM_NOTIFY/TCN_SELCHANGE dispatch to parent
- **Status bar shim**: `msctls_statusbar32` → custom `Win32StatusBarView` (NSView) with SB_SETPARTS/SETTEXT/GETTEXT
- **Toolbar/ReBar**: Data-only TB_*/RB_* message handlers (N++ does custom drawing)
- **ImageList stubs**: Count-tracking Create/Destroy/Add/ReplaceIcon
- **File monitoring**: FSEvents-based `FileMonitorMac` class replacing `ReadDirectoryChanges`
- **Control routing**: `CreateWindowExW` and `SendMessageW` now detect common control classes and route to dedicated handlers via `ControlType` enum in `HandleRegistry::WindowInfo`
- **Phase 3 demo app** (`main_phase3.mm`): Multi-document tabbed editor with per-tab state save/restore, status bar showing line/col/encoding, and periodic timer updates

## Test plan
- [x] `cmake --build . --target npp_phase3_app` builds cleanly
- [x] `cmake --build . --target npp_phase0_test` still passes (no regressions)
- [x] `cmake --build . --target npp_phase2_app` still passes (no regressions)
- [x] App launches, displays tabs and status bar
- [ ] Cmd+N creates new tabs, Cmd+W closes them
- [ ] Cmd+O opens files into new tabs
- [ ] Clicking tabs switches documents with state preserved
- [ ] Status bar updates line/col as cursor moves

🤖 Generated with [Claude Code](https://claude.com/claude-code)