### PR TITLE
Add Phase 7: settings, split view, edit commands, session, encoding

### DIFF
--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -446,6 +446,39 @@ target_compile_options(npp_phase6_app PRIVATE
     -Wno-deprecated-declarations
 )
 
+# ============================================================
+# Phase 7: Settings, Split View, Edit Commands, Session, D&D, Encoding
+# ============================================================
+add_executable(npp_phase7_app
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/main_phase7.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/settings_manager.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/file_monitor_mac.mm"
+)
+target_include_directories(npp_phase7_app PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform"
+    "${SHIM_INCLUDE_DIR}"
+    "${SCINTILLA_INCLUDE_DIR}"
+    "${LEXILLA_INCLUDE_DIR}"
+    "${UCHARDET_DIR}"
+)
+target_link_libraries(npp_phase7_app
+    win32shim
+    scintilla_bridge
+    Scintilla
+    Lexilla
+    pugixml
+    uchardet
+    "-framework Foundation"
+    "-framework AppKit"
+    "-framework QuartzCore"
+    "-framework UniformTypeIdentifiers"
+    "-framework CoreServices"
+)
+target_compile_options(npp_phase7_app PRIVATE
+    -fobjc-arc
+    -Wno-deprecated-declarations
+)
+
 message(STATUS "=== Notepad++ macOS Port ===")
 message(STATUS "Phase 0: Shim compilation test (npp_phase0_test)")
 message(STATUS "Phase 2: File I/O + Menus app (npp_phase2_app)")
@@ -453,6 +486,7 @@ message(STATUS "Phase 3: Tabs + Multi-Document app (npp_phase3_app)")
 message(STATUS "Phase 4: Find/Replace + Dialogs app (npp_phase4_app)")
 message(STATUS "Phase 5: Advanced Editor Features app (npp_phase5_app)")
 message(STATUS "Phase 6: Syntax Highlighting + Code Folding app (npp_phase6_app)")
+message(STATUS "Phase 7: Settings, Split View, Edit, Encoding app (npp_phase7_app)")
 message(STATUS "Shim headers: ${SHIM_INCLUDE_DIR}")
 message(STATUS "Scintilla: ${SCINTILLA_DIR}")
 message(STATUS "Lexilla: ${LEXILLA_DIR}")

--- a/macos/platform/main_phase7.mm
+++ b/macos/platform/main_phase7.mm
@@ -697,6 +697,7 @@ static int g_activeTab2 = -1;
 static HWND g_tabHwnd2 = nullptr;
 static NSView* g_editorContainer = nil;
 static NSView* g_editorContainer2 = nil;
+static NSView* g_sciContainer2 = nil; // Sub-container for scintillaView2 in right pane
 
 // Accessor helpers for split view
 static void*& activeScintillaView() { return g_activeView == 0 ? g_scintillaView : g_scintillaView2; }
@@ -729,61 +730,72 @@ static std::wstring NSStringToWide(NSString* str)
 // ============================================================
 // Scintilla state save/restore
 // ============================================================
-static void saveScintillaState()
+static void saveViewState(void* sci, std::vector<DocumentData>& docs, int tabIdx)
 {
-	if (g_activeTab < 0 || g_activeTab >= static_cast<int>(g_documents.size()))
+	if (tabIdx < 0 || tabIdx >= static_cast<int>(docs.size()))
 		return;
-	if (!g_scintillaView) return;
+	if (!sci) return;
 
-	auto& doc = g_documents[g_activeTab];
-	intptr_t len = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXTLENGTH, 0, 0);
+	auto& doc = docs[tabIdx];
+	intptr_t len = ScintillaBridge_sendMessage(sci, SCI_GETTEXTLENGTH, 0, 0);
 	if (len >= 0)
 	{
 		doc.content.resize(len + 1);
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXT, len + 1,
+		ScintillaBridge_sendMessage(sci, SCI_GETTEXT, len + 1,
 		                            (intptr_t)doc.content.data());
 		doc.content.resize(len);
 	}
-	doc.cursorPos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCURRENTPOS, 0, 0);
-	doc.anchorPos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETANCHOR, 0, 0);
-	doc.firstVisibleLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETFIRSTVISIBLELINE, 0, 0);
-	doc.modified = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETMODIFY, 0, 0) != 0;
+	doc.cursorPos = ScintillaBridge_sendMessage(sci, SCI_GETCURRENTPOS, 0, 0);
+	doc.anchorPos = ScintillaBridge_sendMessage(sci, SCI_GETANCHOR, 0, 0);
+	doc.firstVisibleLine = ScintillaBridge_sendMessage(sci, SCI_GETFIRSTVISIBLELINE, 0, 0);
+	doc.modified = ScintillaBridge_sendMessage(sci, SCI_GETMODIFY, 0, 0) != 0;
 
 	// Save bookmarked lines
 	doc.bookmarkedLines.clear();
-	intptr_t lineCount = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINECOUNT, 0, 0);
+	intptr_t lineCount = ScintillaBridge_sendMessage(sci, SCI_GETLINECOUNT, 0, 0);
 	intptr_t line = 0;
 	while (line < lineCount)
 	{
-		line = ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERNEXT, line, BOOKMARK_MASK);
+		line = ScintillaBridge_sendMessage(sci, SCI_MARKERNEXT, line, BOOKMARK_MASK);
 		if (line < 0) break;
 		doc.bookmarkedLines.push_back(static_cast<int>(line));
 		++line;
 	}
 }
 
-static void restoreScintillaState(int tabIndex)
+static void saveScintillaState()
 {
-	if (tabIndex < 0 || tabIndex >= static_cast<int>(g_documents.size()))
-		return;
-	if (!g_scintillaView) return;
+	saveViewState(g_scintillaView, g_documents, g_activeTab);
+}
 
-	const auto& doc = g_documents[tabIndex];
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTEXT, 0, (intptr_t)doc.content.c_str());
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETFIRSTVISIBLELINE, doc.firstVisibleLine, 0);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEL, doc.anchorPos, doc.cursorPos);
+static void restoreViewToScintilla(void* sci, const std::vector<DocumentData>& docs, int tabIndex)
+{
+	if (tabIndex < 0 || tabIndex >= static_cast<int>(docs.size()))
+		return;
+	if (!sci) return;
+
+	const auto& doc = docs[tabIndex];
+	ScintillaBridge_sendMessage(sci, SCI_SETTEXT, 0, (intptr_t)doc.content.c_str());
+	ScintillaBridge_sendMessage(sci, SCI_SETFIRSTVISIBLELINE, doc.firstVisibleLine, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETSEL, doc.anchorPos, doc.cursorPos);
 	if (!doc.modified)
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSAVEPOINT, 0, 0);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_EMPTYUNDOBUFFER, 0, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETSAVEPOINT, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_EMPTYUNDOBUFFER, 0, 0);
 
 	// Restore bookmarks
 	for (int bkLine : doc.bookmarkedLines)
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERADD, bkLine, BOOKMARK_MARKER);
+		ScintillaBridge_sendMessage(sci, SCI_MARKERADD, bkLine, BOOKMARK_MARKER);
+}
+
+static void restoreScintillaState(int tabIndex)
+{
+	restoreViewToScintilla(g_scintillaView, g_documents, tabIndex);
 }
 
 // ============================================================
 // Language / lexer switching
 // ============================================================
+static void applyLanguageToView(void* sci, int langIndex);
 static void applyLanguage(int langIndex);
 
 // Forward declarations
@@ -792,58 +804,77 @@ static void applyAppearance();
 // ============================================================
 // Tab management
 // ============================================================
-static void switchToTab(int tabIndex)
+static void switchToTabInView(int viewIndex, int tabIndex)
 {
-	if (tabIndex < 0 || tabIndex >= static_cast<int>(g_documents.size()))
-		return;
-	if (tabIndex == g_activeTab)
-		return;
+	auto& docs = (viewIndex == 0) ? g_documents : g_documents2;
+	auto& activeTab = (viewIndex == 0) ? g_activeTab : g_activeTab2;
+	void* sci = (viewIndex == 0) ? g_scintillaView : g_scintillaView2;
+	HWND tabHwnd = (viewIndex == 0) ? g_tabHwnd : g_tabHwnd2;
 
-	saveScintillaState();
-	g_activeTab = tabIndex;
-	SendMessageW(g_tabHwnd, TCM_SETCURSEL, tabIndex, 0);
-	restoreScintillaState(tabIndex);
-	applyLanguage(g_documents[tabIndex].languageIndex);
+	if (tabIndex < 0 || tabIndex >= static_cast<int>(docs.size()))
+		return;
+	if (tabIndex == activeTab)
+		return;
+	if (!sci) return;
 
-	const auto& doc = g_documents[tabIndex];
+	saveViewState(sci, docs, activeTab);
+	activeTab = tabIndex;
+	if (tabHwnd)
+		SendMessageW(tabHwnd, TCM_SETCURSEL, tabIndex, 0);
+	restoreViewToScintilla(sci, docs, tabIndex);
+	applyLanguageToView(sci, docs[tabIndex].languageIndex);
+
+	const auto& doc = docs[tabIndex];
 	NSString* title = WideToNSString(doc.title.c_str());
 	[g_mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@", title]];
 }
 
-static int addNewTab(const std::wstring& title, const std::string& content,
-                      const std::wstring& filePath = L"", int langIndex = 2)
+static void switchToTab(int tabIndex)
 {
-	saveScintillaState();
+	switchToTabInView(g_activeView, tabIndex);
+}
+
+static int addNewTabToView(int viewIndex, const std::wstring& title, const std::string& content,
+                            const std::wstring& filePath = L"", int langIndex = 2)
+{
+	auto& docs = (viewIndex == 0) ? g_documents : g_documents2;
+	auto& activeTab = (viewIndex == 0) ? g_activeTab : g_activeTab2;
+	void* sci = (viewIndex == 0) ? g_scintillaView : g_scintillaView2;
+	HWND tabHwnd = (viewIndex == 0) ? g_tabHwnd : g_tabHwnd2;
+
+	if (!sci) return -1;
+
+	saveViewState(sci, docs, activeTab);
 
 	DocumentData doc;
 	doc.title = title;
 	doc.content = content;
 	doc.filePath = filePath;
 	doc.languageIndex = langIndex;
-	g_documents.push_back(doc);
+	docs.push_back(doc);
 
-	int newIndex = static_cast<int>(g_documents.size()) - 1;
+	int newIndex = static_cast<int>(docs.size()) - 1;
 
-	TCITEMW tcItem = {};
-	tcItem.mask = TCIF_TEXT;
-	wchar_t titleBuf[256];
-	wcsncpy(titleBuf, title.c_str(), 255);
-	titleBuf[255] = L'\0';
-	tcItem.pszText = titleBuf;
-	SendMessageW(g_tabHwnd, TCM_INSERTITEMW, newIndex, reinterpret_cast<LPARAM>(&tcItem));
-
-	g_activeTab = newIndex;
-	SendMessageW(g_tabHwnd, TCM_SETCURSEL, newIndex, 0);
-
-	if (g_scintillaView)
+	if (tabHwnd)
 	{
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTEXT, 0, (intptr_t)content.c_str());
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_GOTOPOS, 0, 0);
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_EMPTYUNDOBUFFER, 0, 0);
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSAVEPOINT, 0, 0);
+		TCITEMW tcItem = {};
+		tcItem.mask = TCIF_TEXT;
+		wchar_t titleBuf[256];
+		wcsncpy(titleBuf, title.c_str(), 255);
+		titleBuf[255] = L'\0';
+		tcItem.pszText = titleBuf;
+		SendMessageW(tabHwnd, TCM_INSERTITEMW, newIndex, reinterpret_cast<LPARAM>(&tcItem));
+		SendMessageW(tabHwnd, TCM_SETCURSEL, newIndex, 0);
 	}
 
-	applyLanguage(langIndex);
+	activeTab = newIndex;
+
+	ScintillaBridge_sendMessage(sci, SCI_SETTEXT, 0, (intptr_t)content.c_str());
+	ScintillaBridge_sendMessage(sci, SCI_GOTOPOS, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_EMPTYUNDOBUFFER, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETSAVEPOINT, 0, 0);
+
+	applyLanguageToView(sci, langIndex);
 
 	NSString* nsTitle = WideToNSString(title.c_str());
 	[g_mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@", nsTitle]];
@@ -851,46 +882,66 @@ static int addNewTab(const std::wstring& title, const std::string& content,
 	return newIndex;
 }
 
-static void closeTab(int tabIndex)
+static int addNewTab(const std::wstring& title, const std::string& content,
+                      const std::wstring& filePath = L"", int langIndex = 2)
 {
-	if (tabIndex < 0 || tabIndex >= static_cast<int>(g_documents.size()))
-		return;
+	return addNewTabToView(g_activeView, title, content, filePath, langIndex);
+}
 
-	if (g_documents.size() <= 1)
+static void closeTabFromView(int viewIndex, int tabIndex)
+{
+	auto& docs = (viewIndex == 0) ? g_documents : g_documents2;
+	auto& activeTab = (viewIndex == 0) ? g_activeTab : g_activeTab2;
+	void* sci = (viewIndex == 0) ? g_scintillaView : g_scintillaView2;
+	HWND tabHwnd = (viewIndex == 0) ? g_tabHwnd : g_tabHwnd2;
+
+	if (tabIndex < 0 || tabIndex >= static_cast<int>(docs.size()))
+		return;
+	if (!sci) return;
+
+	if (docs.size() <= 1)
 	{
-		g_documents[0] = DocumentData();
-		if (g_scintillaView)
+		docs[0] = DocumentData();
+		ScintillaBridge_sendMessage(sci, SCI_CLEARALL, 0, 0);
+		ScintillaBridge_sendMessage(sci, SCI_EMPTYUNDOBUFFER, 0, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETSAVEPOINT, 0, 0);
+		if (tabHwnd)
 		{
-			ScintillaBridge_sendMessage(g_scintillaView, SCI_CLEARALL, 0, 0);
-			ScintillaBridge_sendMessage(g_scintillaView, SCI_EMPTYUNDOBUFFER, 0, 0);
-			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSAVEPOINT, 0, 0);
+			TCITEMW tcItem = {};
+			tcItem.mask = TCIF_TEXT;
+			wchar_t untitled[] = L"Untitled";
+			tcItem.pszText = untitled;
+			SendMessageW(tabHwnd, TCM_SETITEMW, 0, reinterpret_cast<LPARAM>(&tcItem));
 		}
-		TCITEMW tcItem = {};
-		tcItem.mask = TCIF_TEXT;
-		wchar_t title[] = L"Untitled";
-		tcItem.pszText = title;
-		SendMessageW(g_tabHwnd, TCM_SETITEMW, 0, reinterpret_cast<LPARAM>(&tcItem));
 		[g_mainWindow setTitle:@"Notepad++ — Untitled"];
 		return;
 	}
 
-	SendMessageW(g_tabHwnd, TCM_DELETEITEM, tabIndex, 0);
-	g_documents.erase(g_documents.begin() + tabIndex);
+	if (tabHwnd)
+		SendMessageW(tabHwnd, TCM_DELETEITEM, tabIndex, 0);
+	docs.erase(docs.begin() + tabIndex);
 
-	if (tabIndex < g_activeTab)
-		--g_activeTab;
-	else if (tabIndex == g_activeTab)
+	if (tabIndex < activeTab)
+		--activeTab;
+	else if (tabIndex == activeTab)
 	{
-		if (g_activeTab >= static_cast<int>(g_documents.size()))
-			g_activeTab = static_cast<int>(g_documents.size()) - 1;
+		if (activeTab >= static_cast<int>(docs.size()))
+			activeTab = static_cast<int>(docs.size()) - 1;
 	}
 
-	SendMessageW(g_tabHwnd, TCM_SETCURSEL, g_activeTab, 0);
-	restoreScintillaState(g_activeTab);
+	if (tabHwnd)
+		SendMessageW(tabHwnd, TCM_SETCURSEL, activeTab, 0);
+	restoreViewToScintilla(sci, docs, activeTab);
+	applyLanguageToView(sci, docs[activeTab].languageIndex);
 
-	const auto& doc = g_documents[g_activeTab];
+	const auto& doc = docs[activeTab];
 	NSString* title = WideToNSString(doc.title.c_str());
 	[g_mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@", title]];
+}
+
+static void closeTab(int tabIndex)
+{
+	closeTabFromView(g_activeView, tabIndex);
 }
 
 // ============================================================
@@ -898,13 +949,17 @@ static void closeTab(int tabIndex)
 // ============================================================
 static void updateStatusBar()
 {
-	if (!g_scintillaView || !g_statusBarHwnd) return;
+	void* sci = activeScintillaView();
+	if (!sci || !g_statusBarHwnd) return;
 
-	intptr_t pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCURRENTPOS, 0, 0);
-	intptr_t line = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, pos, 0);
-	intptr_t col = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCOLUMN, pos, 0);
-	intptr_t lineCount = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINECOUNT, 0, 0);
-	intptr_t docLen = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLENGTH, 0, 0);
+	auto& docs = activeDocuments();
+	int tabIdx = activeTabIndex();
+
+	intptr_t pos = ScintillaBridge_sendMessage(sci, SCI_GETCURRENTPOS, 0, 0);
+	intptr_t line = ScintillaBridge_sendMessage(sci, SCI_LINEFROMPOSITION, pos, 0);
+	intptr_t col = ScintillaBridge_sendMessage(sci, SCI_GETCOLUMN, pos, 0);
+	intptr_t lineCount = ScintillaBridge_sendMessage(sci, SCI_GETLINECOUNT, 0, 0);
+	intptr_t docLen = ScintillaBridge_sendMessage(sci, SCI_GETLENGTH, 0, 0);
 
 	wchar_t buf[128];
 	swprintf(buf, 128, L"Ln %ld, Col %ld", (long)(line + 1), (long)(col + 1));
@@ -915,9 +970,9 @@ static void updateStatusBar()
 
 	// Show language name
 	const char* langName = "Normal Text";
-	if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+	if (tabIdx >= 0 && tabIdx < static_cast<int>(docs.size()))
 	{
-		int langIdx = g_documents[g_activeTab].languageIndex;
+		int langIdx = docs[tabIdx].languageIndex;
 		if (langIdx >= 0 && langIdx < g_numLanguages)
 			langName = g_languages[langIdx].name;
 	}
@@ -927,21 +982,21 @@ static void updateStatusBar()
 
 	// Encoding
 	const char* encName = "UTF-8";
-	if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
-		encName = encodingName(g_documents[g_activeTab].encoding);
+	if (tabIdx >= 0 && tabIdx < static_cast<int>(docs.size()))
+		encName = encodingName(docs[tabIdx].encoding);
 	NSString* nsEnc = [NSString stringWithUTF8String:encName];
 	std::wstring wEnc = NSStringToWide(nsEnc);
 	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 3, reinterpret_cast<LPARAM>(wEnc.c_str()));
 
 	// EOL mode
 	const char* eolN = "LF";
-	if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
-		eolN = eolName(g_documents[g_activeTab].eolMode);
+	if (tabIdx >= 0 && tabIdx < static_cast<int>(docs.size()))
+		eolN = eolName(docs[tabIdx].eolMode);
 	NSString* nsEol = [NSString stringWithUTF8String:eolN];
 	std::wstring wEol = NSStringToWide(nsEol);
 	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 4, reinterpret_cast<LPARAM>(wEol.c_str()));
 
-	swprintf(buf, 128, L"Doc %d/%d", g_activeTab + 1, (int)g_documents.size());
+	swprintf(buf, 128, L"Doc %d/%d", tabIdx + 1, (int)docs.size());
 	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 5, reinterpret_cast<LPARAM>(buf));
 }
 
@@ -1017,38 +1072,39 @@ static int buildSearchFlags()
 
 static bool doFindNext(bool forward)
 {
-	if (!g_scintillaView || g_findText.empty()) return false;
+	void* sci = activeScintillaView();
+	if (!sci || g_findText.empty()) return false;
 
 	NSString* nsFind = WideToNSString(g_findText.c_str());
 	const char* utf8Find = [nsFind UTF8String];
 
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEARCHFLAGS, buildSearchFlags(), 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETSEARCHFLAGS, buildSearchFlags(), 0);
 
-	intptr_t docLen = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLENGTH, 0, 0);
+	intptr_t docLen = ScintillaBridge_sendMessage(sci, SCI_GETLENGTH, 0, 0);
 
 	if (forward)
 	{
-		intptr_t selEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONEND, 0, 0);
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, selEnd, 0);
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, docLen, 0);
+		intptr_t selEnd = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONEND, 0, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, selEnd, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, docLen, 0);
 	}
 	else
 	{
-		intptr_t selStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONSTART, 0, 0);
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, selStart, 0);
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, 0, 0);
+		intptr_t selStart = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONSTART, 0, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, selStart, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, 0, 0);
 	}
 
-	intptr_t pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_SEARCHINTARGET,
+	intptr_t pos = ScintillaBridge_sendMessage(sci, SCI_SEARCHINTARGET,
 	                                            strlen(utf8Find), (intptr_t)utf8Find);
 	if (pos >= 0)
 	{
-		intptr_t targetEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTARGETEND, 0, 0);
+		intptr_t targetEnd = ScintillaBridge_sendMessage(sci, SCI_GETTARGETEND, 0, 0);
 		// Advance past zero-length matches to avoid infinite Find Next loop
 		if (targetEnd == pos && pos < docLen)
 			targetEnd = pos + 1;
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEL, pos, targetEnd);
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_SCROLLCARET, 0, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETSEL, pos, targetEnd);
+		ScintillaBridge_sendMessage(sci, SCI_SCROLLCARET, 0, 0);
 		updateFindStatus(L"Match found");
 		return true;
 	}
@@ -1057,26 +1113,26 @@ static bool doFindNext(bool forward)
 		// Wrap around
 		if (forward)
 		{
-			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, 0, 0);
-			intptr_t selEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONEND, 0, 0);
-			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, selEnd, 0);
+			ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, 0, 0);
+			intptr_t selEnd = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONEND, 0, 0);
+			ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, selEnd, 0);
 		}
 		else
 		{
-			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, docLen, 0);
-			intptr_t selStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONSTART, 0, 0);
-			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, selStart, 0);
+			ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, docLen, 0);
+			intptr_t selStart = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONSTART, 0, 0);
+			ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, selStart, 0);
 		}
 
-		pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_SEARCHINTARGET,
+		pos = ScintillaBridge_sendMessage(sci, SCI_SEARCHINTARGET,
 		                                  strlen(utf8Find), (intptr_t)utf8Find);
 		if (pos >= 0)
 		{
-			intptr_t targetEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTARGETEND, 0, 0);
+			intptr_t targetEnd = ScintillaBridge_sendMessage(sci, SCI_GETTARGETEND, 0, 0);
 			if (targetEnd == pos && pos < docLen)
 				targetEnd = pos + 1;
-			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEL, pos, targetEnd);
-			ScintillaBridge_sendMessage(g_scintillaView, SCI_SCROLLCARET, 0, 0);
+			ScintillaBridge_sendMessage(sci, SCI_SETSEL, pos, targetEnd);
+			ScintillaBridge_sendMessage(sci, SCI_SCROLLCARET, 0, 0);
 			updateFindStatus(L"Wrapped around");
 			return true;
 		}
@@ -1091,27 +1147,28 @@ static bool doFindNext(bool forward)
 
 static int doCount()
 {
-	if (!g_scintillaView || g_findText.empty()) return 0;
+	void* sci = activeScintillaView();
+	if (!sci || g_findText.empty()) return 0;
 
 	NSString* nsFind = WideToNSString(g_findText.c_str());
 	const char* utf8Find = [nsFind UTF8String];
 
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEARCHFLAGS, buildSearchFlags(), 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETSEARCHFLAGS, buildSearchFlags(), 0);
 
-	intptr_t docLen = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLENGTH, 0, 0);
+	intptr_t docLen = ScintillaBridge_sendMessage(sci, SCI_GETLENGTH, 0, 0);
 	int count = 0;
 	intptr_t searchStart = 0;
 	size_t findLen = strlen(utf8Find);
 
 	while (searchStart < docLen)
 	{
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, searchStart, 0);
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, docLen, 0);
-		intptr_t pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_SEARCHINTARGET,
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, searchStart, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, docLen, 0);
+		intptr_t pos = ScintillaBridge_sendMessage(sci, SCI_SEARCHINTARGET,
 		                                            findLen, (intptr_t)utf8Find);
 		if (pos < 0) break;
 		++count;
-		intptr_t targetEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTARGETEND, 0, 0);
+		intptr_t targetEnd = ScintillaBridge_sendMessage(sci, SCI_GETTARGETEND, 0, 0);
 		if (targetEnd <= pos)
 		{
 			// Zero-length match: advance by 1 to continue counting
@@ -1133,10 +1190,11 @@ static int doCount()
 
 static void doReplaceOne()
 {
-	if (!g_scintillaView) return;
+	void* sci = activeScintillaView();
+	if (!sci) return;
 
-	intptr_t selStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONSTART, 0, 0);
-	intptr_t selEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONEND, 0, 0);
+	intptr_t selStart = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONSTART, 0, 0);
+	intptr_t selEnd = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONEND, 0, 0);
 
 	if (selStart == selEnd)
 	{
@@ -1147,9 +1205,9 @@ static void doReplaceOne()
 	NSString* nsReplace = WideToNSString(g_replaceText.c_str());
 	const char* utf8Replace = [nsReplace UTF8String];
 
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, selStart, 0);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, selEnd, 0);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_REPLACETARGET,
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, selStart, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, selEnd, 0);
+	ScintillaBridge_sendMessage(sci, SCI_REPLACETARGET,
 	                            strlen(utf8Replace), (intptr_t)utf8Replace);
 
 	doFindNext(true);
@@ -1158,16 +1216,17 @@ static void doReplaceOne()
 
 static void doReplaceAll()
 {
-	if (!g_scintillaView || g_findText.empty()) return;
+	void* sci = activeScintillaView();
+	if (!sci || g_findText.empty()) return;
 
 	NSString* nsFind = WideToNSString(g_findText.c_str());
 	NSString* nsReplace = WideToNSString(g_replaceText.c_str());
 	const char* utf8Find = [nsFind UTF8String];
 	const char* utf8Replace = [nsReplace UTF8String];
 
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEARCHFLAGS, buildSearchFlags(), 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETSEARCHFLAGS, buildSearchFlags(), 0);
 
-	intptr_t docLen = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLENGTH, 0, 0);
+	intptr_t docLen = ScintillaBridge_sendMessage(sci, SCI_GETLENGTH, 0, 0);
 	int count = 0;
 	intptr_t searchStart = 0;
 	size_t findLen = strlen(utf8Find);
@@ -1175,18 +1234,18 @@ static void doReplaceAll()
 
 	while (searchStart < docLen)
 	{
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, searchStart, 0);
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, docLen, 0);
-		intptr_t pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_SEARCHINTARGET,
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, searchStart, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, docLen, 0);
+		intptr_t pos = ScintillaBridge_sendMessage(sci, SCI_SEARCHINTARGET,
 		                                            findLen, (intptr_t)utf8Find);
 		if (pos < 0) break;
 
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_REPLACETARGET,
+		ScintillaBridge_sendMessage(sci, SCI_REPLACETARGET,
 		                            replaceLen, (intptr_t)utf8Replace);
 		++count;
 
 		searchStart = pos + static_cast<intptr_t>(replaceLen);
-		docLen = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLENGTH, 0, 0);
+		docLen = ScintillaBridge_sendMessage(sci, SCI_GETLENGTH, 0, 0);
 		// Safety for zero-length replacements: advance at least 1
 		if (searchStart <= pos)
 		{
@@ -1458,23 +1517,26 @@ static void createFindReplaceDlg(bool replaceMode)
 	}
 
 	// Pre-fill find text from current selection
-	if (g_scintillaView)
 	{
-		intptr_t selStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONSTART, 0, 0);
-		intptr_t selEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONEND, 0, 0);
-		if (selEnd > selStart && (selEnd - selStart) < 256)
+		void* sci = activeScintillaView();
+		if (sci)
 		{
-			char utf8Buf[512] = {};
-			ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELTEXT, 0, (intptr_t)utf8Buf);
-			NSString* sel = [NSString stringWithUTF8String:utf8Buf];
-			if (sel.length > 0)
+			intptr_t selStart = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONSTART, 0, 0);
+			intptr_t selEnd = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONEND, 0, 0);
+			if (selEnd > selStart && (selEnd - selStart) < 256)
 			{
-				NSData* data = [sel dataUsingEncoding:NSUTF32LittleEndianStringEncoding];
-				if (data && data.length > 0)
+				char utf8Buf[512] = {};
+				ScintillaBridge_sendMessage(sci, SCI_GETSELTEXT, 0, (intptr_t)utf8Buf);
+				NSString* sel = [NSString stringWithUTF8String:utf8Buf];
+				if (sel.length > 0)
 				{
-					std::wstring wsel(reinterpret_cast<const wchar_t*>(data.bytes),
-					                  data.length / sizeof(wchar_t));
-					SetDlgItemTextW(g_findDlgHwnd, IDC_FIND_EDIT, wsel.c_str());
+					NSData* data = [sel dataUsingEncoding:NSUTF32LittleEndianStringEncoding];
+					if (data && data.length > 0)
+					{
+						std::wstring wsel(reinterpret_cast<const wchar_t*>(data.bytes),
+						                  data.length / sizeof(wchar_t));
+						SetDlgItemTextW(g_findDlgHwnd, IDC_FIND_EDIT, wsel.c_str());
+					}
 				}
 			}
 		}
@@ -1489,11 +1551,12 @@ static void createFindReplaceDlg(bool replaceMode)
 
 static void showGoToLineDlg()
 {
-	if (!g_scintillaView) return;
+	void* sci = activeScintillaView();
+	if (!sci) return;
 
-	intptr_t lineCount = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINECOUNT, 0, 0);
-	intptr_t curPos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCURRENTPOS, 0, 0);
-	intptr_t curLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, curPos, 0);
+	intptr_t lineCount = ScintillaBridge_sendMessage(sci, SCI_GETLINECOUNT, 0, 0);
+	intptr_t curPos = ScintillaBridge_sendMessage(sci, SCI_GETCURRENTPOS, 0, 0);
+	intptr_t curLine = ScintillaBridge_sendMessage(sci, SCI_LINEFROMPOSITION, curPos, 0);
 
 	@autoreleasepool {
 		NSAlert* alert = [[NSAlert alloc] init];
@@ -1515,8 +1578,8 @@ static void showGoToLineDlg()
 			int lineNum = input.intValue;
 			if (lineNum > 0 && lineNum <= static_cast<int>(lineCount))
 			{
-				ScintillaBridge_sendMessage(g_scintillaView, SCI_GOTOLINE, lineNum - 1, 0);
-				ScintillaBridge_sendMessage(g_scintillaView, SCI_SCROLLCARET, 0, 0);
+				ScintillaBridge_sendMessage(sci, SCI_GOTOLINE, lineNum - 1, 0);
+				ScintillaBridge_sendMessage(sci, SCI_SCROLLCARET, 0, 0);
 			}
 		}
 	}
@@ -1528,65 +1591,69 @@ static void showGoToLineDlg()
 
 static void toggleBookmark()
 {
-	if (!g_scintillaView) return;
+	void* sci = activeScintillaView();
+	if (!sci) return;
 
-	intptr_t pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCURRENTPOS, 0, 0);
-	intptr_t line = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, pos, 0);
+	intptr_t pos = ScintillaBridge_sendMessage(sci, SCI_GETCURRENTPOS, 0, 0);
+	intptr_t line = ScintillaBridge_sendMessage(sci, SCI_LINEFROMPOSITION, pos, 0);
 
-	intptr_t markers = ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERGET, line, 0);
+	intptr_t markers = ScintillaBridge_sendMessage(sci, SCI_MARKERGET, line, 0);
 	if (markers & BOOKMARK_MASK)
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERDELETE, line, BOOKMARK_MARKER);
+		ScintillaBridge_sendMessage(sci, SCI_MARKERDELETE, line, BOOKMARK_MARKER);
 	else
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERADD, line, BOOKMARK_MARKER);
+		ScintillaBridge_sendMessage(sci, SCI_MARKERADD, line, BOOKMARK_MARKER);
 }
 
 static void nextBookmark()
 {
-	if (!g_scintillaView) return;
+	void* sci = activeScintillaView();
+	if (!sci) return;
 
-	intptr_t pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCURRENTPOS, 0, 0);
-	intptr_t curLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, pos, 0);
+	intptr_t pos = ScintillaBridge_sendMessage(sci, SCI_GETCURRENTPOS, 0, 0);
+	intptr_t curLine = ScintillaBridge_sendMessage(sci, SCI_LINEFROMPOSITION, pos, 0);
 
-	intptr_t nextLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERNEXT, curLine + 1, BOOKMARK_MASK);
+	intptr_t nextLine = ScintillaBridge_sendMessage(sci, SCI_MARKERNEXT, curLine + 1, BOOKMARK_MASK);
 	if (nextLine < 0)
 	{
 		// Wrap around
-		nextLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERNEXT, 0, BOOKMARK_MASK);
+		nextLine = ScintillaBridge_sendMessage(sci, SCI_MARKERNEXT, 0, BOOKMARK_MASK);
 	}
 
 	if (nextLine >= 0)
 	{
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_GOTOLINE, nextLine, 0);
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_SCROLLCARET, 0, 0);
+		ScintillaBridge_sendMessage(sci, SCI_GOTOLINE, nextLine, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SCROLLCARET, 0, 0);
 	}
 }
 
 static void prevBookmark()
 {
-	if (!g_scintillaView) return;
+	void* sci = activeScintillaView();
+	if (!sci) return;
 
-	intptr_t pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCURRENTPOS, 0, 0);
-	intptr_t curLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, pos, 0);
+	intptr_t pos = ScintillaBridge_sendMessage(sci, SCI_GETCURRENTPOS, 0, 0);
+	intptr_t curLine = ScintillaBridge_sendMessage(sci, SCI_LINEFROMPOSITION, pos, 0);
 
-	intptr_t prevLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERPREVIOUS, curLine - 1, BOOKMARK_MASK);
+	intptr_t prevLine = ScintillaBridge_sendMessage(sci, SCI_MARKERPREVIOUS, curLine - 1, BOOKMARK_MASK);
 	if (prevLine < 0)
 	{
 		// Wrap around from end
-		intptr_t lineCount = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINECOUNT, 0, 0);
-		prevLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERPREVIOUS, lineCount - 1, BOOKMARK_MASK);
+		intptr_t lineCount = ScintillaBridge_sendMessage(sci, SCI_GETLINECOUNT, 0, 0);
+		prevLine = ScintillaBridge_sendMessage(sci, SCI_MARKERPREVIOUS, lineCount - 1, BOOKMARK_MASK);
 	}
 
 	if (prevLine >= 0)
 	{
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_GOTOLINE, prevLine, 0);
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_SCROLLCARET, 0, 0);
+		ScintillaBridge_sendMessage(sci, SCI_GOTOLINE, prevLine, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SCROLLCARET, 0, 0);
 	}
 }
 
 static void clearAllBookmarks()
 {
-	if (!g_scintillaView) return;
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERDELETEALL, BOOKMARK_MARKER, 0);
+	void* sci = activeScintillaView();
+	if (!sci) return;
+	ScintillaBridge_sendMessage(sci, SCI_MARKERDELETEALL, BOOKMARK_MARKER, 0);
 }
 
 // ============================================================
@@ -1595,10 +1662,11 @@ static void clearAllBookmarks()
 
 static void showAutoComplete()
 {
-	if (!g_scintillaView) return;
+	void* sci = activeScintillaView();
+	if (!sci) return;
 
-	intptr_t pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCURRENTPOS, 0, 0);
-	intptr_t wordStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_WORDSTARTPOSITION, pos, 1);
+	intptr_t pos = ScintillaBridge_sendMessage(sci, SCI_GETCURRENTPOS, 0, 0);
+	intptr_t wordStart = ScintillaBridge_sendMessage(sci, SCI_WORDSTARTPOSITION, pos, 1);
 	intptr_t wordLen = pos - wordStart;
 
 	if (wordLen < 1) return;
@@ -1606,16 +1674,16 @@ static void showAutoComplete()
 	// Get the partial word
 	char partial[256] = {};
 	for (intptr_t i = 0; i < wordLen && i < 255; ++i)
-		partial[i] = static_cast<char>(ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCHARAT, wordStart + i, 0));
+		partial[i] = static_cast<char>(ScintillaBridge_sendMessage(sci, SCI_GETCHARAT, wordStart + i, 0));
 	partial[wordLen] = '\0';
 
 	// Collect all words in the document that match the prefix
-	intptr_t docLen = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLENGTH, 0, 0);
+	intptr_t docLen = ScintillaBridge_sendMessage(sci, SCI_GETLENGTH, 0, 0);
 	if (docLen <= 0) return;
 
 	std::string docText;
 	docText.resize(docLen + 1);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXT, docLen + 1, (intptr_t)docText.data());
+	ScintillaBridge_sendMessage(sci, SCI_GETTEXT, docLen + 1, (intptr_t)docText.data());
 
 	// Extract unique words
 	std::set<std::string> words;
@@ -1664,9 +1732,9 @@ static void showAutoComplete()
 		wordList += matches[i];
 	}
 
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_AUTOCSETIGNORECASE, 1, 0);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_AUTOCSETORDER, 1, 0); // SC_ORDER_PERFORMSORT
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_AUTOCSHOW, wordLen, (intptr_t)wordList.c_str());
+	ScintillaBridge_sendMessage(sci, SCI_AUTOCSETIGNORECASE, 1, 0);
+	ScintillaBridge_sendMessage(sci, SCI_AUTOCSETORDER, 1, 0); // SC_ORDER_PERFORMSORT
+	ScintillaBridge_sendMessage(sci, SCI_AUTOCSHOW, wordLen, (intptr_t)wordList.c_str());
 }
 
 // ============================================================
@@ -1829,20 +1897,26 @@ static void showPreferencesDlg()
 			g_fontSize = sizePopup.titleOfSelectedItem.intValue;
 			g_tabWidth = tabPopup.titleOfSelectedItem.intValue;
 
-			if (g_scintillaView)
+			// Apply to both views (global setting)
+			void* views[] = { g_scintillaView, g_scintillaView2 };
+			for (void* sci : views)
 			{
-				ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETFONT, 32, (intptr_t)g_fontName.c_str());
-				ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETSIZE, 32, g_fontSize);
-				ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLECLEARALL, 0, 0);
-				ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTABWIDTH, g_tabWidth, 0);
-
-				// Reapply appearance (colors)
-				applyAppearance();
-
-				// Reapply language keywords/highlighting
-				if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
-					applyLanguage(g_documents[g_activeTab].languageIndex);
+				if (!sci) continue;
+				ScintillaBridge_sendMessage(sci, SCI_STYLESETFONT, 32, (intptr_t)g_fontName.c_str());
+				ScintillaBridge_sendMessage(sci, SCI_STYLESETSIZE, 32, g_fontSize);
+				ScintillaBridge_sendMessage(sci, SCI_STYLECLEARALL, 0, 0);
+				ScintillaBridge_sendMessage(sci, SCI_SETTABWIDTH, g_tabWidth, 0);
 			}
+
+			// Reapply appearance (colors) — handles both views
+			applyAppearance();
+
+			// Reapply language keywords/highlighting for both views
+			if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+				applyLanguageToView(g_scintillaView, g_documents[g_activeTab].languageIndex);
+			if (g_isSplit && g_scintillaView2 && g_activeTab2 >= 0 &&
+			    g_activeTab2 < static_cast<int>(g_documents2.size()))
+				applyLanguageToView(g_scintillaView2, g_documents2[g_activeTab2].languageIndex);
 
 			// Save settings immediately
 			auto& ss = SettingsManager::instance().settings;
@@ -2036,12 +2110,14 @@ static bool openFileAtPath(NSString* path)
 	int langIdx = guessLanguage(wpath);
 	int tabIdx = addNewTab(title, utf8Content, wpath, langIdx);
 
-	if (tabIdx >= 0 && tabIdx < static_cast<int>(g_documents.size()))
+	auto& docs = activeDocuments();
+	if (tabIdx >= 0 && tabIdx < static_cast<int>(docs.size()))
 	{
-		g_documents[tabIdx].encoding = enc;
-		g_documents[tabIdx].eolMode = eol;
-		if (g_scintillaView)
-			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETEOLMODE, eol, 0);
+		docs[tabIdx].encoding = enc;
+		docs[tabIdx].eolMode = eol;
+		void* sci = activeScintillaView();
+		if (sci)
+			ScintillaBridge_sendMessage(sci, SCI_SETEOLMODE, eol, 0);
 	}
 
 	if (g_fileMonitor)
@@ -2096,10 +2172,14 @@ static void openRecentFile(int index)
 
 static void saveCurrentFile()
 {
-	if (g_activeTab < 0 || g_activeTab >= static_cast<int>(g_documents.size()))
+	auto& docs = activeDocuments();
+	int tabIdx = activeTabIndex();
+	if (tabIdx < 0 || tabIdx >= static_cast<int>(docs.size()))
 		return;
 
-	auto& doc = g_documents[g_activeTab];
+	auto& doc = docs[tabIdx];
+	void* sci = activeScintillaView();
+	HWND tabHwnd = activeTabHwnd();
 
 	if (doc.filePath.empty())
 	{
@@ -2124,26 +2204,30 @@ static void saveCurrentFile()
 			doc.title = doc.title.substr(lastSlash + 1);
 
 		// Update tab title
-		TCITEMW tcItem = {};
-		tcItem.mask = TCIF_TEXT;
-		wchar_t titleBuf[256];
-		wcsncpy(titleBuf, doc.title.c_str(), 255);
-		titleBuf[255] = L'\0';
-		tcItem.pszText = titleBuf;
-		SendMessageW(g_tabHwnd, TCM_SETITEMW, g_activeTab, reinterpret_cast<LPARAM>(&tcItem));
+		if (tabHwnd)
+		{
+			TCITEMW tcItem = {};
+			tcItem.mask = TCIF_TEXT;
+			wchar_t titleBuf[256];
+			wcsncpy(titleBuf, doc.title.c_str(), 255);
+			titleBuf[255] = L'\0';
+			tcItem.pszText = titleBuf;
+			SendMessageW(tabHwnd, TCM_SETITEMW, tabIdx, reinterpret_cast<LPARAM>(&tcItem));
+		}
 
 		// Detect language from extension
 		doc.languageIndex = guessLanguage(doc.filePath);
-		applyLanguage(doc.languageIndex);
+		if (sci)
+			applyLanguageToView(sci, doc.languageIndex);
 	}
 
-	if (!g_scintillaView) return;
+	if (!sci) return;
 
-	intptr_t len = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXTLENGTH, 0, 0);
+	intptr_t len = ScintillaBridge_sendMessage(sci, SCI_GETTEXTLENGTH, 0, 0);
 	if (len >= 0)
 	{
 		char* buf = new char[len + 1];
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXT, len + 1, (intptr_t)buf);
+		ScintillaBridge_sendMessage(sci, SCI_GETTEXT, len + 1, (intptr_t)buf);
 
 		NSString* path = WideToNSString(doc.filePath.c_str());
 		NSData* encoded = encodeForSave(buf, len, doc.encoding);
@@ -2155,7 +2239,7 @@ static void saveCurrentFile()
 			NSLog(@"Error saving file");
 		else
 		{
-			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSAVEPOINT, 0, 0);
+			ScintillaBridge_sendMessage(sci, SCI_SETSAVEPOINT, 0, 0);
 			NSString* nsTitle = WideToNSString(doc.title.c_str());
 			[g_mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@", nsTitle]];
 
@@ -2171,37 +2255,42 @@ static void saveCurrentFile()
 // Language switching
 // ============================================================
 
-static void applyLanguage(int langIndex)
+static void applyLanguageToView(void* sci, int langIndex)
 {
-	if (!g_scintillaView) return;
+	if (!sci) return;
 	if (langIndex < 0 || langIndex >= g_numLanguages) return;
 
 	const auto& lang = g_languages[langIndex];
 
 	// Create lexer via Lexilla and send to Scintilla
 	ILexer5* lexer = CreateLexer(lang.lexerName);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETILEXER, 0, (intptr_t)lexer);
+	ScintillaBridge_sendMessage(sci, SCI_SETILEXER, 0, (intptr_t)lexer);
 
 	// Set keyword lists
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETKEYWORDS, 0, (intptr_t)lang.keywords);
+	ScintillaBridge_sendMessage(sci, SCI_SETKEYWORDS, 0, (intptr_t)lang.keywords);
 	if (lang.keywords2 && lang.keywords2[0])
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETKEYWORDS, 1, (intptr_t)lang.keywords2);
+		ScintillaBridge_sendMessage(sci, SCI_SETKEYWORDS, 1, (intptr_t)lang.keywords2);
 
 	// Set fold properties
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETPROPERTY, (uintptr_t)"fold", (intptr_t)"1");
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETPROPERTY, (uintptr_t)"fold.compact", (intptr_t)"0");
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETPROPERTY, (uintptr_t)"fold.comment", (intptr_t)"1");
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETPROPERTY, (uintptr_t)"fold.preprocessor", (intptr_t)"1");
+	ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"fold", (intptr_t)"1");
+	ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"fold.compact", (intptr_t)"0");
+	ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"fold.comment", (intptr_t)"1");
+	ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"fold.preprocessor", (intptr_t)"1");
 
 	// Set font on STYLE_DEFAULT
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETFONT, 32, (intptr_t)g_fontName.c_str());
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETSIZE, 32, g_fontSize);
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETFONT, 32, (intptr_t)g_fontName.c_str());
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETSIZE, 32, g_fontSize);
 
 	// Apply syntax-aware colors
 	applyAppearance();
 
 	// Trigger re-coloring
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_COLOURISE, 0, -1);
+	ScintillaBridge_sendMessage(sci, SCI_COLOURISE, 0, -1);
+}
+
+static void applyLanguage(int langIndex)
+{
+	applyLanguageToView(activeScintillaView(), langIndex);
 }
 
 // ============================================================
@@ -2210,14 +2299,15 @@ static void applyLanguage(int langIndex)
 
 static void doTitleCase()
 {
-	if (!g_scintillaView) return;
-	intptr_t selStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONSTART, 0, 0);
-	intptr_t selEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONEND, 0, 0);
+	void* sci = activeScintillaView();
+	if (!sci) return;
+	intptr_t selStart = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONSTART, 0, 0);
+	intptr_t selEnd = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONEND, 0, 0);
 	if (selStart == selEnd) return;
 
 	intptr_t len = selEnd - selStart;
 	std::string text(len + 1, '\0');
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELTEXT, 0, (intptr_t)text.data());
+	ScintillaBridge_sendMessage(sci, SCI_GETSELTEXT, 0, (intptr_t)text.data());
 	text.resize(len);
 
 	bool capitalize = true;
@@ -2234,68 +2324,72 @@ static void doTitleCase()
 			text[i] = tolower(static_cast<unsigned char>(text[i]));
 	}
 
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_BEGINUNDOACTION, 0, 0);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_REPLACETARGET, -1, 0); // dummy
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, selStart, 0);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, selEnd, 0);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_REPLACETARGET, len, (intptr_t)text.c_str());
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEL, selStart, selStart + (intptr_t)text.size());
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_ENDUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, selStart, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, selEnd, 0);
+	ScintillaBridge_sendMessage(sci, SCI_REPLACETARGET, len, (intptr_t)text.c_str());
+	ScintillaBridge_sendMessage(sci, SCI_SETSEL, selStart, selStart + (intptr_t)text.size());
+	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
 }
 
 static void doTrimTrailingWhitespace()
 {
-	if (!g_scintillaView) return;
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_BEGINUNDOACTION, 0, 0);
+	void* sci = activeScintillaView();
+	if (!sci) return;
+	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
 
-	intptr_t lineCount = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINECOUNT, 0, 0);
+	intptr_t lineCount = ScintillaBridge_sendMessage(sci, SCI_GETLINECOUNT, 0, 0);
 	for (intptr_t line = lineCount - 1; line >= 0; --line)
 	{
-		intptr_t lineEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINEENDPOSITION, line, 0);
-		intptr_t lineStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, line, 0);
+		intptr_t lineEnd = ScintillaBridge_sendMessage(sci, SCI_GETLINEENDPOSITION, line, 0);
+		intptr_t lineStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, line, 0);
 		intptr_t trimPos = lineEnd;
 		while (trimPos > lineStart)
 		{
-			char ch = (char)ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCHARAT, trimPos - 1, 0);
+			char ch = (char)ScintillaBridge_sendMessage(sci, SCI_GETCHARAT, trimPos - 1, 0);
 			if (ch != ' ' && ch != '\t') break;
 			--trimPos;
 		}
 		if (trimPos < lineEnd)
-			ScintillaBridge_sendMessage(g_scintillaView, SCI_DELETERANGE, trimPos, lineEnd - trimPos);
+			ScintillaBridge_sendMessage(sci, SCI_DELETERANGE, trimPos, lineEnd - trimPos);
 	}
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_ENDUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
 }
 
 static void doRemoveEmptyLines()
 {
-	if (!g_scintillaView) return;
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_BEGINUNDOACTION, 0, 0);
+	void* sci = activeScintillaView();
+	if (!sci) return;
+	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
 
-	intptr_t lineCount = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINECOUNT, 0, 0);
+	intptr_t lineCount = ScintillaBridge_sendMessage(sci, SCI_GETLINECOUNT, 0, 0);
 	for (intptr_t line = lineCount - 1; line >= 0; --line)
 	{
-		intptr_t lineStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, line, 0);
-		intptr_t lineEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINEENDPOSITION, line, 0);
+		intptr_t lineStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, line, 0);
+		intptr_t lineEnd = ScintillaBridge_sendMessage(sci, SCI_GETLINEENDPOSITION, line, 0);
 		if (lineStart == lineEnd)
 		{
 			// Delete the line including its EOL
-			intptr_t nextLineStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, line + 1, 0);
+			intptr_t nextLineStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, line + 1, 0);
 			if (nextLineStart > lineStart)
-				ScintillaBridge_sendMessage(g_scintillaView, SCI_DELETERANGE, lineStart, nextLineStart - lineStart);
+				ScintillaBridge_sendMessage(sci, SCI_DELETERANGE, lineStart, nextLineStart - lineStart);
 		}
 	}
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_ENDUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
 }
 
 static void doToggleLineComment()
 {
-	if (!g_scintillaView) return;
+	void* sci = activeScintillaView();
+	if (!sci) return;
 
 	// Determine comment prefix from language
 	const char* prefix = "//";
-	if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+	auto& docs = activeDocuments();
+	int tabIdx = activeTabIndex();
+	if (tabIdx >= 0 && tabIdx < static_cast<int>(docs.size()))
 	{
-		int langIdx = g_documents[g_activeTab].languageIndex;
+		int langIdx = docs[tabIdx].languageIndex;
 		if (langIdx >= 0 && langIdx < g_numLanguages)
 		{
 			const char* lexer = g_languages[langIdx].lexerName;
@@ -2306,11 +2400,11 @@ static void doToggleLineComment()
 		}
 	}
 
-	intptr_t selStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONSTART, 0, 0);
-	intptr_t selEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONEND, 0, 0);
-	intptr_t startLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, selStart, 0);
-	intptr_t endLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, selEnd, 0);
-	if (selEnd == ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, endLine, 0) && endLine > startLine)
+	intptr_t selStart = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONSTART, 0, 0);
+	intptr_t selEnd = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONEND, 0, 0);
+	intptr_t startLine = ScintillaBridge_sendMessage(sci, SCI_LINEFROMPOSITION, selStart, 0);
+	intptr_t endLine = ScintillaBridge_sendMessage(sci, SCI_LINEFROMPOSITION, selEnd, 0);
+	if (selEnd == ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, endLine, 0) && endLine > startLine)
 		--endLine;
 
 	size_t prefixLen = strlen(prefix);
@@ -2319,8 +2413,8 @@ static void doToggleLineComment()
 	bool allCommented = true;
 	for (intptr_t line = startLine; line <= endLine; ++line)
 	{
-		intptr_t lineStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, line, 0);
-		intptr_t lineEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINEENDPOSITION, line, 0);
+		intptr_t lineStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, line, 0);
+		intptr_t lineEnd = ScintillaBridge_sendMessage(sci, SCI_GETLINEENDPOSITION, line, 0);
 		if (lineEnd - lineStart < (intptr_t)prefixLen)
 		{
 			allCommented = false;
@@ -2329,7 +2423,7 @@ static void doToggleLineComment()
 		bool match = true;
 		for (size_t j = 0; j < prefixLen; ++j)
 		{
-			if ((char)ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCHARAT, lineStart + j, 0) != prefix[j])
+			if ((char)ScintillaBridge_sendMessage(sci, SCI_GETCHARAT, lineStart + j, 0) != prefix[j])
 			{
 				match = false;
 				break;
@@ -2338,14 +2432,14 @@ static void doToggleLineComment()
 		if (!match) { allCommented = false; break; }
 	}
 
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_BEGINUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
 	if (allCommented)
 	{
 		// Remove comment prefix
 		for (intptr_t line = endLine; line >= startLine; --line)
 		{
-			intptr_t lineStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, line, 0);
-			ScintillaBridge_sendMessage(g_scintillaView, SCI_DELETERANGE, lineStart, prefixLen);
+			intptr_t lineStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, line, 0);
+			ScintillaBridge_sendMessage(sci, SCI_DELETERANGE, lineStart, prefixLen);
 		}
 	}
 	else
@@ -2353,35 +2447,36 @@ static void doToggleLineComment()
 		// Add comment prefix
 		for (intptr_t line = endLine; line >= startLine; --line)
 		{
-			intptr_t lineStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, line, 0);
-			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, lineStart, 0);
-			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, lineStart, 0);
-			ScintillaBridge_sendMessage(g_scintillaView, SCI_REPLACETARGET, prefixLen, (intptr_t)prefix);
+			intptr_t lineStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, line, 0);
+			ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, lineStart, 0);
+			ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, lineStart, 0);
+			ScintillaBridge_sendMessage(sci, SCI_REPLACETARGET, prefixLen, (intptr_t)prefix);
 		}
 	}
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_ENDUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
 }
 
 static void doSortLines(bool ascending)
 {
-	if (!g_scintillaView) return;
+	void* sci = activeScintillaView();
+	if (!sci) return;
 
-	intptr_t selStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONSTART, 0, 0);
-	intptr_t selEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONEND, 0, 0);
+	intptr_t selStart = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONSTART, 0, 0);
+	intptr_t selEnd = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONEND, 0, 0);
 	if (selStart == selEnd) return;
 
-	intptr_t startLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, selStart, 0);
-	intptr_t endLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, selEnd, 0);
+	intptr_t startLine = ScintillaBridge_sendMessage(sci, SCI_LINEFROMPOSITION, selStart, 0);
+	intptr_t endLine = ScintillaBridge_sendMessage(sci, SCI_LINEFROMPOSITION, selEnd, 0);
 
 	std::vector<std::string> lines;
 	for (intptr_t line = startLine; line <= endLine; ++line)
 	{
-		intptr_t lineStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, line, 0);
-		intptr_t lineEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINEENDPOSITION, line, 0);
+		intptr_t lineStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, line, 0);
+		intptr_t lineEnd = ScintillaBridge_sendMessage(sci, SCI_GETLINEENDPOSITION, line, 0);
 		intptr_t len = lineEnd - lineStart;
 		std::string text(len, '\0');
 		for (intptr_t i = 0; i < len; ++i)
-			text[i] = (char)ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCHARAT, lineStart + i, 0);
+			text[i] = (char)ScintillaBridge_sendMessage(sci, SCI_GETCHARAT, lineStart + i, 0);
 		lines.push_back(text);
 	}
 
@@ -2397,27 +2492,28 @@ static void doSortLines(bool ascending)
 		if (i + 1 < lines.size()) result += '\n';
 	}
 
-	intptr_t replStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, startLine, 0);
-	intptr_t replEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINEENDPOSITION, endLine, 0);
+	intptr_t replStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, startLine, 0);
+	intptr_t replEnd = ScintillaBridge_sendMessage(sci, SCI_GETLINEENDPOSITION, endLine, 0);
 
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_BEGINUNDOACTION, 0, 0);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, replStart, 0);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, replEnd, 0);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_REPLACETARGET, result.size(), (intptr_t)result.c_str());
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_ENDUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, replStart, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, replEnd, 0);
+	ScintillaBridge_sendMessage(sci, SCI_REPLACETARGET, result.size(), (intptr_t)result.c_str());
+	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
 }
 
 static void doJoinLines()
 {
-	if (!g_scintillaView) return;
+	void* sci = activeScintillaView();
+	if (!sci) return;
 
-	intptr_t selStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONSTART, 0, 0);
-	intptr_t selEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONEND, 0, 0);
+	intptr_t selStart = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONSTART, 0, 0);
+	intptr_t selEnd = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONEND, 0, 0);
 	if (selStart == selEnd) return;
 
 	intptr_t len = selEnd - selStart;
 	std::string text(len + 1, '\0');
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELTEXT, 0, (intptr_t)text.data());
+	ScintillaBridge_sendMessage(sci, SCI_GETSELTEXT, 0, (intptr_t)text.data());
 	text.resize(len);
 
 	// Replace all line breaks with space
@@ -2436,12 +2532,12 @@ static void doJoinLines()
 			result += text[i];
 	}
 
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_BEGINUNDOACTION, 0, 0);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, selStart, 0);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, selEnd, 0);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_REPLACETARGET, result.size(), (intptr_t)result.c_str());
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEL, selStart, selStart + (intptr_t)result.size());
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_ENDUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, selStart, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, selEnd, 0);
+	ScintillaBridge_sendMessage(sci, SCI_REPLACETARGET, result.size(), (intptr_t)result.c_str());
+	ScintillaBridge_sendMessage(sci, SCI_SETSEL, selStart, selStart + (intptr_t)result.size());
+	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
 }
 
 // ============================================================
@@ -2460,9 +2556,13 @@ static void saveSession()
 	[[NSFileManager defaultManager] createDirectoryAtPath:dir
 	                          withIntermediateDirectories:YES attributes:nil error:nil];
 
-	NSMutableArray* tabs = [NSMutableArray array];
-	// Save state of current editor first
+	// Save state of both editors
 	saveScintillaState();
+	if (g_isSplit && g_scintillaView2)
+		saveViewState(g_scintillaView2, g_documents2, g_activeTab2);
+
+	// Save tabs for view 0
+	NSMutableArray* tabs = [NSMutableArray array];
 	for (const auto& doc : g_documents)
 	{
 		if (doc.filePath.empty()) continue;
@@ -2478,27 +2578,31 @@ static void saveSession()
 		}];
 	}
 
+	// Save tabs for view 1
 	NSMutableArray* tabs2 = [NSMutableArray array];
-	for (const auto& doc : g_documents2)
+	if (g_isSplit)
 	{
-		if (doc.filePath.empty()) continue;
-		NSString* fp = WideToNSString(doc.filePath.c_str());
-		[tabs2 addObject:@{
-			@"filePath": fp,
-			@"cursorPos": @((long long)doc.cursorPos),
-			@"anchorPos": @((long long)doc.anchorPos),
-			@"firstVisibleLine": @((long long)doc.firstVisibleLine),
-			@"languageIndex": @(doc.languageIndex),
-			@"encoding": @(doc.encoding),
-			@"eolMode": @(doc.eolMode),
-		}];
+		for (const auto& doc : g_documents2)
+		{
+			if (doc.filePath.empty()) continue;
+			NSString* fp = WideToNSString(doc.filePath.c_str());
+			[tabs2 addObject:@{
+				@"filePath": fp,
+				@"cursorPos": @((long long)doc.cursorPos),
+				@"anchorPos": @((long long)doc.anchorPos),
+				@"firstVisibleLine": @((long long)doc.firstVisibleLine),
+				@"languageIndex": @(doc.languageIndex),
+				@"encoding": @(doc.encoding),
+				@"eolMode": @(doc.eolMode),
+			}];
+		}
 	}
 
 	NSDictionary* session = @{
 		@"version": @1,
 		@"tabs": tabs,
-		@"activeTab": @(g_activeTab),
 		@"tabs2": tabs2,
+		@"activeTab": @(g_activeTab),
 		@"activeTab2": @(g_activeTab2),
 		@"isSplit": @(g_isSplit),
 	};
@@ -2511,6 +2615,8 @@ static void saveSession()
 		[data writeToFile:path atomically:YES];
 	}
 }
+
+static void doSplit(); // forward declaration for session restore
 
 static void restoreSession()
 {
@@ -2555,17 +2661,72 @@ static void restoreSession()
 	{
 		// Remove the welcome tab if it was the first one
 		if (g_documents.size() > 1 && g_documents[0].filePath.empty() && g_documents[0].title == L"Welcome")
-			closeTab(0);
+			closeTabFromView(0, 0);
 
 		// Restore active tab
 		int savedActive = [session[@"activeTab"] intValue];
 		if (savedActive >= 0 && savedActive < static_cast<int>(g_documents.size()))
 		{
-			switchToTab(savedActive);
+			switchToTabInView(0, savedActive);
 			// Restore cursor/scroll position
 			const auto& doc = g_documents[savedActive];
 			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETFIRSTVISIBLELINE, doc.firstVisibleLine, 0);
 			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEL, doc.anchorPos, doc.cursorPos);
+		}
+
+		// Restore split view if session had one
+		bool wasSplit = [session[@"isSplit"] boolValue];
+		NSArray* tabs2 = session[@"tabs2"];
+		if (wasSplit && [tabs2 isKindOfClass:[NSArray class]] && tabs2.count > 0)
+		{
+			doSplit(); // creates right pane with a cloned tab
+			if (g_isSplit && g_scintillaView2)
+			{
+				// Clear the default cloned document and populate from session
+				g_documents2.clear();
+				while (SendMessageW(g_tabHwnd2, TCM_GETITEMCOUNT, 0, 0) > 0)
+					SendMessageW(g_tabHwnd2, TCM_DELETEITEM, 0, 0);
+
+				g_activeView = 1;
+				for (NSDictionary* tab in tabs2)
+				{
+					NSString* fp = tab[@"filePath"];
+					if (!fp || ![[NSFileManager defaultManager] fileExistsAtPath:fp]) continue;
+					openFileAtPath(fp);
+					int idx = static_cast<int>(g_documents2.size()) - 1;
+					if (idx >= 0)
+					{
+						if (tab[@"cursorPos"])
+							g_documents2[idx].cursorPos = [tab[@"cursorPos"] longLongValue];
+						if (tab[@"anchorPos"])
+							g_documents2[idx].anchorPos = [tab[@"anchorPos"] longLongValue];
+						if (tab[@"firstVisibleLine"])
+							g_documents2[idx].firstVisibleLine = [tab[@"firstVisibleLine"] longLongValue];
+						if (tab[@"languageIndex"])
+							g_documents2[idx].languageIndex = [tab[@"languageIndex"] intValue];
+						if (tab[@"encoding"])
+							g_documents2[idx].encoding = [tab[@"encoding"] intValue];
+						if (tab[@"eolMode"])
+							g_documents2[idx].eolMode = [tab[@"eolMode"] intValue];
+					}
+				}
+
+				int savedActive2 = [session[@"activeTab2"] intValue];
+				if (savedActive2 >= 0 && savedActive2 < static_cast<int>(g_documents2.size()))
+				{
+					switchToTabInView(1, savedActive2);
+					const auto& doc2 = g_documents2[savedActive2];
+					ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETFIRSTVISIBLELINE, doc2.firstVisibleLine, 0);
+					ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETSEL, doc2.anchorPos, doc2.cursorPos);
+				}
+
+				g_activeView = 0;
+			}
+		}
+		else if (wasSplit && g_documents.size() > 0)
+		{
+			// Fallback: old session format without tabs2
+			doSplit();
 		}
 	}
 }
@@ -2575,6 +2736,45 @@ static void restoreSession()
 // ============================================================
 
 static void configureScintilla(void* sci); // forward
+
+static void layoutSplitTopTabBars()
+{
+	if (!g_mainWindow || !g_tabHwnd)
+		return;
+
+	NSView* contentView = g_mainWindow.contentView;
+	if (!contentView)
+		return;
+
+	const CGFloat tabHeight = 28;
+	const CGFloat topY = contentView.bounds.size.height - tabHeight;
+
+	auto* leftTabInfo = HandleRegistry::getWindowInfo(g_tabHwnd);
+	if (leftTabInfo && leftTabInfo->nativeView)
+	{
+		NSView* leftTabView = (__bridge NSView*)leftTabInfo->nativeView;
+		if (g_isSplit && g_editorContainer)
+		{
+			leftTabView.frame = NSMakeRect(g_editorContainer.frame.origin.x, topY,
+			                               g_editorContainer.frame.size.width, tabHeight);
+		}
+		else
+		{
+			leftTabView.frame = NSMakeRect(0, topY, contentView.bounds.size.width, tabHeight);
+		}
+	}
+
+	if (g_isSplit && g_tabHwnd2 && g_editorContainer2)
+	{
+		auto* rightTabInfo = HandleRegistry::getWindowInfo(g_tabHwnd2);
+		if (rightTabInfo && rightTabInfo->nativeView)
+		{
+			NSView* rightTabView = (__bridge NSView*)rightTabInfo->nativeView;
+			rightTabView.frame = NSMakeRect(g_editorContainer2.frame.origin.x, topY,
+			                                g_editorContainer2.frame.size.width, tabHeight);
+		}
+	}
+}
 
 static void doSplit()
 {
@@ -2600,8 +2800,26 @@ static void doSplit()
 	g_editorContainer2.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 	[g_splitView addArrangedSubview:g_editorContainer2];
 
-	// Create second Scintilla view
-	g_scintillaView2 = ScintillaBridge_createView((__bridge void*)g_editorContainer2, 0, 0, 0, 0);
+	CGFloat containerHeight = rightFrame.size.height;
+	CGFloat containerWidth = rightFrame.size.width;
+
+	// Create top tab bar for right pane
+	g_tabHwnd2 = CreateWindowExW(
+		0, L"SysTabControl32", L"",
+		WS_CHILD | WS_VISIBLE | TCS_FOCUSNEVER,
+		0, 0,
+		static_cast<int>(containerWidth), 28,
+		g_mainHwnd,
+		nullptr, nullptr, nullptr
+	);
+
+	// Create sub-container for scintillaView2 (fills right pane; tab bar stays above split view)
+	g_sciContainer2 = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, containerWidth, containerHeight)];
+	g_sciContainer2.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+	[g_editorContainer2 addSubview:g_sciContainer2];
+
+	// Create second Scintilla view inside the sub-container
+	g_scintillaView2 = ScintillaBridge_createView((__bridge void*)g_sciContainer2, 0, 0, 0, 0);
 	if (g_scintillaView2)
 	{
 		configureScintilla(g_scintillaView2);
@@ -2618,7 +2836,9 @@ static void doSplit()
 						intptr_t line; int foldLevelNow; int foldLevelPrev; int margin;
 					};
 					auto* scn = reinterpret_cast<const SciNotify*>(lParam);
-					if (scn->nmhdr.code == 2010 && scn->margin == 1 && g_scintillaView2)
+					if (scn->nmhdr.code == 2028) // SCN_FOCUSIN
+						g_activeView = 1;
+					else if (scn->nmhdr.code == 2010 && scn->margin == 1 && g_scintillaView2)
 					{
 						intptr_t line = ScintillaBridge_sendMessage(g_scintillaView2, SCI_LINEFROMPOSITION, scn->position, 0);
 						intptr_t markers = ScintillaBridge_sendMessage(g_scintillaView2, SCI_MARKERGET, line, 0);
@@ -2631,22 +2851,45 @@ static void doSplit()
 			});
 	}
 
-	// Add second tab bar (not implemented for simplicity — second view shares same tab switching)
-	// Create initial document in view 2
+	// Clone the current document into the second view's own document list
+	saveScintillaState();
 	g_documents2.clear();
-	DocumentData doc2;
-	doc2.title = L"Untitled";
-	g_documents2.push_back(doc2);
-	g_activeTab2 = 0;
-	if (g_scintillaView2)
+	int srcIdx = g_activeTab >= 0 ? g_activeTab : 0;
+	if (srcIdx >= 0 && srcIdx < static_cast<int>(g_documents.size()))
 	{
-		ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETTEXT, 0, (intptr_t)"");
-		ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETSAVEPOINT, 0, 0);
-		ScintillaBridge_sendMessage(g_scintillaView2, SCI_EMPTYUNDOBUFFER, 0, 0);
+		g_documents2.push_back(g_documents[srcIdx]);
+		g_activeTab2 = 0;
+
+		// Add tab to tab bar 2
+		if (g_tabHwnd2)
+		{
+			TCITEMW tcItem = {};
+			tcItem.mask = TCIF_TEXT;
+			wchar_t titleBuf[256];
+			wcsncpy(titleBuf, g_documents[srcIdx].title.c_str(), 255);
+			titleBuf[255] = L'\0';
+			tcItem.pszText = titleBuf;
+			SendMessageW(g_tabHwnd2, TCM_INSERTITEMW, 0, reinterpret_cast<LPARAM>(&tcItem));
+			SendMessageW(g_tabHwnd2, TCM_SETCURSEL, 0, 0);
+		}
+
+		if (g_scintillaView2)
+		{
+			restoreViewToScintilla(g_scintillaView2, g_documents2, 0);
+			applyLanguageToView(g_scintillaView2, g_documents2[0].languageIndex);
+		}
 	}
 
 	[contentView addSubview:g_splitView];
+	g_splitView.delegate = (id<NSSplitViewDelegate>)g_mainWindow.delegate;
 	g_isSplit = true;
+	layoutSplitTopTabBars();
+
+	// Resize both views to fit their containers
+	ScintillaBridge_resizeToFit(g_scintillaView);
+	if (g_scintillaView2)
+		ScintillaBridge_resizeToFit(g_scintillaView2);
+
 	applyAppearance();
 }
 
@@ -2656,12 +2899,25 @@ static void doUnsplit()
 
 	NSView* contentView = g_mainWindow.contentView;
 
+	// Save right view state
+	if (g_scintillaView2)
+		saveViewState(g_scintillaView2, g_documents2, g_activeTab2);
+
 	// Remove second scintilla
 	if (g_scintillaView2)
 	{
 		ScintillaBridge_destroyView(g_scintillaView2);
 		g_scintillaView2 = nullptr;
 	}
+
+	// Destroy tab bar 2
+	if (g_tabHwnd2)
+	{
+		DestroyWindow(g_tabHwnd2);
+		g_tabHwnd2 = nullptr;
+	}
+
+	g_sciContainer2 = nil;
 
 	// Remove editor containers from split view
 	[g_editorContainer removeFromSuperview];
@@ -2688,44 +2944,77 @@ static void doUnsplit()
 	g_activeTab2 = -1;
 	g_activeView = 0;
 	g_isSplit = false;
+	layoutSplitTopTabBars();
 }
 
 static void doMoveToOtherView()
 {
 	if (!g_isSplit || !g_scintillaView || !g_scintillaView2) return;
-	if (g_activeTab < 0 || g_activeTab >= static_cast<int>(g_documents.size())) return;
 
-	saveScintillaState();
-	DocumentData doc = g_documents[g_activeTab];
+	int srcView = g_activeView;
+	int dstView = 1 - srcView;
+	auto& srcDocs = (srcView == 0) ? g_documents : g_documents2;
+	int srcTab = (srcView == 0) ? g_activeTab : g_activeTab2;
 
-	// Add to other view
-	g_documents2.push_back(doc);
-	g_activeTab2 = static_cast<int>(g_documents2.size()) - 1;
-	ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETTEXT, 0, (intptr_t)doc.content.c_str());
-	ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETFIRSTVISIBLELINE, doc.firstVisibleLine, 0);
-	ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETSEL, doc.anchorPos, doc.cursorPos);
-	if (!doc.modified)
-		ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETSAVEPOINT, 0, 0);
+	if (srcTab < 0 || srcTab >= static_cast<int>(srcDocs.size())) return;
+	if (srcDocs.size() <= 1) return; // don't move the last tab
 
-	// Remove from current view
-	closeTab(g_activeTab);
+	// Save source view state
+	void* srcSci = (srcView == 0) ? g_scintillaView : g_scintillaView2;
+	saveViewState(srcSci, srcDocs, srcTab);
+
+	// Copy document to destination
+	DocumentData docCopy = srcDocs[srcTab];
+	addNewTabToView(dstView, docCopy.title, docCopy.content, docCopy.filePath, docCopy.languageIndex);
+
+	// Copy metadata to the newly added tab
+	auto& dstDocs = (dstView == 0) ? g_documents : g_documents2;
+	int dstIdx = static_cast<int>(dstDocs.size()) - 1;
+	if (dstIdx >= 0)
+	{
+		dstDocs[dstIdx].encoding = docCopy.encoding;
+		dstDocs[dstIdx].eolMode = docCopy.eolMode;
+		dstDocs[dstIdx].cursorPos = docCopy.cursorPos;
+		dstDocs[dstIdx].anchorPos = docCopy.anchorPos;
+		dstDocs[dstIdx].firstVisibleLine = docCopy.firstVisibleLine;
+		dstDocs[dstIdx].bookmarkedLines = docCopy.bookmarkedLines;
+	}
+
+	// Remove from source view
+	closeTabFromView(srcView, srcTab);
 }
 
 static void doCloneToOtherView()
 {
 	if (!g_isSplit || !g_scintillaView || !g_scintillaView2) return;
-	if (g_activeTab < 0 || g_activeTab >= static_cast<int>(g_documents.size())) return;
 
-	saveScintillaState();
-	DocumentData doc = g_documents[g_activeTab];
+	int srcView = g_activeView;
+	int dstView = 1 - srcView;
+	auto& srcDocs = (srcView == 0) ? g_documents : g_documents2;
+	int srcTab = (srcView == 0) ? g_activeTab : g_activeTab2;
 
-	g_documents2.push_back(doc);
-	g_activeTab2 = static_cast<int>(g_documents2.size()) - 1;
-	ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETTEXT, 0, (intptr_t)doc.content.c_str());
-	ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETFIRSTVISIBLELINE, doc.firstVisibleLine, 0);
-	ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETSEL, doc.anchorPos, doc.cursorPos);
-	if (!doc.modified)
-		ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETSAVEPOINT, 0, 0);
+	if (srcTab < 0 || srcTab >= static_cast<int>(srcDocs.size())) return;
+
+	// Save source view state
+	void* srcSci = (srcView == 0) ? g_scintillaView : g_scintillaView2;
+	saveViewState(srcSci, srcDocs, srcTab);
+
+	// Copy document to destination
+	DocumentData docCopy = srcDocs[srcTab];
+	addNewTabToView(dstView, docCopy.title, docCopy.content, docCopy.filePath, docCopy.languageIndex);
+
+	// Copy metadata to the newly added tab
+	auto& dstDocs = (dstView == 0) ? g_documents : g_documents2;
+	int dstIdx = static_cast<int>(dstDocs.size()) - 1;
+	if (dstIdx >= 0)
+	{
+		dstDocs[dstIdx].encoding = docCopy.encoding;
+		dstDocs[dstIdx].eolMode = docCopy.eolMode;
+		dstDocs[dstIdx].cursorPos = docCopy.cursorPos;
+		dstDocs[dstIdx].anchorPos = docCopy.anchorPos;
+		dstDocs[dstIdx].firstVisibleLine = docCopy.firstVisibleLine;
+		dstDocs[dstIdx].bookmarkedLines = docCopy.bookmarkedLines;
+	}
 }
 
 // ============================================================
@@ -2751,8 +3040,10 @@ static LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM l
 			if (cmdId >= IDM_LANG_BASE && cmdId < IDM_LANG_BASE + g_numLanguages)
 			{
 				int langIdx = cmdId - IDM_LANG_BASE;
-				if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
-					g_documents[g_activeTab].languageIndex = langIdx;
+				auto& docs = activeDocuments();
+				int tabIdx = activeTabIndex();
+				if (tabIdx >= 0 && tabIdx < static_cast<int>(docs.size()))
+					docs[tabIdx].languageIndex = langIdx;
 				applyLanguage(langIdx);
 				return 0;
 			}
@@ -2771,86 +3062,115 @@ static LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM l
 				case IDM_FILE_SAVEAS:
 				{
 					// Force Save As by temporarily clearing the file path
-					if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+					auto& docs = activeDocuments();
+					int tabIdx = activeTabIndex();
+					if (tabIdx >= 0 && tabIdx < static_cast<int>(docs.size()))
 					{
-						std::wstring origPath = g_documents[g_activeTab].filePath;
-						g_documents[g_activeTab].filePath.clear();
+						std::wstring origPath = docs[tabIdx].filePath;
+						docs[tabIdx].filePath.clear();
 						saveCurrentFile();
 						// If user cancelled, restore original path
-						if (g_documents[g_activeTab].filePath.empty())
-							g_documents[g_activeTab].filePath = origPath;
+						if (docs[tabIdx].filePath.empty())
+							docs[tabIdx].filePath = origPath;
 					}
 					return 0;
 				}
 				case IDM_FILE_CLOSE:
-					closeTab(g_activeTab);
+					closeTabFromView(g_activeView, activeTabIndex());
 					return 0;
 				case IDM_FILE_CLOSEALL:
-					while (g_documents.size() > 1)
-						closeTab(static_cast<int>(g_documents.size()) - 1);
-					closeTab(0);
+				{
+					auto& closeDocs = activeDocuments();
+					while (closeDocs.size() > 1)
+						closeTabFromView(g_activeView, static_cast<int>(closeDocs.size()) - 1);
+					closeTabFromView(g_activeView, 0);
 					return 0;
+				}
 				case IDM_FILE_RECENT_CLEAR:
 					g_recentFiles.clear();
 					rebuildRecentMenu();
 					return 0;
 
 				case IDM_EDIT_UNDO:
-					if (g_scintillaView)
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_UNDO, 0, 0);
+				{
+					void* sci = activeScintillaView();
+					if (sci) ScintillaBridge_sendMessage(sci, SCI_UNDO, 0, 0);
 					return 0;
+				}
 				case IDM_EDIT_REDO:
-					if (g_scintillaView)
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_REDO, 0, 0);
+				{
+					void* sci = activeScintillaView();
+					if (sci) ScintillaBridge_sendMessage(sci, SCI_REDO, 0, 0);
 					return 0;
+				}
 				case IDM_EDIT_CUT:
-					if (g_scintillaView)
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_CUT, 0, 0);
+				{
+					void* sci = activeScintillaView();
+					if (sci) ScintillaBridge_sendMessage(sci, SCI_CUT, 0, 0);
 					return 0;
+				}
 				case IDM_EDIT_COPY:
-					if (g_scintillaView)
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_COPY, 0, 0);
+				{
+					void* sci = activeScintillaView();
+					if (sci) ScintillaBridge_sendMessage(sci, SCI_COPY, 0, 0);
 					return 0;
+				}
 				case IDM_EDIT_PASTE:
-					if (g_scintillaView)
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_PASTE, 0, 0);
+				{
+					void* sci = activeScintillaView();
+					if (sci) ScintillaBridge_sendMessage(sci, SCI_PASTE, 0, 0);
 					return 0;
+				}
 				case IDM_EDIT_SELECTALL:
-					if (g_scintillaView)
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_SELECTALL, 0, 0);
+				{
+					void* sci = activeScintillaView();
+					if (sci) ScintillaBridge_sendMessage(sci, SCI_SELECTALL, 0, 0);
 					return 0;
+				}
 
 				case IDM_VIEW_WORDWRAP:
-					if (g_scintillaView)
+				{
+					void* sci = activeScintillaView();
+					if (sci)
 					{
-						intptr_t mode = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETWRAPMODE, 0, 0);
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_SETWRAPMODE, mode == 0 ? 1 : 0, 0);
+						intptr_t mode = ScintillaBridge_sendMessage(sci, SCI_GETWRAPMODE, 0, 0);
+						ScintillaBridge_sendMessage(sci, SCI_SETWRAPMODE, mode == 0 ? 1 : 0, 0);
 						HMENU hMenu = GetMenu(hWnd);
 						if (hMenu)
 							CheckMenuItem(hMenu, IDM_VIEW_WORDWRAP,
 							              MF_BYCOMMAND | (mode == 0 ? MF_CHECKED : MF_UNCHECKED));
 					}
 					return 0;
+				}
 				case IDM_VIEW_LINENUMBER:
-					if (g_scintillaView)
+				{
+					g_showLineNumbers = !g_showLineNumbers;
+					// Apply to both views (global setting)
+					void* views[] = { g_scintillaView, g_scintillaView2 };
+					for (void* sci : views)
 					{
-						g_showLineNumbers = !g_showLineNumbers;
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_SETMARGINWIDTHN, 0,
-						                           g_showLineNumbers ? 50 : 0);
-						HMENU hMenu = GetMenu(hWnd);
-						if (hMenu)
-							CheckMenuItem(hMenu, IDM_VIEW_LINENUMBER,
-							              MF_BYCOMMAND | (g_showLineNumbers ? MF_CHECKED : MF_UNCHECKED));
+						if (sci)
+							ScintillaBridge_sendMessage(sci, SCI_SETMARGINWIDTHN, 0,
+							                           g_showLineNumbers ? 50 : 0);
 					}
+					HMENU hMenu = GetMenu(hWnd);
+					if (hMenu)
+						CheckMenuItem(hMenu, IDM_VIEW_LINENUMBER,
+						              MF_BYCOMMAND | (g_showLineNumbers ? MF_CHECKED : MF_UNCHECKED));
 					return 0;
+				}
 				case IDM_VIEW_FOLDALL:
-					if (g_scintillaView)
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_FOLDALL, SC_FOLDACTION_CONTRACT, 0);
+				{
+					void* sci = activeScintillaView();
+					if (sci) ScintillaBridge_sendMessage(sci, SCI_FOLDALL, SC_FOLDACTION_CONTRACT, 0);
 					return 0;
+				}
 				case IDM_VIEW_UNFOLDALL:
-					if (g_scintillaView)
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_FOLDALL, SC_FOLDACTION_EXPAND, 0);
+				{
+					void* sci = activeScintillaView();
+					if (sci) ScintillaBridge_sendMessage(sci, SCI_FOLDALL, SC_FOLDACTION_EXPAND, 0);
 					return 0;
+				}
 				case IDM_VIEW_PREFERENCES:
 					showPreferencesDlg();
 					return 0;
@@ -2896,32 +3216,44 @@ static LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM l
 
 				// Phase 7 — Edit commands
 				case IDM_EDIT_UPPERCASE:
-					if (g_scintillaView)
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_UPPERCASE, 0, 0);
+				{
+					void* sci = activeScintillaView();
+					if (sci) ScintillaBridge_sendMessage(sci, SCI_UPPERCASE, 0, 0);
 					return 0;
+				}
 				case IDM_EDIT_LOWERCASE:
-					if (g_scintillaView)
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_LOWERCASE, 0, 0);
+				{
+					void* sci = activeScintillaView();
+					if (sci) ScintillaBridge_sendMessage(sci, SCI_LOWERCASE, 0, 0);
 					return 0;
+				}
 				case IDM_EDIT_TITLECASE:
 					doTitleCase();
 					return 0;
 				case IDM_EDIT_DUP_LINE:
-					if (g_scintillaView)
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEDUPLICATE, 0, 0);
+				{
+					void* sci = activeScintillaView();
+					if (sci) ScintillaBridge_sendMessage(sci, SCI_LINEDUPLICATE, 0, 0);
 					return 0;
+				}
 				case IDM_EDIT_DEL_LINE:
-					if (g_scintillaView)
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEDELETE, 0, 0);
+				{
+					void* sci = activeScintillaView();
+					if (sci) ScintillaBridge_sendMessage(sci, SCI_LINEDELETE, 0, 0);
 					return 0;
+				}
 				case IDM_EDIT_MOVEUP:
-					if (g_scintillaView)
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_MOVESELECTEDLINESUP, 0, 0);
+				{
+					void* sci = activeScintillaView();
+					if (sci) ScintillaBridge_sendMessage(sci, SCI_MOVESELECTEDLINESUP, 0, 0);
 					return 0;
+				}
 				case IDM_EDIT_MOVEDOWN:
-					if (g_scintillaView)
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_MOVESELECTEDLINESDOWN, 0, 0);
+				{
+					void* sci = activeScintillaView();
+					if (sci) ScintillaBridge_sendMessage(sci, SCI_MOVESELECTEDLINESDOWN, 0, 0);
 					return 0;
+				}
 				case IDM_EDIT_TRIMTRAILING:
 					doTrimTrailingWhitespace();
 					return 0;
@@ -2957,32 +3289,24 @@ static LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM l
 
 				// Phase 7 — EOL conversion
 				case IDM_FORMAT_EOL_LF:
-					if (g_scintillaView && g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
-					{
-						g_documents[g_activeTab].eolMode = SC_EOL_LF;
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_SETEOLMODE, SC_EOL_LF, 0);
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_CONVERTEOLS, SC_EOL_LF, 0);
-						updateStatusBar();
-					}
-					return 0;
 				case IDM_FORMAT_EOL_CRLF:
-					if (g_scintillaView && g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
-					{
-						g_documents[g_activeTab].eolMode = SC_EOL_CRLF;
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_SETEOLMODE, SC_EOL_CRLF, 0);
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_CONVERTEOLS, SC_EOL_CRLF, 0);
-						updateStatusBar();
-					}
-					return 0;
 				case IDM_FORMAT_EOL_CR:
-					if (g_scintillaView && g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+				{
+					void* sci = activeScintillaView();
+					auto& docs = activeDocuments();
+					int tabIdx = activeTabIndex();
+					if (sci && tabIdx >= 0 && tabIdx < static_cast<int>(docs.size()))
 					{
-						g_documents[g_activeTab].eolMode = SC_EOL_CR;
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_SETEOLMODE, SC_EOL_CR, 0);
-						ScintillaBridge_sendMessage(g_scintillaView, SCI_CONVERTEOLS, SC_EOL_CR, 0);
+						int eol = SC_EOL_LF;
+						if (cmdId == IDM_FORMAT_EOL_CRLF) eol = SC_EOL_CRLF;
+						if (cmdId == IDM_FORMAT_EOL_CR)   eol = SC_EOL_CR;
+						docs[tabIdx].eolMode = eol;
+						ScintillaBridge_sendMessage(sci, SCI_SETEOLMODE, eol, 0);
+						ScintillaBridge_sendMessage(sci, SCI_CONVERTEOLS, eol, 0);
 						updateStatusBar();
 					}
 					return 0;
+				}
 
 				// Phase 7 — Encoding change
 				case IDM_FORMAT_ENC_UTF8:
@@ -2990,17 +3314,21 @@ static LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM l
 				case IDM_FORMAT_ENC_UTF16LE:
 				case IDM_FORMAT_ENC_UTF16BE:
 				case IDM_FORMAT_ENC_ANSI:
-					if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+				{
+					auto& docs = activeDocuments();
+					int tabIdx = activeTabIndex();
+					if (tabIdx >= 0 && tabIdx < static_cast<int>(docs.size()))
 					{
 						int newEnc = ENC_UTF8;
 						if (cmdId == IDM_FORMAT_ENC_UTF8BOM)  newEnc = ENC_UTF8_BOM;
 						if (cmdId == IDM_FORMAT_ENC_UTF16LE)  newEnc = ENC_UTF16_LE;
 						if (cmdId == IDM_FORMAT_ENC_UTF16BE)  newEnc = ENC_UTF16_BE;
 						if (cmdId == IDM_FORMAT_ENC_ANSI)     newEnc = ENC_ANSI;
-						g_documents[g_activeTab].encoding = newEnc;
+						docs[tabIdx].encoding = newEnc;
 						updateStatusBar();
 					}
 					return 0;
+				}
 			}
 			break;
 		}
@@ -3010,9 +3338,18 @@ static LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM l
 			NMHDR* pNmhdr = reinterpret_cast<NMHDR*>(lParam);
 			if (pNmhdr && pNmhdr->code == TCN_SELCHANGE)
 			{
-				int newSel = static_cast<int>(SendMessageW(g_tabHwnd, TCM_GETCURSEL, 0, 0));
-				if (newSel != g_activeTab && newSel >= 0)
-					switchToTab(newSel);
+				if (pNmhdr->hwndFrom == g_tabHwnd)
+				{
+					int newSel = static_cast<int>(SendMessageW(g_tabHwnd, TCM_GETCURSEL, 0, 0));
+					if (newSel != g_activeTab && newSel >= 0)
+						switchToTabInView(0, newSel);
+				}
+				else if (pNmhdr->hwndFrom == g_tabHwnd2)
+				{
+					int newSel = static_cast<int>(SendMessageW(g_tabHwnd2, TCM_GETCURSEL, 0, 0));
+					if (newSel != g_activeTab2 && newSel >= 0)
+						switchToTabInView(1, newSel);
+				}
 				return 0;
 			}
 			break;
@@ -3029,6 +3366,8 @@ static LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM l
 		case WM_SIZE:
 			if (g_scintillaView)
 				ScintillaBridge_resizeToFit(g_scintillaView);
+			if (g_isSplit && g_scintillaView2)
+				ScintillaBridge_resizeToFit(g_scintillaView2);
 			return 0;
 
 		case WM_CLOSE:
@@ -3226,16 +3565,60 @@ static void configureScintilla(void* sci)
 // Dark mode support
 // ============================================================
 
-static void applyFoldMarkerColors(bool isDark)
+static void applyFoldMarkerColorsToView(void* sci, bool isDark)
 {
-	if (!g_scintillaView) return;
+	if (!sci) return;
 	int fgColor = isDark ? 0xD4D4D4 : 0x808080;
 	int bgColor = isDark ? 0x2D2D2D : 0xF0F0F0;
 	for (int m = SC_MARKNUM_FOLDEREND; m <= SC_MARKNUM_FOLDEROPEN; ++m)
 	{
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERSETFORE, m, fgColor);
-		ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERSETBACK, m, bgColor);
+		ScintillaBridge_sendMessage(sci, SCI_MARKERSETFORE, m, fgColor);
+		ScintillaBridge_sendMessage(sci, SCI_MARKERSETBACK, m, bgColor);
 	}
+}
+
+static void applyAppearanceToView(void* sci, int langIdx, bool isDark)
+{
+	if (!sci) return;
+
+	// Set STYLE_DEFAULT colors
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETFORE, 32, isDark ? 0xD4D4D4 : 0x000000);
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETBACK, 32, isDark ? 0x1E1E1E : 0xFFFFFF);
+	ScintillaBridge_sendMessage(sci, SCI_STYLECLEARALL, 0, 0); // propagate to all
+
+	// Apply per-lexer syntax styles
+	if (langIdx >= 0 && langIdx < g_numLanguages)
+	{
+		const LexerStyles* ls = findLexerStyles(g_languages[langIdx].lexerName);
+		if (ls)
+		{
+			for (int i = 0; i < ls->numStyles; ++i)
+			{
+				const auto& s = ls->styles[i];
+				ScintillaBridge_sendMessage(sci, SCI_STYLESETFORE, s.styleId,
+					isDark ? s.darkFore : s.lightFore);
+				if (s.bold)
+					ScintillaBridge_sendMessage(sci, SCI_STYLESETBOLD, s.styleId, 1);
+				if (s.italic)
+					ScintillaBridge_sendMessage(sci, SCI_STYLESETITALIC, s.styleId, 1);
+			}
+		}
+	}
+
+	// Caret, caret line
+	ScintillaBridge_sendMessage(sci, SCI_SETCARETFORE, isDark ? 0xAEAFAD : 0x000000, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEBACK, isDark ? 0x2A2A2A : 0xF0F0F0, 0);
+
+	// Line number margin
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETFORE, 33, isDark ? 0x858585 : 0x808080);
+	ScintillaBridge_sendMessage(sci, SCI_STYLESETBACK, 33, isDark ? 0x1E1E1E : 0xF0F0F0);
+
+	// Bookmark marker
+	ScintillaBridge_sendMessage(sci, SCI_MARKERSETBACK, BOOKMARK_MARKER,
+		isDark ? 0xFFA050 : 0xFF8000);
+
+	// Fold marker colors
+	applyFoldMarkerColorsToView(sci, isDark);
 }
 
 static void applyAppearance()
@@ -3246,47 +3629,18 @@ static void applyAppearance()
 		bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
 	bool isDark = [appearanceName isEqualToString:NSAppearanceNameDarkAqua];
 
-	// Set STYLE_DEFAULT colors
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETFORE, 32, isDark ? 0xD4D4D4 : 0x000000);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETBACK, 32, isDark ? 0x1E1E1E : 0xFFFFFF);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLECLEARALL, 0, 0); // propagate to all
-
-	// Apply per-lexer syntax styles
 	int langIdx = 0;
 	if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
 		langIdx = g_documents[g_activeTab].languageIndex;
-	if (langIdx >= 0 && langIdx < g_numLanguages)
+	applyAppearanceToView(g_scintillaView, langIdx, isDark);
+
+	if (g_isSplit && g_scintillaView2)
 	{
-		const LexerStyles* ls = findLexerStyles(g_languages[langIdx].lexerName);
-		if (ls)
-		{
-			for (int i = 0; i < ls->numStyles; ++i)
-			{
-				const auto& s = ls->styles[i];
-				ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETFORE, s.styleId,
-					isDark ? s.darkFore : s.lightFore);
-				if (s.bold)
-					ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETBOLD, s.styleId, 1);
-				if (s.italic)
-					ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETITALIC, s.styleId, 1);
-			}
-		}
+		int langIdx2 = 0;
+		if (g_activeTab2 >= 0 && g_activeTab2 < static_cast<int>(g_documents2.size()))
+			langIdx2 = g_documents2[g_activeTab2].languageIndex;
+		applyAppearanceToView(g_scintillaView2, langIdx2, isDark);
 	}
-
-	// Caret, caret line
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETCARETFORE, isDark ? 0xAEAFAD : 0x000000, 0);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETCARETLINEBACK, isDark ? 0x2A2A2A : 0xF0F0F0, 0);
-
-	// Line number margin
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETFORE, 33, isDark ? 0x858585 : 0x808080);
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETBACK, 33, isDark ? 0x1E1E1E : 0xF0F0F0);
-
-	// Bookmark marker
-	ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERSETBACK, BOOKMARK_MARKER,
-		isDark ? 0xFFA050 : 0xFF8000);
-
-	// Fold marker colors
-	applyFoldMarkerColors(isDark);
 }
 
 // ============================================================
@@ -3330,7 +3684,7 @@ static void applyAppearance()
 
 @end
 
-@interface NppPhase7Delegate : NSObject <NSApplicationDelegate, NSWindowDelegate>
+@interface NppPhase7Delegate : NSObject <NSApplicationDelegate, NSWindowDelegate, NSSplitViewDelegate>
 - (void)performContextAction:(NSMenuItem*)sender;
 @end
 
@@ -3493,7 +3847,9 @@ static void applyAppearance()
 				};
 				auto* scn = reinterpret_cast<const SciNotify*>(lParam);
 
-				if (scn->nmhdr.code == 2010) // SCN_MARGINCLICK
+				if (scn->nmhdr.code == 2028) // SCN_FOCUSIN
+					g_activeView = 0;
+				else if (scn->nmhdr.code == 2010) // SCN_MARGINCLICK
 				{
 					if (scn->margin == 1 && g_scintillaView) // Bookmark margin
 					{
@@ -3637,6 +3993,8 @@ static void applyAppearance()
 		applyAppearance();
 		if (g_scintillaView)
 			ScintillaBridge_sendMessage(g_scintillaView, SCI_COLOURISE, 0, -1);
+		if (g_isSplit && g_scintillaView2)
+			ScintillaBridge_sendMessage(g_scintillaView2, SCI_COLOURISE, 0, -1);
 	});
 }
 
@@ -3696,17 +4054,12 @@ static void applyAppearance()
 	if (g_isSplit && g_scintillaView2)
 		ScintillaBridge_resizeToFit(g_scintillaView2);
 
-	if (g_tabHwnd && g_mainWindow)
-	{
-		auto* tabInfo = HandleRegistry::getWindowInfo(g_tabHwnd);
-		if (tabInfo && tabInfo->nativeView)
-		{
-			NSView* tabView = (__bridge NSView*)tabInfo->nativeView;
-			NSRect f = tabView.frame;
-			f.size.width = g_mainWindow.contentView.bounds.size.width;
-			tabView.frame = f;
-		}
-	}
+	layoutSplitTopTabBars();
+}
+
+- (void)splitViewDidResizeSubviews:(NSNotification*)notification
+{
+	layoutSplitTopTabBars();
 }
 
 @end

--- a/macos/platform/main_phase7.mm
+++ b/macos/platform/main_phase7.mm
@@ -1,0 +1,3731 @@
+// Notepad++ macOS Port — Phase 7 Entry Point
+// Settings persistence, split view, edit commands, session management,
+// drag-and-drop, encoding support.
+//
+// Builds on Phase 6: Syntax highlighting, code folding, regex search,
+// bookmarks, auto-completion, preferences, language selection.
+
+#import <Cocoa/Cocoa.h>
+#include <set>
+#include <algorithm>
+#include <sstream>
+#include "settings_manager.h"
+#include "uchardet.h"
+#include "windows.h"
+#include "commctrl.h"
+#include "commdlg.h"
+#include "handle_registry.h"
+#include "scintilla_bridge.h"
+#include "file_monitor_mac.h"
+#include "ILexer.h"
+#include "Lexilla.h"
+
+// ============================================================
+// Command IDs (matching Notepad++ IDM_* convention)
+// ============================================================
+#define IDM_FILE_NEW          41001
+#define IDM_FILE_OPEN         41002
+#define IDM_FILE_SAVE         41006
+#define IDM_FILE_SAVEAS       41008
+#define IDM_FILE_CLOSE        41003
+#define IDM_FILE_CLOSEALL     41004
+#define IDM_EDIT_UNDO         42001
+#define IDM_EDIT_REDO         42002
+#define IDM_EDIT_CUT          42003
+#define IDM_EDIT_COPY         42004
+#define IDM_EDIT_PASTE        42005
+#define IDM_EDIT_SELECTALL    42013
+#define IDM_VIEW_WORDWRAP     42026
+#define IDM_VIEW_LINENUMBER   42027
+#define IDM_SEARCH_FIND       43001
+#define IDM_SEARCH_REPLACE    43003
+#define IDM_SEARCH_FINDNEXT   43004
+#define IDM_SEARCH_FINDPREV   43005
+#define IDM_SEARCH_GOTOLINE   43009
+
+// Phase 6 command IDs
+#define IDM_SEARCH_BOOKMARK_TOGGLE   43010
+#define IDM_SEARCH_BOOKMARK_NEXT     43011
+#define IDM_SEARCH_BOOKMARK_PREV     43012
+#define IDM_SEARCH_BOOKMARK_CLEARALL 43013
+#define IDM_EDIT_AUTOCOMPLETE        42030
+#define IDM_FILE_RECENT_BASE         41100  // 41100..41109 for 10 recent files
+#define IDM_FILE_RECENT_CLEAR        41110
+#define IDM_VIEW_PREFERENCES         42050
+#define IDM_VIEW_FOLDALL             42060
+#define IDM_VIEW_UNFOLDALL           42061
+#define IDM_LANG_BASE                44000  // Base for language menu items
+
+// Phase 7 command IDs — Edit commands
+#define IDM_EDIT_UPPERCASE           42031
+#define IDM_EDIT_LOWERCASE           42032
+#define IDM_EDIT_TITLECASE           42033
+#define IDM_EDIT_DUP_LINE            42034
+#define IDM_EDIT_DEL_LINE            42035
+#define IDM_EDIT_MOVEUP              42036
+#define IDM_EDIT_MOVEDOWN            42037
+#define IDM_EDIT_TRIMTRAILING        42038
+#define IDM_EDIT_REMOVEEMPTY         42039
+#define IDM_EDIT_TOGGLECOMMENT       42040
+#define IDM_EDIT_SORTASC             42041
+#define IDM_EDIT_SORTDESC            42042
+#define IDM_EDIT_JOINLINES           42043
+
+// Phase 7 — View commands
+#define IDM_VIEW_SPLIT               42070
+#define IDM_VIEW_UNSPLIT             42071
+#define IDM_VIEW_MOVETOOTHER         42072
+#define IDM_VIEW_CLONETOOTHER        42073
+
+// Phase 7 — Format/Encoding commands
+#define IDM_FORMAT_EOL_LF            45001
+#define IDM_FORMAT_EOL_CRLF          45002
+#define IDM_FORMAT_EOL_CR            45003
+#define IDM_FORMAT_ENC_UTF8          45010
+#define IDM_FORMAT_ENC_UTF8BOM       45011
+#define IDM_FORMAT_ENC_UTF16LE       45012
+#define IDM_FORMAT_ENC_UTF16BE       45013
+#define IDM_FORMAT_ENC_ANSI          45014
+
+// Control IDs
+#define IDC_TABBAR       1001
+#define IDC_STATUSBAR    1002
+
+// Find/Replace dialog control IDs
+#define IDC_FIND_EDIT        2001
+#define IDC_REPLACE_EDIT     2002
+#define IDC_FIND_NEXT        2003
+#define IDC_FIND_PREV        2004
+#define IDC_FIND_COUNT       2005
+#define IDC_REPLACE_ONE      2006
+#define IDC_REPLACE_ALL      2007
+#define IDC_FIND_CLOSE       2008
+#define IDC_MATCH_CASE       2009
+#define IDC_WHOLE_WORD       2010
+#define IDC_FIND_LABEL       2011
+#define IDC_REPLACE_LABEL    2012
+#define IDC_FIND_STATUS      2013
+#define IDC_USE_REGEX        2014
+
+// Timer ID
+#define IDT_STATUSBAR    5001
+
+// ============================================================
+// SCI message IDs
+// ============================================================
+enum {
+	SCI_CLEARALL = 2004,
+	SCI_SETSAVEPOINT = 2014,
+	SCI_GETLENGTH = 2006,
+	SCI_GOTOPOS = 2025,
+	SCI_GOTOLINE = 2024,
+	SCI_GETCURRENTPOS = 2008,
+	SCI_LINEFROMPOSITION = 2166,
+	SCI_GETCOLUMN = 2129,
+	SCI_GETLINECOUNT = 2154,
+	SCI_SETTABWIDTH = 2036,
+	SCI_GETTABWIDTH = 2121,
+	SCI_SETCODEPAGE = 2037,
+	SCI_STYLECLEARALL = 2050,
+	SCI_STYLESETFORE = 2051,
+	SCI_STYLESETBOLD = 2053,
+	SCI_STYLESETSIZE = 2055,
+	SCI_STYLESETFONT = 2056,
+	SCI_STYLESETBACK = 2052,
+	SCI_GETMODIFY = 2159,
+	SCI_EMPTYUNDOBUFFER = 2175,
+	SCI_SETTEXT = 2181,
+	SCI_GETTEXT = 2182,
+	SCI_GETTEXTLENGTH = 2183,
+	SCI_SETMARGINTYPEN = 2240,
+	SCI_SETMARGINWIDTHN = 2242,
+	SCI_SETMARGINMASKN = 2244,
+	SCI_SETMARGINSENSITIVEN = 2246,
+	SCI_SETWRAPMODE = 2268,
+	SCI_GETWRAPMODE = 2269,
+	SCI_SETCARETLINEVISIBLE = 2096,
+	SCI_SETCARETLINEBACK = 2098,
+	SCI_SETUSETABS = 2124,
+	SCI_SETCARETFORE = 2069,
+	SCI_SETPROPERTY = 4004,
+	SCI_SETKEYWORDS = 4005,
+	SCI_SETILEXER = 4033,
+	SCI_COLOURISE = 4003,
+	SCI_STYLESETITALIC = 2054,
+	SCI_TOGGLEFOLD = 2231,
+	SCI_FOLDALL = 2662,
+	SCI_GETFOLDLEVEL = 2223,
+	SCI_SETFOLDFLAGS = 2233,
+	SCI_SETAUTOMATICFOLD = 2663,
+	SCI_SETFIRSTVISIBLELINE = 2613,
+	SCI_GETFIRSTVISIBLELINE = 2152,
+	SCI_SETSEL = 2160,
+	SCI_GETSELTEXT = 2161,
+	SCI_GETANCHOR = 2009,
+	SCI_SCROLLCARET = 2169,
+	SCI_GETSELECTIONSTART = 2143,
+	SCI_GETSELECTIONEND = 2145,
+	SCI_SETTARGETSTART = 2190,
+	SCI_GETTARGETSTART = 2191,
+	SCI_SETTARGETEND = 2192,
+	SCI_GETTARGETEND = 2193,
+	SCI_REPLACETARGET = 2194,
+	SCI_SEARCHINTARGET = 2197,
+	SCI_SETSEARCHFLAGS = 2198,
+
+	// Bookmark / marker messages
+	SCI_MARKERADD = 2043,
+	SCI_MARKERDELETE = 2044,
+	SCI_MARKERGET = 2046,
+	SCI_MARKERNEXT = 2047,
+	SCI_MARKERPREVIOUS = 2048,
+	SCI_MARKERDELETEALL = 2045,
+	SCI_MARKERDEFINE = 2040,
+	SCI_MARKERSETFORE = 2041,
+	SCI_MARKERSETBACK = 2042,
+
+	// Auto-complete messages
+	SCI_AUTOCSHOW = 2100,
+	SCI_AUTOCCANCEL = 2101,
+	SCI_AUTOCACTIVE = 2102,
+	SCI_AUTOCSETIGNORECASE = 2115,
+	SCI_AUTOCSETORDER = 2660,
+	SCI_WORDSTARTPOSITION = 2266,
+	SCI_GETCHARAT = 2007,
+	SCI_GETCURLINE = 2027,
+	SCI_POSITIONFROMLINE = 2167,
+
+	// Edit operations
+	SCI_UNDO = 2176,
+	SCI_REDO = 2011,
+	SCI_CUT = 2177,
+	SCI_COPY = 2178,
+	SCI_PASTE = 2179,
+	SCI_SELECTALL = 2013,
+
+	// Style
+	SCI_STYLEGETFONT = 2486,
+	SCI_STYLEGETSIZE = 2485,
+
+	// Phase 7 — Edit operations
+	SCI_UPPERCASE = 2341,
+	SCI_LOWERCASE = 2340,
+	SCI_LINEDUPLICATE = 2404,
+	SCI_LINEDELETE = 2338,
+	SCI_MOVESELECTEDLINESUP = 2620,
+	SCI_MOVESELECTEDLINESDOWN = 2621,
+	SCI_REPLACESEL = 2170,
+	SCI_BEGINUNDOACTION = 2078,
+	SCI_ENDUNDOACTION = 2079,
+	SCI_GETLINEENDPOSITION = 2136,
+	SCI_DELETERANGE = 2645,
+	SCI_GETLINE = 2153,
+	SCI_GETLINESELSTARTPOSITION = 2424,
+	SCI_GETLINESELENDPOSITION = 2425,
+	SCI_LINELENGTH = 2350,
+
+	// Phase 7 — EOL
+	SCI_SETEOLMODE = 2031,
+	SCI_GETEOLMODE = 2030,
+	SCI_CONVERTEOLS = 2029,
+};
+
+// Scintilla search flags
+#define SCFIND_MATCHCASE  4
+#define SCFIND_WHOLEWORD  2
+#define SCFIND_REGEXP     0x00200000
+#define SCFIND_POSIX      0x00400000
+#define SCFIND_CXX11REGEX 0x00800000
+
+// Bookmark marker
+#define BOOKMARK_MARKER  24
+#define BOOKMARK_MASK    (1 << BOOKMARK_MARKER)
+
+// Scintilla marker shapes
+#define SC_MARK_CIRCLE      0
+#define SC_MARK_ROUNDRECT   1
+#define SC_MARK_ARROW       2
+#define SC_MARK_SMALLRECT   3
+#define SC_MARK_SHORTARROW  4
+#define SC_MARK_FULLRECT   26
+#define SC_MARK_BOOKMARK   31
+#define SC_MARK_BOXPLUS          12
+#define SC_MARK_BOXMINUS         14
+#define SC_MARK_VLINE            9
+#define SC_MARK_LCORNER          10
+#define SC_MARK_BOXPLUSCONNECTED  13
+#define SC_MARK_BOXMINUSCONNECTED 15
+#define SC_MARK_TCORNER          11
+
+// Fold margin constants
+#define SC_MARKNUM_FOLDEREND      25
+#define SC_MARKNUM_FOLDEROPENMID  26
+#define SC_MARKNUM_FOLDERMIDTAIL  27
+#define SC_MARKNUM_FOLDERTAIL     28
+#define SC_MARKNUM_FOLDERSUB      29
+#define SC_MARKNUM_FOLDER         30
+#define SC_MARKNUM_FOLDEROPEN     31
+#define SC_MASK_FOLDERS           0xFE000000
+#define SC_FOLDACTION_CONTRACT    0
+#define SC_FOLDACTION_EXPAND      1
+#define SC_FOLDACTION_TOGGLE      2
+#define SC_FOLDLEVELHEADERFLAG    0x2000
+#define SC_AUTOMATICFOLD_CLICK    0x0004
+
+// ============================================================
+// Per-lexer syntax style definitions
+// ============================================================
+
+struct StyleDef
+{
+	int styleId;
+	int lightFore;  // BGR color
+	int darkFore;   // BGR color
+	bool bold;
+	bool italic;
+};
+
+struct LexerStyles
+{
+	const char* lexerName;
+	const StyleDef* styles;
+	int numStyles;
+};
+
+// C/C++ lexer styles (SCE_C_*)
+static const StyleDef s_cppStyles[] = {
+	{1,  0x008000, 0x6A9955, false, false},  // COMMENT
+	{2,  0x008000, 0x6A9955, false, false},  // COMMENTLINE
+	{3,  0x008000, 0x6A9955, false, true},   // COMMENTDOC
+	{4,  0x008080, 0xB5CEA8, false, false},  // NUMBER
+	{5,  0xFF0000, 0x569CD6, true,  false},  // WORD (keywords)
+	{6,  0x800080, 0xCE9178, false, false},  // STRING
+	{7,  0x800080, 0xCE9178, false, false},  // CHARACTER
+	{9,  0x808080, 0xC586C0, false, false},  // PREPROCESSOR
+	{10, 0x000000, 0xD4D4D4, false, false},  // OPERATOR
+	{16, 0x990000, 0x4EC9B0, false, false},  // WORD2 (types)
+};
+
+// Objective-C uses same style IDs as C++
+static const StyleDef s_objcStyles[] = {
+	{1,  0x008000, 0x6A9955, false, false},
+	{2,  0x008000, 0x6A9955, false, false},
+	{3,  0x008000, 0x6A9955, false, true},
+	{4,  0x008080, 0xB5CEA8, false, false},
+	{5,  0xFF0000, 0x569CD6, true,  false},
+	{6,  0x800080, 0xCE9178, false, false},
+	{7,  0x800080, 0xCE9178, false, false},
+	{9,  0x808080, 0xC586C0, false, false},
+	{10, 0x000000, 0xD4D4D4, false, false},
+	{16, 0x990000, 0x4EC9B0, false, false},
+};
+
+// Python lexer styles (SCE_P_*)
+static const StyleDef s_pythonStyles[] = {
+	{1,  0x008000, 0x6A9955, false, false},  // COMMENTLINE
+	{2,  0x008080, 0xB5CEA8, false, false},  // NUMBER
+	{3,  0x800080, 0xCE9178, false, false},  // STRING
+	{4,  0x800080, 0xCE9178, false, false},  // CHARACTER
+	{5,  0xFF0000, 0x569CD6, true,  false},  // WORD
+	{6,  0x800080, 0xCE9178, false, false},  // TRIPLE
+	{7,  0x800080, 0xCE9178, false, false},  // TRIPLEDOUBLE
+	{8,  0x990000, 0x4EC9B0, false, false},  // CLASSNAME
+	{9,  0x880000, 0xDCDCAA, false, false},  // DEFNAME
+	{10, 0x000000, 0xD4D4D4, false, false},  // OPERATOR
+	{14, 0x990000, 0x4EC9B0, false, false},  // WORD2 (builtins)
+	{15, 0xCC6600, 0xDCDCAA, false, true},   // DECORATOR
+};
+
+// HTML/Hypertext lexer styles (SCE_H_*)
+static const StyleDef s_htmlStyles[] = {
+	{1,  0x800000, 0x569CD6, true,  false},  // TAG
+	{2,  0x800000, 0x569CD6, false, false},  // TAGUNKNOWN
+	{3,  0xFF0000, 0x9CDCFE, false, false},  // ATTRIBUTE
+	{5,  0x008080, 0xB5CEA8, false, false},  // NUMBER
+	{6,  0x800080, 0xCE9178, false, false},  // DOUBLESTRING
+	{7,  0x800080, 0xCE9178, false, false},  // SINGLESTRING
+	{9,  0x008000, 0x6A9955, false, false},  // COMMENT
+};
+
+// CSS lexer styles (SCE_CSS_*)
+static const StyleDef s_cssStyles[] = {
+	{1,  0x800000, 0x569CD6, true,  false},  // TAG
+	{2,  0x990000, 0xD7BA7D, false, false},  // CLASS
+	{4,  0x990000, 0xD7BA7D, false, false},  // ID
+	{5,  0x000000, 0xD4D4D4, false, false},  // OPERATOR
+	{7,  0x008080, 0xCE9178, false, false},  // VALUE
+	{9,  0x008000, 0x6A9955, false, false},  // COMMENT
+	{13, 0xFF0000, 0x569CD6, true,  false},  // DIRECTIVE
+};
+
+// JSON lexer styles (SCE_JSON_*)
+static const StyleDef s_jsonStyles[] = {
+	{1,  0x008080, 0xB5CEA8, false, false},  // NUMBER
+	{2,  0x800080, 0xCE9178, false, false},  // STRING
+	{4,  0x990000, 0x9CDCFE, false, false},  // PROPERTYNAME
+	{8,  0xFF0000, 0x569CD6, true,  false},  // KEYWORD (true/false/null)
+	{9,  0x008080, 0xB5CEA8, false, false},  // LDKEYWORD
+	{5,  0x000000, 0xD4D4D4, false, false},  // ESCAPESEQUENCE
+};
+
+// SQL lexer styles (SCE_SQL_*)
+static const StyleDef s_sqlStyles[] = {
+	{1,  0x008000, 0x6A9955, false, false},  // COMMENT
+	{2,  0x008000, 0x6A9955, false, false},  // COMMENTLINE
+	{4,  0x008080, 0xB5CEA8, false, false},  // NUMBER
+	{5,  0xFF0000, 0x569CD6, true,  false},  // WORD (keywords)
+	{6,  0x800080, 0xCE9178, false, false},  // STRING
+	{7,  0x000000, 0xD4D4D4, false, false},  // OPERATOR
+	{8,  0x990000, 0x4EC9B0, false, false},  // WORD2 (types)
+};
+
+// Bash/Shell lexer styles (SCE_SH_*)
+static const StyleDef s_bashStyles[] = {
+	{2,  0x008000, 0x6A9955, false, false},  // COMMENTLINE
+	{3,  0x008080, 0xB5CEA8, false, false},  // NUMBER
+	{4,  0xFF0000, 0x569CD6, true,  false},  // WORD (keywords)
+	{5,  0x800080, 0xCE9178, false, false},  // STRING (double-quoted)
+	{6,  0x800080, 0xCE9178, false, false},  // STRING (single-quoted)
+	{7,  0x000000, 0xD4D4D4, false, false},  // OPERATOR
+	{8,  0x990000, 0x9CDCFE, false, false},  // SCALAR ($var)
+	{9,  0xCC6600, 0xDCDCAA, false, false},  // PARAM
+};
+
+// Rust lexer styles (SCE_RUST_*)
+static const StyleDef s_rustStyles[] = {
+	{1,  0x008000, 0x6A9955, false, false},  // COMMENTBLOCK
+	{2,  0x008000, 0x6A9955, false, false},  // COMMENTLINE
+	{3,  0x008000, 0x6A9955, false, true},   // COMMENTBLOCKDOC
+	{4,  0x008000, 0x6A9955, false, true},   // COMMENTLINEDOC
+	{5,  0xFF0000, 0x569CD6, true,  false},  // WORD (keywords)
+	{6,  0x800080, 0xCE9178, false, false},  // STRING
+	{8,  0x008080, 0xB5CEA8, false, false},  // NUMBER
+	{10, 0x000000, 0xD4D4D4, false, false},  // OPERATOR
+	{12, 0x800080, 0xCE9178, false, false},  // BYTESTRING
+	{14, 0x990000, 0x4EC9B0, false, false},  // WORD2 (types)
+	{16, 0xCC6600, 0xDCDCAA, false, false},  // LIFETIME
+};
+
+// Markdown lexer styles (SCE_MARKDOWN_*)
+static const StyleDef s_markdownStyles[] = {
+	{4,  0x000000, 0xD4D4D4, true,  false},  // STRONG1
+	{5,  0x000000, 0xD4D4D4, true,  false},  // STRONG2
+	{6,  0x000000, 0xD4D4D4, false, true},   // EM1
+	{7,  0x000000, 0xD4D4D4, false, true},   // EM2
+	{8,  0x800000, 0x569CD6, true,  false},  // HEADER1
+	{9,  0x800000, 0x569CD6, true,  false},  // HEADER2
+	{10, 0x800000, 0x569CD6, true,  false},  // HEADER3
+	{11, 0x800000, 0x569CD6, true,  false},  // HEADER4
+	{12, 0x800000, 0x569CD6, true,  false},  // HEADER5
+	{19, 0x808080, 0xCE9178, false, false},  // CODE
+	{20, 0x808080, 0xCE9178, false, false},  // CODE2
+	{21, 0x0000FF, 0x569CD6, false, false},  // LINK
+};
+
+// XML lexer styles (same IDs as HTML/SCE_H_*)
+static const StyleDef s_xmlStyles[] = {
+	{1,  0x800000, 0x569CD6, true,  false},  // TAG
+	{3,  0xFF0000, 0x9CDCFE, false, false},  // ATTRIBUTE
+	{5,  0x008080, 0xB5CEA8, false, false},  // NUMBER
+	{6,  0x800080, 0xCE9178, false, false},  // DOUBLESTRING
+	{7,  0x800080, 0xCE9178, false, false},  // SINGLESTRING
+	{9,  0x008000, 0x6A9955, false, false},  // COMMENT
+};
+
+// Lookup table
+static const LexerStyles s_allLexerStyles[] = {
+	{"cpp",        s_cppStyles,      sizeof(s_cppStyles) / sizeof(s_cppStyles[0])},
+	{"objc",       s_objcStyles,     sizeof(s_objcStyles) / sizeof(s_objcStyles[0])},
+	{"python",     s_pythonStyles,   sizeof(s_pythonStyles) / sizeof(s_pythonStyles[0])},
+	{"hypertext",  s_htmlStyles,     sizeof(s_htmlStyles) / sizeof(s_htmlStyles[0])},
+	{"css",        s_cssStyles,      sizeof(s_cssStyles) / sizeof(s_cssStyles[0])},
+	{"json",       s_jsonStyles,     sizeof(s_jsonStyles) / sizeof(s_jsonStyles[0])},
+	{"sql",        s_sqlStyles,      sizeof(s_sqlStyles) / sizeof(s_sqlStyles[0])},
+	{"bash",       s_bashStyles,     sizeof(s_bashStyles) / sizeof(s_bashStyles[0])},
+	{"rust",       s_rustStyles,     sizeof(s_rustStyles) / sizeof(s_rustStyles[0])},
+	{"markdown",   s_markdownStyles, sizeof(s_markdownStyles) / sizeof(s_markdownStyles[0])},
+	{"xml",        s_xmlStyles,      sizeof(s_xmlStyles) / sizeof(s_xmlStyles[0])},
+};
+
+static const LexerStyles* findLexerStyles(const char* lexerName)
+{
+	if (!lexerName) return nullptr;
+	for (const auto& ls : s_allLexerStyles)
+	{
+		if (strcmp(ls.lexerName, lexerName) == 0)
+			return &ls;
+	}
+	return nullptr;
+}
+
+// ============================================================
+// Language definition
+// ============================================================
+struct LangDef
+{
+	const char* name;          // Display name
+	const char* lexerName;     // Scintilla lexer name
+	const char* keywords;      // Primary keywords (set 0)
+	const char* keywords2;     // Secondary keywords (set 1) - types, builtins
+	int menuId;                // Menu command ID
+};
+
+static const LangDef g_languages[] = {
+	{"Normal Text", "null", "", "", IDM_LANG_BASE + 0},
+	{"C", "cpp",
+	 "auto break case char const continue default do double else enum extern float for goto "
+	 "if int long register return short signed sizeof static struct switch typedef union "
+	 "unsigned void volatile while",
+	 "int long double float char void short unsigned signed size_t ptrdiff_t bool "
+	 "int8_t int16_t int32_t int64_t uint8_t uint16_t uint32_t uint64_t FILE",
+	 IDM_LANG_BASE + 1},
+	{"C++", "cpp",
+	 "alignas alignof and and_eq asm auto bitand bitor bool break case catch char char8_t "
+	 "char16_t char32_t class compl concept const consteval constexpr constinit const_cast "
+	 "continue co_await co_return co_yield decltype default delete do double dynamic_cast "
+	 "else enum explicit export extern false float for friend goto if import inline int long "
+	 "module mutable namespace new noexcept not not_eq nullptr operator or or_eq private "
+	 "protected public register reinterpret_cast requires return short signed sizeof static "
+	 "static_assert static_cast struct switch template this thread_local throw true try "
+	 "typedef typeid typename union unsigned using virtual void volatile wchar_t while xor xor_eq "
+	 "override final include define ifdef ifndef endif pragma",
+	 "string wstring vector map set unordered_map unordered_set list deque array "
+	 "unique_ptr shared_ptr weak_ptr optional variant any tuple pair size_t "
+	 "int8_t int16_t int32_t int64_t uint8_t uint16_t uint32_t uint64_t ptrdiff_t",
+	 IDM_LANG_BASE + 2},
+	{"Java", "cpp",
+	 "abstract assert boolean break byte case catch char class const continue default do double "
+	 "else enum extends final finally float for goto if implements import instanceof int "
+	 "interface long native new package private protected public return short static strictfp "
+	 "super switch synchronized this throw throws transient try void volatile while",
+	 "String Integer Long Double Float Boolean Byte Short Character Object Class "
+	 "List ArrayList Map HashMap Set HashSet Array Collections Arrays",
+	 IDM_LANG_BASE + 3},
+	{"Python", "python",
+	 "False None True and as assert async await break class continue def del elif else except "
+	 "finally for from global if import in is lambda nonlocal not or pass raise return try "
+	 "while with yield",
+	 "print len range list dict str int float bool type input open isinstance issubclass "
+	 "hasattr getattr setattr delattr callable super object enumerate zip map filter sorted "
+	 "reversed min max sum abs any all dir vars repr format id hash iter next",
+	 IDM_LANG_BASE + 4},
+	{"JavaScript", "cpp",
+	 "abstract arguments async await boolean break byte case catch char class const continue "
+	 "debugger default delete do double else enum eval export extends false final finally float "
+	 "for from function goto if implements import in instanceof int interface let long native "
+	 "new null of package private protected public return short static super switch synchronized "
+	 "this throw throws transient true try typeof undefined var void volatile while with yield",
+	 "console document window Math Array Object Promise Map Set WeakMap WeakSet JSON "
+	 "Date RegExp Error TypeError RangeError Symbol Proxy Reflect Number String Boolean",
+	 IDM_LANG_BASE + 5},
+	{"HTML", "hypertext",
+	 "a abbr address area article aside audio b base bdi bdo blockquote body br button canvas "
+	 "caption cite code col colgroup data datalist dd del details dfn dialog div dl dt em embed "
+	 "fieldset figcaption figure footer form h1 h2 h3 h4 h5 h6 head header hr html i iframe "
+	 "img input ins kbd label legend li link main map mark meta meter nav noscript object ol "
+	 "optgroup option output p param picture pre progress q rp rt ruby s samp script section "
+	 "select small source span strong style sub summary sup table tbody td template textarea "
+	 "tfoot th thead time title tr track u ul var video wbr",
+	 "",
+	 IDM_LANG_BASE + 6},
+	{"CSS", "css",
+	 "color background font margin padding border width height display position top left right "
+	 "bottom float clear overflow visibility z-index text-align text-decoration line-height "
+	 "font-size font-weight font-family content cursor opacity flex grid transition transform "
+	 "animation box-shadow border-radius min-width max-width min-height max-height",
+	 "",
+	 IDM_LANG_BASE + 7},
+	{"XML", "xml",
+	 "",
+	 "",
+	 IDM_LANG_BASE + 8},
+	{"JSON", "json",
+	 "true false null",
+	 "",
+	 IDM_LANG_BASE + 9},
+	{"Markdown", "markdown",
+	 "",
+	 "",
+	 IDM_LANG_BASE + 10},
+	{"SQL", "sql",
+	 "select from where insert into values update set delete create table alter drop index "
+	 "join inner outer left right on and or not null is in between like as order by group "
+	 "having count sum avg min max distinct union all exists case when then else end primary "
+	 "key foreign references constraint default check unique grant revoke",
+	 "integer varchar text boolean date timestamp numeric decimal char real serial "
+	 "bigint smallint float double blob clob nvarchar nchar",
+	 IDM_LANG_BASE + 11},
+	{"Shell", "bash",
+	 "if then else elif fi case esac for while until do done in function select time coproc "
+	 "echo printf read declare local export readonly typeset shift exit return break continue "
+	 "eval exec source test true false",
+	 "",
+	 IDM_LANG_BASE + 12},
+	{"Rust", "rust",
+	 "as async await break const continue crate dyn else enum extern false fn for if impl "
+	 "in let loop match mod move mut pub ref return self Self static struct super trait true "
+	 "type unsafe use where while",
+	 "i8 i16 i32 i64 i128 isize u8 u16 u32 u64 u128 usize f32 f64 bool char "
+	 "String Vec Box Rc Arc Option Result Some None Ok Err HashMap HashSet",
+	 IDM_LANG_BASE + 13},
+	{"Go", "cpp",
+	 "break case chan const continue default defer else fallthrough for func go goto if import "
+	 "interface map package range return select struct switch type var true false nil",
+	 "int int8 int16 int32 int64 uint uint8 uint16 uint32 uint64 uintptr "
+	 "float32 float64 complex64 complex128 byte rune string bool error",
+	 IDM_LANG_BASE + 14},
+	{"Objective-C", "objc",
+	 "auto break case char const continue default do double else enum extern float for goto "
+	 "if int long register return short signed sizeof static struct switch typedef union "
+	 "unsigned void volatile while id self super nil Nil YES NO "
+	 "@interface @implementation @end @protocol @class @selector @property @synthesize "
+	 "@dynamic @try @catch @finally @throw @autoreleasepool @encode @synchronized "
+	 "instancetype nullable nonnull",
+	 "NSObject NSString NSArray NSDictionary NSMutableArray NSMutableDictionary NSNumber "
+	 "NSData NSDate NSURL NSError NSSet NSMutableSet NSInteger NSUInteger CGFloat BOOL",
+	 IDM_LANG_BASE + 15},
+	{"Swift", "cpp",
+	 "actor any associatedtype async await break case catch class continue convenience default "
+	 "defer deinit do else enum extension fallthrough false fileprivate final for func get "
+	 "guard if import in indirect infix init inout internal is lazy let mutating nil nonisolated "
+	 "nonmutating open operator optional override postfix precedencegroup prefix private protocol "
+	 "public repeat required rethrows return self Self set some static struct subscript super "
+	 "switch Task throw throws true try typealias unowned var weak where while",
+	 "Int Double Float String Bool Character Array Dictionary Set Optional Result "
+	 "Any AnyObject Void Never Error Codable Equatable Hashable Comparable",
+	 IDM_LANG_BASE + 16},
+};
+static const int g_numLanguages = sizeof(g_languages) / sizeof(g_languages[0]);
+
+// ============================================================
+// Document data — per-tab state
+// ============================================================
+
+// Encoding constants
+enum DocEncoding
+{
+	ENC_UTF8 = 0,
+	ENC_UTF8_BOM = 1,
+	ENC_UTF16_LE = 2,
+	ENC_UTF16_BE = 3,
+	ENC_ANSI = 4,
+};
+
+static const char* encodingName(int enc)
+{
+	switch (enc)
+	{
+		case ENC_UTF8:     return "UTF-8";
+		case ENC_UTF8_BOM: return "UTF-8 BOM";
+		case ENC_UTF16_LE: return "UTF-16 LE";
+		case ENC_UTF16_BE: return "UTF-16 BE";
+		case ENC_ANSI:     return "ANSI";
+		default:           return "UTF-8";
+	}
+}
+
+// EOL mode constants matching Scintilla
+#define SC_EOL_CRLF 0
+#define SC_EOL_CR   1
+#define SC_EOL_LF   2
+
+static const char* eolName(int mode)
+{
+	switch (mode)
+	{
+		case SC_EOL_CRLF: return "CRLF";
+		case SC_EOL_CR:   return "CR";
+		case SC_EOL_LF:   return "LF";
+		default:          return "LF";
+	}
+}
+
+struct DocumentData
+{
+	std::wstring filePath;
+	std::wstring title = L"Untitled";
+	std::string content;
+	intptr_t cursorPos = 0;
+	intptr_t anchorPos = 0;
+	intptr_t firstVisibleLine = 0;
+	bool modified = false;
+	int languageIndex = 2; // Default: C++
+	std::vector<int> bookmarkedLines; // Persisted across tab switches
+	int encoding = ENC_UTF8;
+	int eolMode = SC_EOL_LF;
+};
+
+// ============================================================
+// Globals
+// ============================================================
+static void* g_scintillaView = nullptr;
+static NSWindow* g_mainWindow = nil;
+static HWND g_mainHwnd = nullptr;
+static HWND g_tabHwnd = nullptr;
+static HWND g_statusBarHwnd = nullptr;
+static std::vector<DocumentData> g_documents;
+static int g_activeTab = -1;
+static FileMonitorMac* g_fileMonitor = nullptr;
+
+// Find/Replace state
+static HWND g_findDlgHwnd = nullptr;
+static std::wstring g_findText;
+static std::wstring g_replaceText;
+static bool g_matchCase = false;
+static bool g_wholeWord = false;
+static bool g_useRegex = false;
+static bool g_findMode = true; // true = Find, false = Replace
+
+// Recent files
+static const int MAX_RECENT_FILES = 10;
+static std::vector<std::wstring> g_recentFiles;
+static HMENU g_recentMenu = nullptr;
+
+// Preferences state
+static int g_fontSize = 13;
+static int g_tabWidth = 4;
+static std::string g_fontName = "Menlo";
+static bool g_showLineNumbers = true;
+
+// Split view state
+static void* g_scintillaView2 = nullptr;
+static NSSplitView* g_splitView = nil;
+static bool g_isSplit = false;
+static int g_activeView = 0; // 0=main, 1=sub
+static std::vector<DocumentData> g_documents2;
+static int g_activeTab2 = -1;
+static HWND g_tabHwnd2 = nullptr;
+static NSView* g_editorContainer = nil;
+static NSView* g_editorContainer2 = nil;
+
+// Accessor helpers for split view
+static void*& activeScintillaView() { return g_activeView == 0 ? g_scintillaView : g_scintillaView2; }
+static std::vector<DocumentData>& activeDocuments() { return g_activeView == 0 ? g_documents : g_documents2; }
+static int& activeTabIndex() { return g_activeView == 0 ? g_activeTab : g_activeTab2; }
+static HWND& activeTabHwnd() { return g_activeView == 0 ? g_tabHwnd : g_tabHwnd2; }
+
+// ============================================================
+// Helper: Convert wchar_t* to NSString
+// ============================================================
+static NSString* WideToNSString(const wchar_t* wstr)
+{
+	if (!wstr) return @"";
+	size_t len = wcslen(wstr);
+	NSString* str = [[NSString alloc] initWithBytes:wstr
+	                                         length:len * sizeof(wchar_t)
+	                                       encoding:NSUTF32LittleEndianStringEncoding];
+	return str ?: @"";
+}
+
+static std::wstring NSStringToWide(NSString* str)
+{
+	if (!str) return L"";
+	NSData* data = [str dataUsingEncoding:NSUTF32LittleEndianStringEncoding];
+	if (!data || data.length == 0) return L"";
+	return std::wstring(reinterpret_cast<const wchar_t*>(data.bytes),
+	                    data.length / sizeof(wchar_t));
+}
+
+// ============================================================
+// Scintilla state save/restore
+// ============================================================
+static void saveScintillaState()
+{
+	if (g_activeTab < 0 || g_activeTab >= static_cast<int>(g_documents.size()))
+		return;
+	if (!g_scintillaView) return;
+
+	auto& doc = g_documents[g_activeTab];
+	intptr_t len = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXTLENGTH, 0, 0);
+	if (len >= 0)
+	{
+		doc.content.resize(len + 1);
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXT, len + 1,
+		                            (intptr_t)doc.content.data());
+		doc.content.resize(len);
+	}
+	doc.cursorPos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCURRENTPOS, 0, 0);
+	doc.anchorPos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETANCHOR, 0, 0);
+	doc.firstVisibleLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETFIRSTVISIBLELINE, 0, 0);
+	doc.modified = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETMODIFY, 0, 0) != 0;
+
+	// Save bookmarked lines
+	doc.bookmarkedLines.clear();
+	intptr_t lineCount = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINECOUNT, 0, 0);
+	intptr_t line = 0;
+	while (line < lineCount)
+	{
+		line = ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERNEXT, line, BOOKMARK_MASK);
+		if (line < 0) break;
+		doc.bookmarkedLines.push_back(static_cast<int>(line));
+		++line;
+	}
+}
+
+static void restoreScintillaState(int tabIndex)
+{
+	if (tabIndex < 0 || tabIndex >= static_cast<int>(g_documents.size()))
+		return;
+	if (!g_scintillaView) return;
+
+	const auto& doc = g_documents[tabIndex];
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTEXT, 0, (intptr_t)doc.content.c_str());
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETFIRSTVISIBLELINE, doc.firstVisibleLine, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEL, doc.anchorPos, doc.cursorPos);
+	if (!doc.modified)
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSAVEPOINT, 0, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_EMPTYUNDOBUFFER, 0, 0);
+
+	// Restore bookmarks
+	for (int bkLine : doc.bookmarkedLines)
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERADD, bkLine, BOOKMARK_MARKER);
+}
+
+// ============================================================
+// Language / lexer switching
+// ============================================================
+static void applyLanguage(int langIndex);
+
+// Forward declarations
+static void applyAppearance();
+
+// ============================================================
+// Tab management
+// ============================================================
+static void switchToTab(int tabIndex)
+{
+	if (tabIndex < 0 || tabIndex >= static_cast<int>(g_documents.size()))
+		return;
+	if (tabIndex == g_activeTab)
+		return;
+
+	saveScintillaState();
+	g_activeTab = tabIndex;
+	SendMessageW(g_tabHwnd, TCM_SETCURSEL, tabIndex, 0);
+	restoreScintillaState(tabIndex);
+	applyLanguage(g_documents[tabIndex].languageIndex);
+
+	const auto& doc = g_documents[tabIndex];
+	NSString* title = WideToNSString(doc.title.c_str());
+	[g_mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@", title]];
+}
+
+static int addNewTab(const std::wstring& title, const std::string& content,
+                      const std::wstring& filePath = L"", int langIndex = 2)
+{
+	saveScintillaState();
+
+	DocumentData doc;
+	doc.title = title;
+	doc.content = content;
+	doc.filePath = filePath;
+	doc.languageIndex = langIndex;
+	g_documents.push_back(doc);
+
+	int newIndex = static_cast<int>(g_documents.size()) - 1;
+
+	TCITEMW tcItem = {};
+	tcItem.mask = TCIF_TEXT;
+	wchar_t titleBuf[256];
+	wcsncpy(titleBuf, title.c_str(), 255);
+	titleBuf[255] = L'\0';
+	tcItem.pszText = titleBuf;
+	SendMessageW(g_tabHwnd, TCM_INSERTITEMW, newIndex, reinterpret_cast<LPARAM>(&tcItem));
+
+	g_activeTab = newIndex;
+	SendMessageW(g_tabHwnd, TCM_SETCURSEL, newIndex, 0);
+
+	if (g_scintillaView)
+	{
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTEXT, 0, (intptr_t)content.c_str());
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_GOTOPOS, 0, 0);
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_EMPTYUNDOBUFFER, 0, 0);
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSAVEPOINT, 0, 0);
+	}
+
+	applyLanguage(langIndex);
+
+	NSString* nsTitle = WideToNSString(title.c_str());
+	[g_mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@", nsTitle]];
+
+	return newIndex;
+}
+
+static void closeTab(int tabIndex)
+{
+	if (tabIndex < 0 || tabIndex >= static_cast<int>(g_documents.size()))
+		return;
+
+	if (g_documents.size() <= 1)
+	{
+		g_documents[0] = DocumentData();
+		if (g_scintillaView)
+		{
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_CLEARALL, 0, 0);
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_EMPTYUNDOBUFFER, 0, 0);
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSAVEPOINT, 0, 0);
+		}
+		TCITEMW tcItem = {};
+		tcItem.mask = TCIF_TEXT;
+		wchar_t title[] = L"Untitled";
+		tcItem.pszText = title;
+		SendMessageW(g_tabHwnd, TCM_SETITEMW, 0, reinterpret_cast<LPARAM>(&tcItem));
+		[g_mainWindow setTitle:@"Notepad++ — Untitled"];
+		return;
+	}
+
+	SendMessageW(g_tabHwnd, TCM_DELETEITEM, tabIndex, 0);
+	g_documents.erase(g_documents.begin() + tabIndex);
+
+	if (tabIndex < g_activeTab)
+		--g_activeTab;
+	else if (tabIndex == g_activeTab)
+	{
+		if (g_activeTab >= static_cast<int>(g_documents.size()))
+			g_activeTab = static_cast<int>(g_documents.size()) - 1;
+	}
+
+	SendMessageW(g_tabHwnd, TCM_SETCURSEL, g_activeTab, 0);
+	restoreScintillaState(g_activeTab);
+
+	const auto& doc = g_documents[g_activeTab];
+	NSString* title = WideToNSString(doc.title.c_str());
+	[g_mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@", title]];
+}
+
+// ============================================================
+// Status bar
+// ============================================================
+static void updateStatusBar()
+{
+	if (!g_scintillaView || !g_statusBarHwnd) return;
+
+	intptr_t pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCURRENTPOS, 0, 0);
+	intptr_t line = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, pos, 0);
+	intptr_t col = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCOLUMN, pos, 0);
+	intptr_t lineCount = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINECOUNT, 0, 0);
+	intptr_t docLen = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLENGTH, 0, 0);
+
+	wchar_t buf[128];
+	swprintf(buf, 128, L"Ln %ld, Col %ld", (long)(line + 1), (long)(col + 1));
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 0, reinterpret_cast<LPARAM>(buf));
+
+	swprintf(buf, 128, L"%ld lines, %ld bytes", (long)lineCount, (long)docLen);
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 1, reinterpret_cast<LPARAM>(buf));
+
+	// Show language name
+	const char* langName = "Normal Text";
+	if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+	{
+		int langIdx = g_documents[g_activeTab].languageIndex;
+		if (langIdx >= 0 && langIdx < g_numLanguages)
+			langName = g_languages[langIdx].name;
+	}
+	NSString* nsLang = [NSString stringWithUTF8String:langName];
+	std::wstring wLang = NSStringToWide(nsLang);
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 2, reinterpret_cast<LPARAM>(wLang.c_str()));
+
+	// Encoding
+	const char* encName = "UTF-8";
+	if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+		encName = encodingName(g_documents[g_activeTab].encoding);
+	NSString* nsEnc = [NSString stringWithUTF8String:encName];
+	std::wstring wEnc = NSStringToWide(nsEnc);
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 3, reinterpret_cast<LPARAM>(wEnc.c_str()));
+
+	// EOL mode
+	const char* eolN = "LF";
+	if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+		eolN = eolName(g_documents[g_activeTab].eolMode);
+	NSString* nsEol = [NSString stringWithUTF8String:eolN];
+	std::wstring wEol = NSStringToWide(nsEol);
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 4, reinterpret_cast<LPARAM>(wEol.c_str()));
+
+	swprintf(buf, 128, L"Doc %d/%d", g_activeTab + 1, (int)g_documents.size());
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 5, reinterpret_cast<LPARAM>(buf));
+}
+
+// ============================================================
+// Recent files management
+// ============================================================
+static void addRecentFile(const std::wstring& path)
+{
+	// Remove if already in list
+	auto it = std::find(g_recentFiles.begin(), g_recentFiles.end(), path);
+	if (it != g_recentFiles.end())
+		g_recentFiles.erase(it);
+
+	// Add to front
+	g_recentFiles.insert(g_recentFiles.begin(), path);
+
+	// Trim to max
+	if (static_cast<int>(g_recentFiles.size()) > MAX_RECENT_FILES)
+		g_recentFiles.resize(MAX_RECENT_FILES);
+}
+
+static void rebuildRecentMenu()
+{
+	if (!g_recentMenu) return;
+
+	// Remove all items from the recent menu
+	// We use the Win32 API: delete items from position 0 repeatedly
+	int itemCount = GetMenuItemCount(g_recentMenu);
+	for (int i = itemCount - 1; i >= 0; --i)
+		DeleteMenu(g_recentMenu, i, MF_BYPOSITION);
+
+	if (g_recentFiles.empty())
+	{
+		AppendMenuW(g_recentMenu, MF_STRING | MF_GRAYED, 0, L"(No recent files)");
+		return;
+	}
+
+	for (int i = 0; i < static_cast<int>(g_recentFiles.size()); ++i)
+	{
+		// Show just the filename with a number prefix
+		std::wstring display = g_recentFiles[i];
+		size_t lastSlash = display.rfind(L'/');
+		if (lastSlash != std::wstring::npos)
+			display = display.substr(lastSlash + 1);
+
+		wchar_t label[300];
+		swprintf(label, 300, L"&%d %ls", i + 1, display.c_str());
+		AppendMenuW(g_recentMenu, MF_STRING, IDM_FILE_RECENT_BASE + i, label);
+	}
+
+	AppendMenuW(g_recentMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(g_recentMenu, MF_STRING, IDM_FILE_RECENT_CLEAR, L"Clear Recent Files List");
+}
+
+// ============================================================
+// Find/Replace operations using Scintilla
+// ============================================================
+
+static void updateFindStatus(const wchar_t* msg)
+{
+	if (g_findDlgHwnd)
+		SetDlgItemTextW(g_findDlgHwnd, IDC_FIND_STATUS, msg);
+}
+
+static int buildSearchFlags()
+{
+	int flags = 0;
+	if (g_matchCase) flags |= SCFIND_MATCHCASE;
+	if (g_wholeWord) flags |= SCFIND_WHOLEWORD;
+	if (g_useRegex)  flags |= SCFIND_REGEXP | SCFIND_CXX11REGEX;
+	return flags;
+}
+
+static bool doFindNext(bool forward)
+{
+	if (!g_scintillaView || g_findText.empty()) return false;
+
+	NSString* nsFind = WideToNSString(g_findText.c_str());
+	const char* utf8Find = [nsFind UTF8String];
+
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEARCHFLAGS, buildSearchFlags(), 0);
+
+	intptr_t docLen = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLENGTH, 0, 0);
+
+	if (forward)
+	{
+		intptr_t selEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONEND, 0, 0);
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, selEnd, 0);
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, docLen, 0);
+	}
+	else
+	{
+		intptr_t selStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONSTART, 0, 0);
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, selStart, 0);
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, 0, 0);
+	}
+
+	intptr_t pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_SEARCHINTARGET,
+	                                            strlen(utf8Find), (intptr_t)utf8Find);
+	if (pos >= 0)
+	{
+		intptr_t targetEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTARGETEND, 0, 0);
+		// Advance past zero-length matches to avoid infinite Find Next loop
+		if (targetEnd == pos && pos < docLen)
+			targetEnd = pos + 1;
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEL, pos, targetEnd);
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SCROLLCARET, 0, 0);
+		updateFindStatus(L"Match found");
+		return true;
+	}
+	else
+	{
+		// Wrap around
+		if (forward)
+		{
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, 0, 0);
+			intptr_t selEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONEND, 0, 0);
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, selEnd, 0);
+		}
+		else
+		{
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, docLen, 0);
+			intptr_t selStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONSTART, 0, 0);
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, selStart, 0);
+		}
+
+		pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_SEARCHINTARGET,
+		                                  strlen(utf8Find), (intptr_t)utf8Find);
+		if (pos >= 0)
+		{
+			intptr_t targetEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTARGETEND, 0, 0);
+			if (targetEnd == pos && pos < docLen)
+				targetEnd = pos + 1;
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEL, pos, targetEnd);
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SCROLLCARET, 0, 0);
+			updateFindStatus(L"Wrapped around");
+			return true;
+		}
+	}
+
+	if (g_useRegex)
+		updateFindStatus(L"Not found (check regex syntax)");
+	else
+		updateFindStatus(L"Not found");
+	return false;
+}
+
+static int doCount()
+{
+	if (!g_scintillaView || g_findText.empty()) return 0;
+
+	NSString* nsFind = WideToNSString(g_findText.c_str());
+	const char* utf8Find = [nsFind UTF8String];
+
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEARCHFLAGS, buildSearchFlags(), 0);
+
+	intptr_t docLen = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLENGTH, 0, 0);
+	int count = 0;
+	intptr_t searchStart = 0;
+	size_t findLen = strlen(utf8Find);
+
+	while (searchStart < docLen)
+	{
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, searchStart, 0);
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, docLen, 0);
+		intptr_t pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_SEARCHINTARGET,
+		                                            findLen, (intptr_t)utf8Find);
+		if (pos < 0) break;
+		++count;
+		intptr_t targetEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTARGETEND, 0, 0);
+		if (targetEnd <= pos)
+		{
+			// Zero-length match: advance by 1 to continue counting
+			if (pos < docLen)
+			{
+				searchStart = pos + 1;
+				continue;
+			}
+			break;
+		}
+		searchStart = targetEnd;
+	}
+
+	wchar_t buf[64];
+	swprintf(buf, 64, L"%d matches found", count);
+	updateFindStatus(buf);
+	return count;
+}
+
+static void doReplaceOne()
+{
+	if (!g_scintillaView) return;
+
+	intptr_t selStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONSTART, 0, 0);
+	intptr_t selEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONEND, 0, 0);
+
+	if (selStart == selEnd)
+	{
+		doFindNext(true);
+		return;
+	}
+
+	NSString* nsReplace = WideToNSString(g_replaceText.c_str());
+	const char* utf8Replace = [nsReplace UTF8String];
+
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, selStart, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, selEnd, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_REPLACETARGET,
+	                            strlen(utf8Replace), (intptr_t)utf8Replace);
+
+	doFindNext(true);
+	updateFindStatus(L"Replaced 1 occurrence");
+}
+
+static void doReplaceAll()
+{
+	if (!g_scintillaView || g_findText.empty()) return;
+
+	NSString* nsFind = WideToNSString(g_findText.c_str());
+	NSString* nsReplace = WideToNSString(g_replaceText.c_str());
+	const char* utf8Find = [nsFind UTF8String];
+	const char* utf8Replace = [nsReplace UTF8String];
+
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEARCHFLAGS, buildSearchFlags(), 0);
+
+	intptr_t docLen = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLENGTH, 0, 0);
+	int count = 0;
+	intptr_t searchStart = 0;
+	size_t findLen = strlen(utf8Find);
+	size_t replaceLen = strlen(utf8Replace);
+
+	while (searchStart < docLen)
+	{
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, searchStart, 0);
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, docLen, 0);
+		intptr_t pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_SEARCHINTARGET,
+		                                            findLen, (intptr_t)utf8Find);
+		if (pos < 0) break;
+
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_REPLACETARGET,
+		                            replaceLen, (intptr_t)utf8Replace);
+		++count;
+
+		searchStart = pos + static_cast<intptr_t>(replaceLen);
+		docLen = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLENGTH, 0, 0);
+		// Safety for zero-length replacements: advance at least 1
+		if (searchStart <= pos)
+		{
+			if (searchStart < docLen)
+				++searchStart;
+			else
+				break;
+		}
+	}
+
+	wchar_t buf[64];
+	swprintf(buf, 64, L"Replaced %d occurrences", count);
+	updateFindStatus(buf);
+}
+
+// ============================================================
+// Find/Replace dialog
+// ============================================================
+
+static void readFindDlgState()
+{
+	if (!g_findDlgHwnd) return;
+
+	wchar_t buf[1024];
+	GetDlgItemTextW(g_findDlgHwnd, IDC_FIND_EDIT, buf, 1024);
+	g_findText = buf;
+
+	GetDlgItemTextW(g_findDlgHwnd, IDC_REPLACE_EDIT, buf, 1024);
+	g_replaceText = buf;
+
+	g_matchCase = (IsDlgButtonChecked(g_findDlgHwnd, IDC_MATCH_CASE) == BST_CHECKED);
+	g_wholeWord = (IsDlgButtonChecked(g_findDlgHwnd, IDC_WHOLE_WORD) == BST_CHECKED);
+	g_useRegex  = (IsDlgButtonChecked(g_findDlgHwnd, IDC_USE_REGEX) == BST_CHECKED);
+}
+
+static void createFindReplaceDlg(bool replaceMode)
+{
+	g_findMode = !replaceMode;
+
+	// If dialog already exists, just show/update it
+	if (g_findDlgHwnd)
+	{
+		auto* info = HandleRegistry::getWindowInfo(g_findDlgHwnd);
+		if (info && info->nativeWindow)
+		{
+			NSWindow* win = (__bridge NSWindow*)info->nativeWindow;
+
+			int dlgHeight = replaceMode ? 270 : 210;
+			NSRect contentRect = [win contentRectForFrameRect:win.frame];
+			CGFloat heightDiff = dlgHeight - contentRect.size.height;
+			NSRect newFrame = win.frame;
+			newFrame.origin.y -= heightDiff;
+			newFrame.size.height += heightDiff;
+			[win setFrame:newFrame display:YES];
+
+			int dlgWidth = 450;
+			int cbY = replaceMode ? 75 : 45;
+			int regexY = replaceMode ? 100 : 70;
+			int btnY = replaceMode ? 135 : 100;
+			int rBtnY = 170;
+			int statusY = replaceMode ? 240 : 150;
+			int btnW = 90;
+			int btnH = 28;
+			int btnGap = 8;
+
+			MoveWindow(GetDlgItem(g_findDlgHwnd, IDC_FIND_LABEL), 15, 15, 80, 20, TRUE);
+			MoveWindow(GetDlgItem(g_findDlgHwnd, IDC_FIND_EDIT), 100, 12, 230, 24, TRUE);
+
+			MoveWindow(GetDlgItem(g_findDlgHwnd, IDC_REPLACE_LABEL), 15, 45, 80, 20, TRUE);
+			MoveWindow(GetDlgItem(g_findDlgHwnd, IDC_REPLACE_EDIT), 100, 42, 230, 24, TRUE);
+
+			MoveWindow(GetDlgItem(g_findDlgHwnd, IDC_MATCH_CASE), 15, cbY, 120, 20, TRUE);
+			MoveWindow(GetDlgItem(g_findDlgHwnd, IDC_WHOLE_WORD), 145, cbY, 120, 20, TRUE);
+			MoveWindow(GetDlgItem(g_findDlgHwnd, IDC_USE_REGEX), 15, regexY, 160, 20, TRUE);
+
+			MoveWindow(GetDlgItem(g_findDlgHwnd, IDC_FIND_NEXT), 15, btnY, btnW, btnH, TRUE);
+			MoveWindow(GetDlgItem(g_findDlgHwnd, IDC_FIND_PREV), 15 + btnW + btnGap, btnY, btnW, btnH, TRUE);
+			MoveWindow(GetDlgItem(g_findDlgHwnd, IDC_FIND_COUNT), 15 + 2 * (btnW + btnGap), btnY, 70, btnH, TRUE);
+			MoveWindow(GetDlgItem(g_findDlgHwnd, IDC_FIND_CLOSE), dlgWidth - 85, btnY, 70, btnH, TRUE);
+
+			MoveWindow(GetDlgItem(g_findDlgHwnd, IDC_REPLACE_ONE), 15, rBtnY, btnW, btnH, TRUE);
+			MoveWindow(GetDlgItem(g_findDlgHwnd, IDC_REPLACE_ALL), 15 + btnW + btnGap, rBtnY, btnW + 10, btnH, TRUE);
+
+			MoveWindow(GetDlgItem(g_findDlgHwnd, IDC_FIND_STATUS), 15, statusY, dlgWidth - 30, 20, TRUE);
+
+			ShowWindow(GetDlgItem(g_findDlgHwnd, IDC_REPLACE_EDIT), replaceMode ? SW_SHOW : SW_HIDE);
+			ShowWindow(GetDlgItem(g_findDlgHwnd, IDC_REPLACE_LABEL), replaceMode ? SW_SHOW : SW_HIDE);
+			ShowWindow(GetDlgItem(g_findDlgHwnd, IDC_REPLACE_ONE), replaceMode ? SW_SHOW : SW_HIDE);
+			ShowWindow(GetDlgItem(g_findDlgHwnd, IDC_REPLACE_ALL), replaceMode ? SW_SHOW : SW_HIDE);
+
+			[win setTitle:replaceMode ? @"Replace" : @"Find"];
+			[win makeKeyAndOrderFront:nil];
+		}
+		return;
+	}
+
+	int dlgWidth = 450;
+	int dlgHeight = replaceMode ? 270 : 210;
+
+	NSUInteger styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable;
+	NSRect contentRect = NSMakeRect(0, 0, dlgWidth, dlgHeight);
+	NSPanel* panel = [[NSPanel alloc] initWithContentRect:contentRect
+	                                    styleMask:styleMask
+	                                    backing:NSBackingStoreBuffered
+	                                    defer:NO];
+	[panel setTitle:replaceMode ? @"Replace" : @"Find"];
+	[panel setReleasedWhenClosed:NO];
+	[panel setFloatingPanel:YES];
+	[panel setBecomesKeyOnlyIfNeeded:YES];
+
+	if (g_mainWindow)
+	{
+		NSRect mainFrame = g_mainWindow.frame;
+		CGFloat x = mainFrame.origin.x + (mainFrame.size.width - dlgWidth) / 2;
+		CGFloat y = mainFrame.origin.y + (mainFrame.size.height - dlgHeight) / 2;
+		[panel setFrameOrigin:NSMakePoint(x, y)];
+	}
+	else
+	{
+		[panel center];
+	}
+
+	HandleRegistry::WindowInfo dlgInfo;
+	dlgInfo.className = L"#32770";
+	dlgInfo.windowName = replaceMode ? L"Replace" : L"Find";
+	dlgInfo.style = WS_POPUP | WS_CAPTION;
+	dlgInfo.parent = g_mainHwnd;
+	dlgInfo.nativeWindow = (__bridge void*)panel;
+	dlgInfo.nativeView = (__bridge void*)[panel contentView];
+
+	g_findDlgHwnd = HandleRegistry::createWindow(dlgInfo);
+
+	// "Find:" label
+	CreateWindowExW(0, L"Static", L"Find:",
+		WS_CHILD | WS_VISIBLE | SS_LEFT,
+		15, 15, 80, 20,
+		g_findDlgHwnd, reinterpret_cast<HMENU>(IDC_FIND_LABEL), nullptr, nullptr);
+
+	// Find text field
+	CreateWindowExW(0, L"Edit", L"",
+		WS_CHILD | WS_VISIBLE | ES_AUTOHSCROLL,
+		100, 12, 230, 24,
+		g_findDlgHwnd, reinterpret_cast<HMENU>(IDC_FIND_EDIT), nullptr, nullptr);
+
+	// "Replace:" label
+	CreateWindowExW(0, L"Static", L"Replace:",
+		WS_CHILD | (replaceMode ? WS_VISIBLE : 0) | SS_LEFT,
+		15, 45, 80, 20,
+		g_findDlgHwnd, reinterpret_cast<HMENU>(IDC_REPLACE_LABEL), nullptr, nullptr);
+
+	// Replace text field
+	CreateWindowExW(0, L"Edit", L"",
+		WS_CHILD | (replaceMode ? WS_VISIBLE : 0) | ES_AUTOHSCROLL,
+		100, 42, 230, 24,
+		g_findDlgHwnd, reinterpret_cast<HMENU>(IDC_REPLACE_EDIT), nullptr, nullptr);
+
+	// Checkboxes
+	int cbY = replaceMode ? 75 : 45;
+	CreateWindowExW(0, L"Button", L"Match case",
+		WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX,
+		15, cbY, 120, 20,
+		g_findDlgHwnd, reinterpret_cast<HMENU>(IDC_MATCH_CASE), nullptr, nullptr);
+
+	CreateWindowExW(0, L"Button", L"Whole word",
+		WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX,
+		145, cbY, 120, 20,
+		g_findDlgHwnd, reinterpret_cast<HMENU>(IDC_WHOLE_WORD), nullptr, nullptr);
+
+	// Regex checkbox (new in Phase 6)
+	int regexY = replaceMode ? 100 : 70;
+	CreateWindowExW(0, L"Button", L"Regular expression",
+		WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX,
+		15, regexY, 160, 20,
+		g_findDlgHwnd, reinterpret_cast<HMENU>(IDC_USE_REGEX), nullptr, nullptr);
+
+	// Buttons row
+	int btnY = replaceMode ? 135 : 100;
+	int btnW = 90;
+	int btnH = 28;
+	int btnGap = 8;
+
+	CreateWindowExW(0, L"Button", L"Find Next",
+		WS_CHILD | WS_VISIBLE | BS_DEFPUSHBUTTON,
+		15, btnY, btnW, btnH,
+		g_findDlgHwnd, reinterpret_cast<HMENU>(IDC_FIND_NEXT), nullptr, nullptr);
+
+	CreateWindowExW(0, L"Button", L"Find Prev",
+		WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON,
+		15 + btnW + btnGap, btnY, btnW, btnH,
+		g_findDlgHwnd, reinterpret_cast<HMENU>(IDC_FIND_PREV), nullptr, nullptr);
+
+	CreateWindowExW(0, L"Button", L"Count",
+		WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON,
+		15 + 2 * (btnW + btnGap), btnY, 70, btnH,
+		g_findDlgHwnd, reinterpret_cast<HMENU>(IDC_FIND_COUNT), nullptr, nullptr);
+
+	CreateWindowExW(0, L"Button", L"Close",
+		WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON,
+		dlgWidth - 85, btnY, 70, btnH,
+		g_findDlgHwnd, reinterpret_cast<HMENU>(IDC_FIND_CLOSE), nullptr, nullptr);
+
+	// Replace buttons row
+	int rBtnY = 170;
+	CreateWindowExW(0, L"Button", L"Replace",
+		WS_CHILD | (replaceMode ? WS_VISIBLE : 0) | BS_PUSHBUTTON,
+		15, rBtnY, btnW, btnH,
+		g_findDlgHwnd, reinterpret_cast<HMENU>(IDC_REPLACE_ONE), nullptr, nullptr);
+
+	CreateWindowExW(0, L"Button", L"Replace All",
+		WS_CHILD | (replaceMode ? WS_VISIBLE : 0) | BS_PUSHBUTTON,
+		15 + btnW + btnGap, rBtnY, btnW + 10, btnH,
+		g_findDlgHwnd, reinterpret_cast<HMENU>(IDC_REPLACE_ALL), nullptr, nullptr);
+
+	// Status label at bottom
+	int statusY = replaceMode ? 240 : 150;
+	CreateWindowExW(0, L"Static", L"",
+		WS_CHILD | WS_VISIBLE | SS_LEFT,
+		15, statusY, dlgWidth - 30, 20,
+		g_findDlgHwnd, reinterpret_cast<HMENU>(IDC_FIND_STATUS), nullptr, nullptr);
+
+	auto* findDlgInfo = HandleRegistry::getWindowInfo(g_findDlgHwnd);
+	if (findDlgInfo)
+	{
+		findDlgInfo->wndProc = [](HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) -> LRESULT {
+			if (msg == WM_COMMAND)
+			{
+				UINT cmdId = LOWORD(wParam);
+				UINT notif = HIWORD(wParam);
+
+				if (notif == BN_CLICKED)
+				{
+					switch (cmdId)
+					{
+						case IDC_FIND_NEXT:
+							readFindDlgState();
+							doFindNext(true);
+							return 0;
+						case IDC_FIND_PREV:
+							readFindDlgState();
+							doFindNext(false);
+							return 0;
+						case IDC_FIND_COUNT:
+							readFindDlgState();
+							doCount();
+							return 0;
+						case IDC_REPLACE_ONE:
+							readFindDlgState();
+							doReplaceOne();
+							return 0;
+						case IDC_REPLACE_ALL:
+							readFindDlgState();
+							doReplaceAll();
+							return 0;
+						case IDC_FIND_CLOSE:
+						{
+							auto* info = HandleRegistry::getWindowInfo(hWnd);
+							if (info && info->nativeWindow)
+							{
+								NSWindow* win = (__bridge NSWindow*)info->nativeWindow;
+								[win orderOut:nil];
+							}
+							return 0;
+						}
+					}
+				}
+			}
+			return DefWindowProcW(hWnd, msg, wParam, lParam);
+		};
+	}
+
+	// Pre-fill find text from current selection
+	if (g_scintillaView)
+	{
+		intptr_t selStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONSTART, 0, 0);
+		intptr_t selEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONEND, 0, 0);
+		if (selEnd > selStart && (selEnd - selStart) < 256)
+		{
+			char utf8Buf[512] = {};
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELTEXT, 0, (intptr_t)utf8Buf);
+			NSString* sel = [NSString stringWithUTF8String:utf8Buf];
+			if (sel.length > 0)
+			{
+				NSData* data = [sel dataUsingEncoding:NSUTF32LittleEndianStringEncoding];
+				if (data && data.length > 0)
+				{
+					std::wstring wsel(reinterpret_cast<const wchar_t*>(data.bytes),
+					                  data.length / sizeof(wchar_t));
+					SetDlgItemTextW(g_findDlgHwnd, IDC_FIND_EDIT, wsel.c_str());
+				}
+			}
+		}
+	}
+
+	[panel makeKeyAndOrderFront:nil];
+}
+
+// ============================================================
+// Go To Line dialog (modal)
+// ============================================================
+
+static void showGoToLineDlg()
+{
+	if (!g_scintillaView) return;
+
+	intptr_t lineCount = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINECOUNT, 0, 0);
+	intptr_t curPos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCURRENTPOS, 0, 0);
+	intptr_t curLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, curPos, 0);
+
+	@autoreleasepool {
+		NSAlert* alert = [[NSAlert alloc] init];
+		[alert setMessageText:@"Go To Line"];
+		[alert setInformativeText:[NSString stringWithFormat:
+			@"Enter line number (1-%ld). Current line: %ld",
+			(long)lineCount, (long)(curLine + 1)]];
+		[alert addButtonWithTitle:@"Go"];
+		[alert addButtonWithTitle:@"Cancel"];
+
+		NSTextField* input = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 200, 24)];
+		input.stringValue = [NSString stringWithFormat:@"%ld", (long)(curLine + 1)];
+		[alert setAccessoryView:input];
+		[alert.window setInitialFirstResponder:input];
+
+		NSModalResponse response = [alert runModal];
+		if (response == NSAlertFirstButtonReturn)
+		{
+			int lineNum = input.intValue;
+			if (lineNum > 0 && lineNum <= static_cast<int>(lineCount))
+			{
+				ScintillaBridge_sendMessage(g_scintillaView, SCI_GOTOLINE, lineNum - 1, 0);
+				ScintillaBridge_sendMessage(g_scintillaView, SCI_SCROLLCARET, 0, 0);
+			}
+		}
+	}
+}
+
+// ============================================================
+// Bookmarks (Scintilla marker-based)
+// ============================================================
+
+static void toggleBookmark()
+{
+	if (!g_scintillaView) return;
+
+	intptr_t pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCURRENTPOS, 0, 0);
+	intptr_t line = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, pos, 0);
+
+	intptr_t markers = ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERGET, line, 0);
+	if (markers & BOOKMARK_MASK)
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERDELETE, line, BOOKMARK_MARKER);
+	else
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERADD, line, BOOKMARK_MARKER);
+}
+
+static void nextBookmark()
+{
+	if (!g_scintillaView) return;
+
+	intptr_t pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCURRENTPOS, 0, 0);
+	intptr_t curLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, pos, 0);
+
+	intptr_t nextLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERNEXT, curLine + 1, BOOKMARK_MASK);
+	if (nextLine < 0)
+	{
+		// Wrap around
+		nextLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERNEXT, 0, BOOKMARK_MASK);
+	}
+
+	if (nextLine >= 0)
+	{
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_GOTOLINE, nextLine, 0);
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SCROLLCARET, 0, 0);
+	}
+}
+
+static void prevBookmark()
+{
+	if (!g_scintillaView) return;
+
+	intptr_t pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCURRENTPOS, 0, 0);
+	intptr_t curLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, pos, 0);
+
+	intptr_t prevLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERPREVIOUS, curLine - 1, BOOKMARK_MASK);
+	if (prevLine < 0)
+	{
+		// Wrap around from end
+		intptr_t lineCount = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINECOUNT, 0, 0);
+		prevLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERPREVIOUS, lineCount - 1, BOOKMARK_MASK);
+	}
+
+	if (prevLine >= 0)
+	{
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_GOTOLINE, prevLine, 0);
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SCROLLCARET, 0, 0);
+	}
+}
+
+static void clearAllBookmarks()
+{
+	if (!g_scintillaView) return;
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERDELETEALL, BOOKMARK_MARKER, 0);
+}
+
+// ============================================================
+// Auto-completion (word completion)
+// ============================================================
+
+static void showAutoComplete()
+{
+	if (!g_scintillaView) return;
+
+	intptr_t pos = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCURRENTPOS, 0, 0);
+	intptr_t wordStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_WORDSTARTPOSITION, pos, 1);
+	intptr_t wordLen = pos - wordStart;
+
+	if (wordLen < 1) return;
+
+	// Get the partial word
+	char partial[256] = {};
+	for (intptr_t i = 0; i < wordLen && i < 255; ++i)
+		partial[i] = static_cast<char>(ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCHARAT, wordStart + i, 0));
+	partial[wordLen] = '\0';
+
+	// Collect all words in the document that match the prefix
+	intptr_t docLen = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLENGTH, 0, 0);
+	if (docLen <= 0) return;
+
+	std::string docText;
+	docText.resize(docLen + 1);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXT, docLen + 1, (intptr_t)docText.data());
+
+	// Extract unique words
+	std::set<std::string> words;
+	std::string currentWord;
+	for (intptr_t i = 0; i < docLen; ++i)
+	{
+		unsigned char ch = static_cast<unsigned char>(docText[i]);
+		if (isalnum(ch) || ch == '_')
+		{
+			currentWord += ch;
+		}
+		else
+		{
+			if (!currentWord.empty() && currentWord.length() >= 3)
+				words.insert(currentWord);
+			currentWord.clear();
+		}
+	}
+	if (!currentWord.empty() && currentWord.length() >= 3)
+		words.insert(currentWord);
+
+	// Filter words that start with the partial text (case-insensitive prefix match)
+	std::string partialLower(partial);
+	std::transform(partialLower.begin(), partialLower.end(), partialLower.begin(),
+	               [](unsigned char c){ return std::tolower(c); });
+
+	std::vector<std::string> matches;
+	for (const auto& w : words)
+	{
+		if (static_cast<intptr_t>(w.length()) <= wordLen) continue;
+		// Case-insensitive prefix compare
+		std::string wLower = w.substr(0, wordLen);
+		std::transform(wLower.begin(), wLower.end(), wLower.begin(),
+		               [](unsigned char c){ return std::tolower(c); });
+		if (wLower == partialLower)
+			matches.push_back(w);
+	}
+
+	if (matches.empty()) return;
+
+	// Build space-separated list (Scintilla expects this)
+	std::string wordList;
+	for (size_t i = 0; i < matches.size(); ++i)
+	{
+		if (i > 0) wordList += ' ';
+		wordList += matches[i];
+	}
+
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_AUTOCSETIGNORECASE, 1, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_AUTOCSETORDER, 1, 0); // SC_ORDER_PERFORMSORT
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_AUTOCSHOW, wordLen, (intptr_t)wordList.c_str());
+}
+
+// ============================================================
+// Context menu
+// ============================================================
+
+static void showContextMenu(NSPoint screenPoint)
+{
+	NSMenu* contextMenu = [[NSMenu alloc] initWithTitle:@"Context"];
+
+	NSMenuItem* undoItem = [[NSMenuItem alloc] initWithTitle:@"Undo" action:@selector(performContextAction:) keyEquivalent:@""];
+	undoItem.tag = IDM_EDIT_UNDO;
+
+	NSMenuItem* redoItem = [[NSMenuItem alloc] initWithTitle:@"Redo" action:@selector(performContextAction:) keyEquivalent:@""];
+	redoItem.tag = IDM_EDIT_REDO;
+
+	NSMenuItem* cutItem = [[NSMenuItem alloc] initWithTitle:@"Cut" action:@selector(performContextAction:) keyEquivalent:@""];
+	cutItem.tag = IDM_EDIT_CUT;
+
+	NSMenuItem* copyItem = [[NSMenuItem alloc] initWithTitle:@"Copy" action:@selector(performContextAction:) keyEquivalent:@""];
+	copyItem.tag = IDM_EDIT_COPY;
+
+	NSMenuItem* pasteItem = [[NSMenuItem alloc] initWithTitle:@"Paste" action:@selector(performContextAction:) keyEquivalent:@""];
+	pasteItem.tag = IDM_EDIT_PASTE;
+
+	NSMenuItem* selectAllItem = [[NSMenuItem alloc] initWithTitle:@"Select All" action:@selector(performContextAction:) keyEquivalent:@""];
+	selectAllItem.tag = IDM_EDIT_SELECTALL;
+
+	NSMenuItem* bookmarkItem = [[NSMenuItem alloc] initWithTitle:@"Toggle Bookmark" action:@selector(performContextAction:) keyEquivalent:@""];
+	bookmarkItem.tag = IDM_SEARCH_BOOKMARK_TOGGLE;
+
+	[contextMenu addItem:undoItem];
+	[contextMenu addItem:redoItem];
+	[contextMenu addItem:[NSMenuItem separatorItem]];
+	[contextMenu addItem:cutItem];
+	[contextMenu addItem:copyItem];
+	[contextMenu addItem:pasteItem];
+	[contextMenu addItem:[NSMenuItem separatorItem]];
+	[contextMenu addItem:selectAllItem];
+	[contextMenu addItem:[NSMenuItem separatorItem]];
+	[contextMenu addItem:bookmarkItem];
+
+	[NSMenu popUpContextMenu:contextMenu withEvent:[NSApp currentEvent] forView:g_mainWindow.contentView];
+}
+
+// ============================================================
+// Preferences dialog (modal)
+// ============================================================
+
+static void showPreferencesDlg()
+{
+	@autoreleasepool {
+		NSPanel* panel = [[NSPanel alloc] initWithContentRect:NSMakeRect(0, 0, 380, 240)
+		                                    styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable
+		                                    backing:NSBackingStoreBuffered
+		                                    defer:NO];
+		[panel setTitle:@"Preferences"];
+		[panel center];
+
+		NSView* content = panel.contentView;
+
+		// Font name
+		NSTextField* fontLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 195, 100, 20)];
+		fontLabel.stringValue = @"Font:";
+		fontLabel.bezeled = NO;
+		fontLabel.drawsBackground = NO;
+		fontLabel.editable = NO;
+		fontLabel.selectable = NO;
+		[content addSubview:fontLabel];
+
+		NSPopUpButton* fontPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(130, 192, 200, 26) pullsDown:NO];
+		NSArray* fonts = @[@"Menlo", @"Monaco", @"SF Mono", @"Courier New", @"Consolas",
+		                   @"Fira Code", @"JetBrains Mono", @"Source Code Pro"];
+		for (NSString* f in fonts)
+			[fontPopup addItemWithTitle:f];
+		NSString* currentFont = [NSString stringWithUTF8String:g_fontName.c_str()];
+		[fontPopup selectItemWithTitle:currentFont];
+		if (fontPopup.indexOfSelectedItem < 0)
+			[fontPopup selectItemAtIndex:0];
+		[content addSubview:fontPopup];
+
+		// Font size
+		NSTextField* sizeLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 160, 100, 20)];
+		sizeLabel.stringValue = @"Font Size:";
+		sizeLabel.bezeled = NO;
+		sizeLabel.drawsBackground = NO;
+		sizeLabel.editable = NO;
+		sizeLabel.selectable = NO;
+		[content addSubview:sizeLabel];
+
+		NSPopUpButton* sizePopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(130, 157, 80, 26) pullsDown:NO];
+		NSArray* sizes = @[@"9", @"10", @"11", @"12", @"13", @"14", @"16", @"18", @"20", @"24"];
+		for (NSString* s in sizes)
+			[sizePopup addItemWithTitle:s];
+		[sizePopup selectItemWithTitle:[NSString stringWithFormat:@"%d", g_fontSize]];
+		if (sizePopup.indexOfSelectedItem < 0)
+			[sizePopup selectItemAtIndex:4]; // Default 13
+		[content addSubview:sizePopup];
+
+		// Tab width
+		NSTextField* tabLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 125, 100, 20)];
+		tabLabel.stringValue = @"Tab Width:";
+		tabLabel.bezeled = NO;
+		tabLabel.drawsBackground = NO;
+		tabLabel.editable = NO;
+		tabLabel.selectable = NO;
+		[content addSubview:tabLabel];
+
+		NSPopUpButton* tabPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(130, 122, 80, 26) pullsDown:NO];
+		NSArray* tabSizes = @[@"2", @"3", @"4", @"5", @"6", @"7", @"8"];
+		for (NSString* t in tabSizes)
+			[tabPopup addItemWithTitle:t];
+		[tabPopup selectItemWithTitle:[NSString stringWithFormat:@"%d", g_tabWidth]];
+		if (tabPopup.indexOfSelectedItem < 0)
+			[tabPopup selectItemAtIndex:2]; // Default 4
+		[content addSubview:tabPopup];
+
+		// Dark mode toggle info
+		NSTextField* darkLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 85, 340, 20)];
+		darkLabel.stringValue = @"Dark mode follows system preferences.";
+		darkLabel.bezeled = NO;
+		darkLabel.drawsBackground = NO;
+		darkLabel.editable = NO;
+		darkLabel.selectable = NO;
+		darkLabel.textColor = [NSColor secondaryLabelColor];
+		[content addSubview:darkLabel];
+
+		// OK / Cancel buttons
+		NSButton* okButton = [[NSButton alloc] initWithFrame:NSMakeRect(270, 15, 90, 32)];
+		okButton.title = @"OK";
+		okButton.bezelStyle = NSBezelStyleRounded;
+		okButton.keyEquivalent = @"\r"; // Enter
+		okButton.target = panel;
+		okButton.action = @selector(performClose:);
+		okButton.tag = 1;
+		[content addSubview:okButton];
+
+		NSButton* cancelButton = [[NSButton alloc] initWithFrame:NSMakeRect(170, 15, 90, 32)];
+		cancelButton.title = @"Cancel";
+		cancelButton.bezelStyle = NSBezelStyleRounded;
+		cancelButton.keyEquivalent = @"\033"; // Escape
+		cancelButton.target = panel;
+		cancelButton.action = @selector(performClose:);
+		cancelButton.tag = 0;
+		[content addSubview:cancelButton];
+
+		// Run as modal
+		okButton.target = NSApp;
+		okButton.action = @selector(stopModal);
+		cancelButton.target = NSApp;
+		cancelButton.action = @selector(abortModal);
+
+		NSModalResponse result = [NSApp runModalForWindow:panel];
+
+		if (result == NSModalResponseStop)
+		{
+			// OK pressed - apply settings
+			NSString* selFont = fontPopup.titleOfSelectedItem;
+			g_fontName = [selFont UTF8String];
+			g_fontSize = sizePopup.titleOfSelectedItem.intValue;
+			g_tabWidth = tabPopup.titleOfSelectedItem.intValue;
+
+			if (g_scintillaView)
+			{
+				ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETFONT, 32, (intptr_t)g_fontName.c_str());
+				ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETSIZE, 32, g_fontSize);
+				ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLECLEARALL, 0, 0);
+				ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTABWIDTH, g_tabWidth, 0);
+
+				// Reapply appearance (colors)
+				applyAppearance();
+
+				// Reapply language keywords/highlighting
+				if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+					applyLanguage(g_documents[g_activeTab].languageIndex);
+			}
+
+			// Save settings immediately
+			auto& ss = SettingsManager::instance().settings;
+			ss.fontName = g_fontName;
+			ss.fontSize = g_fontSize;
+			ss.tabWidth = g_tabWidth;
+			SettingsManager::instance().save();
+		}
+
+		[panel orderOut:nil];
+	}
+}
+
+// ============================================================
+// File operations
+// ============================================================
+
+// Guess language from file extension
+static int guessLanguage(const std::wstring& filePath)
+{
+	NSString* path = WideToNSString(filePath.c_str());
+	NSString* ext = [path.pathExtension lowercaseString];
+
+	if ([ext isEqualToString:@"c"] || [ext isEqualToString:@"h"])
+		return 1; // C
+	if ([ext isEqualToString:@"cpp"] || [ext isEqualToString:@"cc"] ||
+	    [ext isEqualToString:@"cxx"] || [ext isEqualToString:@"hpp"] ||
+	    [ext isEqualToString:@"hh"] || [ext isEqualToString:@"hxx"] ||
+	    [ext isEqualToString:@"mm"])
+		return 2; // C++
+	if ([ext isEqualToString:@"java"])
+		return 3; // Java
+	if ([ext isEqualToString:@"py"] || [ext isEqualToString:@"pyw"])
+		return 4; // Python
+	if ([ext isEqualToString:@"js"] || [ext isEqualToString:@"jsx"] ||
+	    [ext isEqualToString:@"ts"] || [ext isEqualToString:@"tsx"])
+		return 5; // JavaScript
+	if ([ext isEqualToString:@"html"] || [ext isEqualToString:@"htm"])
+		return 6; // HTML
+	if ([ext isEqualToString:@"css"] || [ext isEqualToString:@"scss"] ||
+	    [ext isEqualToString:@"less"])
+		return 7; // CSS
+	if ([ext isEqualToString:@"xml"] || [ext isEqualToString:@"xsl"] ||
+	    [ext isEqualToString:@"xslt"] || [ext isEqualToString:@"plist"])
+		return 8; // XML
+	if ([ext isEqualToString:@"json"])
+		return 9; // JSON
+	if ([ext isEqualToString:@"md"] || [ext isEqualToString:@"markdown"])
+		return 10; // Markdown
+	if ([ext isEqualToString:@"sql"])
+		return 11; // SQL
+	if ([ext isEqualToString:@"sh"] || [ext isEqualToString:@"bash"] ||
+	    [ext isEqualToString:@"zsh"])
+		return 12; // Shell
+	if ([ext isEqualToString:@"rs"])
+		return 13; // Rust
+	if ([ext isEqualToString:@"go"])
+		return 14; // Go
+	if ([ext isEqualToString:@"m"])
+		return 15; // Objective-C
+	if ([ext isEqualToString:@"swift"])
+		return 16; // Swift
+
+	return 0; // Normal text
+}
+
+// Detect encoding from raw file data
+static int detectEncoding(NSData* data)
+{
+	const unsigned char* bytes = (const unsigned char*)[data bytes];
+	NSUInteger len = [data length];
+	if (len >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+		return ENC_UTF8_BOM;
+	if (len >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE)
+		return ENC_UTF16_LE;
+	if (len >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF)
+		return ENC_UTF16_BE;
+
+	// Use uchardet for further detection
+	uchardet_t ud = uchardet_new();
+	uchardet_handle_data(ud, (const char*)bytes, (size_t)len);
+	uchardet_data_end(ud);
+	const char* charset = uchardet_get_charset(ud);
+	int result = ENC_UTF8;
+	if (charset && strlen(charset) > 0)
+	{
+		NSString* cs = [[NSString stringWithUTF8String:charset] uppercaseString];
+		if ([cs containsString:@"UTF-16LE"]) result = ENC_UTF16_LE;
+		else if ([cs containsString:@"UTF-16BE"]) result = ENC_UTF16_BE;
+		else if ([cs containsString:@"ASCII"] || [cs containsString:@"ISO-8859"] ||
+		         [cs containsString:@"WINDOWS-1252"]) result = ENC_ANSI;
+	}
+	uchardet_delete(ud);
+	return result;
+}
+
+// Detect EOL mode from raw text
+static int detectEOLMode(const char* text, size_t len)
+{
+	for (size_t i = 0; i < len; ++i)
+	{
+		if (text[i] == '\r')
+		{
+			if (i + 1 < len && text[i + 1] == '\n')
+				return SC_EOL_CRLF;
+			return SC_EOL_CR;
+		}
+		if (text[i] == '\n')
+			return SC_EOL_LF;
+	}
+	return SC_EOL_LF;
+}
+
+// Decode file data to UTF-8 string for Scintilla
+static std::string decodeFileData(NSData* data, int encoding)
+{
+	const unsigned char* bytes = (const unsigned char*)[data bytes];
+	NSUInteger len = [data length];
+	NSString* str = nil;
+
+	switch (encoding)
+	{
+		case ENC_UTF8_BOM:
+			if (len >= 3)
+				str = [[NSString alloc] initWithBytes:bytes + 3 length:len - 3 encoding:NSUTF8StringEncoding];
+			break;
+		case ENC_UTF16_LE:
+			str = [[NSString alloc] initWithBytes:bytes length:len encoding:NSUTF16LittleEndianStringEncoding];
+			break;
+		case ENC_UTF16_BE:
+			str = [[NSString alloc] initWithBytes:bytes length:len encoding:NSUTF16BigEndianStringEncoding];
+			break;
+		case ENC_ANSI:
+			str = [[NSString alloc] initWithBytes:bytes length:len encoding:NSWindowsCP1252StringEncoding];
+			break;
+		default: // UTF-8
+			str = [[NSString alloc] initWithBytes:bytes length:len encoding:NSUTF8StringEncoding];
+			break;
+	}
+	if (!str)
+		str = [[NSString alloc] initWithBytes:bytes length:len encoding:NSUTF8StringEncoding];
+	if (!str)
+		str = [[NSString alloc] initWithBytes:bytes length:len encoding:NSISOLatin1StringEncoding];
+	return str ? std::string([str UTF8String]) : std::string();
+}
+
+// Encode UTF-8 string back to target encoding for saving
+static NSData* encodeForSave(const char* utf8Text, size_t len, int encoding)
+{
+	NSString* str = [[NSString alloc] initWithBytes:utf8Text length:len encoding:NSUTF8StringEncoding];
+	if (!str) return nil;
+
+	switch (encoding)
+	{
+		case ENC_UTF8_BOM:
+		{
+			NSMutableData* d = [NSMutableData data];
+			unsigned char bom[] = {0xEF, 0xBB, 0xBF};
+			[d appendBytes:bom length:3];
+			NSData* body = [str dataUsingEncoding:NSUTF8StringEncoding];
+			if (body) [d appendData:body];
+			return d;
+		}
+		case ENC_UTF16_LE:
+			return [str dataUsingEncoding:NSUTF16LittleEndianStringEncoding];
+		case ENC_UTF16_BE:
+			return [str dataUsingEncoding:NSUTF16BigEndianStringEncoding];
+		case ENC_ANSI:
+			return [str dataUsingEncoding:NSWindowsCP1252StringEncoding];
+		default:
+			return [str dataUsingEncoding:NSUTF8StringEncoding];
+	}
+}
+
+// Open a file by path (shared by file dialog, recent files, drag-and-drop, session)
+static bool openFileAtPath(NSString* path)
+{
+	NSData* rawData = [NSData dataWithContentsOfFile:path];
+	if (!rawData) return false;
+
+	int enc = detectEncoding(rawData);
+	std::string utf8Content = decodeFileData(rawData, enc);
+	int eol = detectEOLMode(utf8Content.c_str(), utf8Content.size());
+
+	std::wstring wpath = NSStringToWide(path);
+	std::wstring title = wpath;
+	size_t lastSlash = title.rfind(L'/');
+	if (lastSlash != std::wstring::npos)
+		title = title.substr(lastSlash + 1);
+
+	int langIdx = guessLanguage(wpath);
+	int tabIdx = addNewTab(title, utf8Content, wpath, langIdx);
+
+	if (tabIdx >= 0 && tabIdx < static_cast<int>(g_documents.size()))
+	{
+		g_documents[tabIdx].encoding = enc;
+		g_documents[tabIdx].eolMode = eol;
+		if (g_scintillaView)
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETEOLMODE, eol, 0);
+	}
+
+	if (g_fileMonitor)
+	{
+		std::wstring dir = wpath.substr(0, wpath.rfind(L'/'));
+		g_fileMonitor->addDirectory(dir);
+	}
+
+	addRecentFile(wpath);
+	rebuildRecentMenu();
+	updateStatusBar();
+	return true;
+}
+
+static void openFile()
+{
+	OPENFILENAMEW ofn = {};
+	wchar_t filePath[MAX_PATH] = {0};
+	ofn.lStructSize = sizeof(ofn);
+	ofn.hwndOwner = g_mainHwnd;
+	ofn.lpstrFile = filePath;
+	ofn.nMaxFile = MAX_PATH;
+	ofn.lpstrTitle = L"Open File";
+	ofn.lpstrFilter = L"All Files\0*.*\0"
+	                   L"C/C++ Files\0*.c;*.cpp;*.cc;*.h;*.hpp\0"
+	                   L"Text Files\0*.txt\0";
+	ofn.nFilterIndex = 1;
+	ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST;
+
+	if (GetOpenFileNameW(&ofn))
+	{
+		NSString* path = WideToNSString(filePath);
+		openFileAtPath(path);
+	}
+}
+
+static void openRecentFile(int index)
+{
+	if (index < 0 || index >= static_cast<int>(g_recentFiles.size()))
+		return;
+
+	std::wstring wpath = g_recentFiles[index];
+	NSString* path = WideToNSString(wpath.c_str());
+
+	if (!openFileAtPath(path))
+	{
+		// Remove from recent list if file no longer exists
+		g_recentFiles.erase(g_recentFiles.begin() + index);
+		rebuildRecentMenu();
+	}
+}
+
+static void saveCurrentFile()
+{
+	if (g_activeTab < 0 || g_activeTab >= static_cast<int>(g_documents.size()))
+		return;
+
+	auto& doc = g_documents[g_activeTab];
+
+	if (doc.filePath.empty())
+	{
+		OPENFILENAMEW ofn = {};
+		wchar_t filePath[MAX_PATH] = {0};
+		ofn.lStructSize = sizeof(ofn);
+		ofn.hwndOwner = g_mainHwnd;
+		ofn.lpstrFile = filePath;
+		ofn.nMaxFile = MAX_PATH;
+		ofn.lpstrTitle = L"Save File As";
+		ofn.lpstrFilter = L"All Files\0*.*\0";
+		ofn.nFilterIndex = 1;
+		ofn.Flags = OFN_OVERWRITEPROMPT;
+
+		if (!GetSaveFileNameW(&ofn))
+			return;
+
+		doc.filePath = filePath;
+		doc.title = doc.filePath;
+		size_t lastSlash = doc.title.rfind(L'/');
+		if (lastSlash != std::wstring::npos)
+			doc.title = doc.title.substr(lastSlash + 1);
+
+		// Update tab title
+		TCITEMW tcItem = {};
+		tcItem.mask = TCIF_TEXT;
+		wchar_t titleBuf[256];
+		wcsncpy(titleBuf, doc.title.c_str(), 255);
+		titleBuf[255] = L'\0';
+		tcItem.pszText = titleBuf;
+		SendMessageW(g_tabHwnd, TCM_SETITEMW, g_activeTab, reinterpret_cast<LPARAM>(&tcItem));
+
+		// Detect language from extension
+		doc.languageIndex = guessLanguage(doc.filePath);
+		applyLanguage(doc.languageIndex);
+	}
+
+	if (!g_scintillaView) return;
+
+	intptr_t len = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXTLENGTH, 0, 0);
+	if (len >= 0)
+	{
+		char* buf = new char[len + 1];
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_GETTEXT, len + 1, (intptr_t)buf);
+
+		NSString* path = WideToNSString(doc.filePath.c_str());
+		NSData* encoded = encodeForSave(buf, len, doc.encoding);
+		BOOL ok = NO;
+		if (encoded)
+			ok = [encoded writeToFile:path atomically:YES];
+
+		if (!ok)
+			NSLog(@"Error saving file");
+		else
+		{
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSAVEPOINT, 0, 0);
+			NSString* nsTitle = WideToNSString(doc.title.c_str());
+			[g_mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@", nsTitle]];
+
+			addRecentFile(doc.filePath);
+			rebuildRecentMenu();
+		}
+
+		delete[] buf;
+	}
+}
+
+// ============================================================
+// Language switching
+// ============================================================
+
+static void applyLanguage(int langIndex)
+{
+	if (!g_scintillaView) return;
+	if (langIndex < 0 || langIndex >= g_numLanguages) return;
+
+	const auto& lang = g_languages[langIndex];
+
+	// Create lexer via Lexilla and send to Scintilla
+	ILexer5* lexer = CreateLexer(lang.lexerName);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETILEXER, 0, (intptr_t)lexer);
+
+	// Set keyword lists
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETKEYWORDS, 0, (intptr_t)lang.keywords);
+	if (lang.keywords2 && lang.keywords2[0])
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETKEYWORDS, 1, (intptr_t)lang.keywords2);
+
+	// Set fold properties
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETPROPERTY, (uintptr_t)"fold", (intptr_t)"1");
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETPROPERTY, (uintptr_t)"fold.compact", (intptr_t)"0");
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETPROPERTY, (uintptr_t)"fold.comment", (intptr_t)"1");
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETPROPERTY, (uintptr_t)"fold.preprocessor", (intptr_t)"1");
+
+	// Set font on STYLE_DEFAULT
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETFONT, 32, (intptr_t)g_fontName.c_str());
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETSIZE, 32, g_fontSize);
+
+	// Apply syntax-aware colors
+	applyAppearance();
+
+	// Trigger re-coloring
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_COLOURISE, 0, -1);
+}
+
+// ============================================================
+// Edit commands (Phase 7)
+// ============================================================
+
+static void doTitleCase()
+{
+	if (!g_scintillaView) return;
+	intptr_t selStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONSTART, 0, 0);
+	intptr_t selEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONEND, 0, 0);
+	if (selStart == selEnd) return;
+
+	intptr_t len = selEnd - selStart;
+	std::string text(len + 1, '\0');
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELTEXT, 0, (intptr_t)text.data());
+	text.resize(len);
+
+	bool capitalize = true;
+	for (size_t i = 0; i < text.size(); ++i)
+	{
+		if (isspace(static_cast<unsigned char>(text[i])) || text[i] == '-' || text[i] == '_')
+			capitalize = true;
+		else if (capitalize)
+		{
+			text[i] = toupper(static_cast<unsigned char>(text[i]));
+			capitalize = false;
+		}
+		else
+			text[i] = tolower(static_cast<unsigned char>(text[i]));
+	}
+
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_BEGINUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_REPLACETARGET, -1, 0); // dummy
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, selStart, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, selEnd, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_REPLACETARGET, len, (intptr_t)text.c_str());
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEL, selStart, selStart + (intptr_t)text.size());
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_ENDUNDOACTION, 0, 0);
+}
+
+static void doTrimTrailingWhitespace()
+{
+	if (!g_scintillaView) return;
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_BEGINUNDOACTION, 0, 0);
+
+	intptr_t lineCount = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINECOUNT, 0, 0);
+	for (intptr_t line = lineCount - 1; line >= 0; --line)
+	{
+		intptr_t lineEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINEENDPOSITION, line, 0);
+		intptr_t lineStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, line, 0);
+		intptr_t trimPos = lineEnd;
+		while (trimPos > lineStart)
+		{
+			char ch = (char)ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCHARAT, trimPos - 1, 0);
+			if (ch != ' ' && ch != '\t') break;
+			--trimPos;
+		}
+		if (trimPos < lineEnd)
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_DELETERANGE, trimPos, lineEnd - trimPos);
+	}
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_ENDUNDOACTION, 0, 0);
+}
+
+static void doRemoveEmptyLines()
+{
+	if (!g_scintillaView) return;
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_BEGINUNDOACTION, 0, 0);
+
+	intptr_t lineCount = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINECOUNT, 0, 0);
+	for (intptr_t line = lineCount - 1; line >= 0; --line)
+	{
+		intptr_t lineStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, line, 0);
+		intptr_t lineEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINEENDPOSITION, line, 0);
+		if (lineStart == lineEnd)
+		{
+			// Delete the line including its EOL
+			intptr_t nextLineStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, line + 1, 0);
+			if (nextLineStart > lineStart)
+				ScintillaBridge_sendMessage(g_scintillaView, SCI_DELETERANGE, lineStart, nextLineStart - lineStart);
+		}
+	}
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_ENDUNDOACTION, 0, 0);
+}
+
+static void doToggleLineComment()
+{
+	if (!g_scintillaView) return;
+
+	// Determine comment prefix from language
+	const char* prefix = "//";
+	if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+	{
+		int langIdx = g_documents[g_activeTab].languageIndex;
+		if (langIdx >= 0 && langIdx < g_numLanguages)
+		{
+			const char* lexer = g_languages[langIdx].lexerName;
+			if (strcmp(lexer, "python") == 0 || strcmp(lexer, "bash") == 0)
+				prefix = "#";
+			else if (strcmp(lexer, "sql") == 0)
+				prefix = "--";
+		}
+	}
+
+	intptr_t selStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONSTART, 0, 0);
+	intptr_t selEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONEND, 0, 0);
+	intptr_t startLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, selStart, 0);
+	intptr_t endLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, selEnd, 0);
+	if (selEnd == ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, endLine, 0) && endLine > startLine)
+		--endLine;
+
+	size_t prefixLen = strlen(prefix);
+
+	// Check if all lines are already commented
+	bool allCommented = true;
+	for (intptr_t line = startLine; line <= endLine; ++line)
+	{
+		intptr_t lineStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, line, 0);
+		intptr_t lineEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINEENDPOSITION, line, 0);
+		if (lineEnd - lineStart < (intptr_t)prefixLen)
+		{
+			allCommented = false;
+			break;
+		}
+		bool match = true;
+		for (size_t j = 0; j < prefixLen; ++j)
+		{
+			if ((char)ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCHARAT, lineStart + j, 0) != prefix[j])
+			{
+				match = false;
+				break;
+			}
+		}
+		if (!match) { allCommented = false; break; }
+	}
+
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_BEGINUNDOACTION, 0, 0);
+	if (allCommented)
+	{
+		// Remove comment prefix
+		for (intptr_t line = endLine; line >= startLine; --line)
+		{
+			intptr_t lineStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, line, 0);
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_DELETERANGE, lineStart, prefixLen);
+		}
+	}
+	else
+	{
+		// Add comment prefix
+		for (intptr_t line = endLine; line >= startLine; --line)
+		{
+			intptr_t lineStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, line, 0);
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, lineStart, 0);
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, lineStart, 0);
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_REPLACETARGET, prefixLen, (intptr_t)prefix);
+		}
+	}
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_ENDUNDOACTION, 0, 0);
+}
+
+static void doSortLines(bool ascending)
+{
+	if (!g_scintillaView) return;
+
+	intptr_t selStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONSTART, 0, 0);
+	intptr_t selEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONEND, 0, 0);
+	if (selStart == selEnd) return;
+
+	intptr_t startLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, selStart, 0);
+	intptr_t endLine = ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEFROMPOSITION, selEnd, 0);
+
+	std::vector<std::string> lines;
+	for (intptr_t line = startLine; line <= endLine; ++line)
+	{
+		intptr_t lineStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, line, 0);
+		intptr_t lineEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINEENDPOSITION, line, 0);
+		intptr_t len = lineEnd - lineStart;
+		std::string text(len, '\0');
+		for (intptr_t i = 0; i < len; ++i)
+			text[i] = (char)ScintillaBridge_sendMessage(g_scintillaView, SCI_GETCHARAT, lineStart + i, 0);
+		lines.push_back(text);
+	}
+
+	if (ascending)
+		std::sort(lines.begin(), lines.end());
+	else
+		std::sort(lines.begin(), lines.end(), std::greater<std::string>());
+
+	std::string result;
+	for (size_t i = 0; i < lines.size(); ++i)
+	{
+		result += lines[i];
+		if (i + 1 < lines.size()) result += '\n';
+	}
+
+	intptr_t replStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_POSITIONFROMLINE, startLine, 0);
+	intptr_t replEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETLINEENDPOSITION, endLine, 0);
+
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_BEGINUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, replStart, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, replEnd, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_REPLACETARGET, result.size(), (intptr_t)result.c_str());
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_ENDUNDOACTION, 0, 0);
+}
+
+static void doJoinLines()
+{
+	if (!g_scintillaView) return;
+
+	intptr_t selStart = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONSTART, 0, 0);
+	intptr_t selEnd = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELECTIONEND, 0, 0);
+	if (selStart == selEnd) return;
+
+	intptr_t len = selEnd - selStart;
+	std::string text(len + 1, '\0');
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_GETSELTEXT, 0, (intptr_t)text.data());
+	text.resize(len);
+
+	// Replace all line breaks with space
+	std::string result;
+	result.reserve(text.size());
+	for (size_t i = 0; i < text.size(); ++i)
+	{
+		if (text[i] == '\r' && i + 1 < text.size() && text[i + 1] == '\n')
+		{
+			result += ' ';
+			++i;
+		}
+		else if (text[i] == '\r' || text[i] == '\n')
+			result += ' ';
+		else
+			result += text[i];
+	}
+
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_BEGINUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETSTART, selStart, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETTARGETEND, selEnd, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_REPLACETARGET, result.size(), (intptr_t)result.c_str());
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEL, selStart, selStart + (intptr_t)result.size());
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_ENDUNDOACTION, 0, 0);
+}
+
+// ============================================================
+// Session management
+// ============================================================
+
+static std::string sessionPath()
+{
+	NSString* home = NSHomeDirectory();
+	return std::string([home UTF8String]) + "/.npp-macos/session.json";
+}
+
+static void saveSession()
+{
+	NSString* dir = [NSString stringWithFormat:@"%@/.npp-macos", NSHomeDirectory()];
+	[[NSFileManager defaultManager] createDirectoryAtPath:dir
+	                          withIntermediateDirectories:YES attributes:nil error:nil];
+
+	NSMutableArray* tabs = [NSMutableArray array];
+	// Save state of current editor first
+	saveScintillaState();
+	for (const auto& doc : g_documents)
+	{
+		if (doc.filePath.empty()) continue;
+		NSString* fp = WideToNSString(doc.filePath.c_str());
+		[tabs addObject:@{
+			@"filePath": fp,
+			@"cursorPos": @((long long)doc.cursorPos),
+			@"anchorPos": @((long long)doc.anchorPos),
+			@"firstVisibleLine": @((long long)doc.firstVisibleLine),
+			@"languageIndex": @(doc.languageIndex),
+			@"encoding": @(doc.encoding),
+			@"eolMode": @(doc.eolMode),
+		}];
+	}
+
+	NSMutableArray* tabs2 = [NSMutableArray array];
+	for (const auto& doc : g_documents2)
+	{
+		if (doc.filePath.empty()) continue;
+		NSString* fp = WideToNSString(doc.filePath.c_str());
+		[tabs2 addObject:@{
+			@"filePath": fp,
+			@"cursorPos": @((long long)doc.cursorPos),
+			@"anchorPos": @((long long)doc.anchorPos),
+			@"firstVisibleLine": @((long long)doc.firstVisibleLine),
+			@"languageIndex": @(doc.languageIndex),
+			@"encoding": @(doc.encoding),
+			@"eolMode": @(doc.eolMode),
+		}];
+	}
+
+	NSDictionary* session = @{
+		@"version": @1,
+		@"tabs": tabs,
+		@"activeTab": @(g_activeTab),
+		@"tabs2": tabs2,
+		@"activeTab2": @(g_activeTab2),
+		@"isSplit": @(g_isSplit),
+	};
+
+	NSData* data = [NSJSONSerialization dataWithJSONObject:session
+	                                              options:NSJSONWritingPrettyPrinted error:nil];
+	if (data)
+	{
+		NSString* path = [NSString stringWithUTF8String:sessionPath().c_str()];
+		[data writeToFile:path atomically:YES];
+	}
+}
+
+static void restoreSession()
+{
+	NSString* path = [NSString stringWithUTF8String:sessionPath().c_str()];
+	NSData* data = [NSData dataWithContentsOfFile:path];
+	if (!data) return;
+
+	NSDictionary* session = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+	if (!session) return;
+
+	NSArray* tabs = session[@"tabs"];
+	if (![tabs isKindOfClass:[NSArray class]] || tabs.count == 0) return;
+
+	bool anyOpened = false;
+	for (NSDictionary* tab in tabs)
+	{
+		NSString* fp = tab[@"filePath"];
+		if (!fp || ![[NSFileManager defaultManager] fileExistsAtPath:fp]) continue;
+		if (openFileAtPath(fp))
+		{
+			anyOpened = true;
+			int idx = static_cast<int>(g_documents.size()) - 1;
+			if (idx >= 0)
+			{
+				if (tab[@"cursorPos"])
+					g_documents[idx].cursorPos = [tab[@"cursorPos"] longLongValue];
+				if (tab[@"anchorPos"])
+					g_documents[idx].anchorPos = [tab[@"anchorPos"] longLongValue];
+				if (tab[@"firstVisibleLine"])
+					g_documents[idx].firstVisibleLine = [tab[@"firstVisibleLine"] longLongValue];
+				if (tab[@"languageIndex"])
+					g_documents[idx].languageIndex = [tab[@"languageIndex"] intValue];
+				if (tab[@"encoding"])
+					g_documents[idx].encoding = [tab[@"encoding"] intValue];
+				if (tab[@"eolMode"])
+					g_documents[idx].eolMode = [tab[@"eolMode"] intValue];
+			}
+		}
+	}
+
+	if (anyOpened)
+	{
+		// Remove the welcome tab if it was the first one
+		if (g_documents.size() > 1 && g_documents[0].filePath.empty() && g_documents[0].title == L"Welcome")
+			closeTab(0);
+
+		// Restore active tab
+		int savedActive = [session[@"activeTab"] intValue];
+		if (savedActive >= 0 && savedActive < static_cast<int>(g_documents.size()))
+		{
+			switchToTab(savedActive);
+			// Restore cursor/scroll position
+			const auto& doc = g_documents[savedActive];
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETFIRSTVISIBLELINE, doc.firstVisibleLine, 0);
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_SETSEL, doc.anchorPos, doc.cursorPos);
+		}
+	}
+}
+
+// ============================================================
+// Split view management
+// ============================================================
+
+static void configureScintilla(void* sci); // forward
+
+static void doSplit()
+{
+	if (g_isSplit || !g_mainWindow || !g_editorContainer) return;
+
+	NSView* contentView = g_mainWindow.contentView;
+
+	// Create NSSplitView
+	g_splitView = [[NSSplitView alloc] initWithFrame:g_editorContainer.frame];
+	g_splitView.vertical = YES;
+	g_splitView.dividerStyle = NSSplitViewDividerStyleThin;
+	g_splitView.autoresizingMask = g_editorContainer.autoresizingMask;
+
+	// Reparent the existing editor container into the split view
+	NSRect leftFrame = NSMakeRect(0, 0, g_editorContainer.frame.size.width / 2, g_editorContainer.frame.size.height);
+	g_editorContainer.frame = leftFrame;
+	[g_editorContainer removeFromSuperview];
+	[g_splitView addArrangedSubview:g_editorContainer];
+
+	// Create second editor container
+	NSRect rightFrame = NSMakeRect(0, 0, g_splitView.frame.size.width / 2, g_splitView.frame.size.height);
+	g_editorContainer2 = [[NSView alloc] initWithFrame:rightFrame];
+	g_editorContainer2.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+	[g_splitView addArrangedSubview:g_editorContainer2];
+
+	// Create second Scintilla view
+	g_scintillaView2 = ScintillaBridge_createView((__bridge void*)g_editorContainer2, 0, 0, 0, 0);
+	if (g_scintillaView2)
+	{
+		configureScintilla(g_scintillaView2);
+		// Set up notification callback for view 2
+		ScintillaBridge_setNotifyCallback(g_scintillaView2, 1,
+			[](intptr_t windowid, unsigned int iMessage, uintptr_t wParam, uintptr_t lParam) {
+				if (iMessage == 1002 && lParam)
+				{
+					struct SciNotifyHeader { void* hwndFrom; uintptr_t idFrom; unsigned int code; };
+					struct SciNotify {
+						SciNotifyHeader nmhdr; intptr_t position; int ch; int modifiers;
+						int modificationType; const char* text; intptr_t length;
+						intptr_t linesAdded; int message; uintptr_t wParam; intptr_t sLParam;
+						intptr_t line; int foldLevelNow; int foldLevelPrev; int margin;
+					};
+					auto* scn = reinterpret_cast<const SciNotify*>(lParam);
+					if (scn->nmhdr.code == 2010 && scn->margin == 1 && g_scintillaView2)
+					{
+						intptr_t line = ScintillaBridge_sendMessage(g_scintillaView2, SCI_LINEFROMPOSITION, scn->position, 0);
+						intptr_t markers = ScintillaBridge_sendMessage(g_scintillaView2, SCI_MARKERGET, line, 0);
+						if (markers & BOOKMARK_MASK)
+							ScintillaBridge_sendMessage(g_scintillaView2, SCI_MARKERDELETE, line, BOOKMARK_MARKER);
+						else
+							ScintillaBridge_sendMessage(g_scintillaView2, SCI_MARKERADD, line, BOOKMARK_MARKER);
+					}
+				}
+			});
+	}
+
+	// Add second tab bar (not implemented for simplicity — second view shares same tab switching)
+	// Create initial document in view 2
+	g_documents2.clear();
+	DocumentData doc2;
+	doc2.title = L"Untitled";
+	g_documents2.push_back(doc2);
+	g_activeTab2 = 0;
+	if (g_scintillaView2)
+	{
+		ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETTEXT, 0, (intptr_t)"");
+		ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETSAVEPOINT, 0, 0);
+		ScintillaBridge_sendMessage(g_scintillaView2, SCI_EMPTYUNDOBUFFER, 0, 0);
+	}
+
+	[contentView addSubview:g_splitView];
+	g_isSplit = true;
+	applyAppearance();
+}
+
+static void doUnsplit()
+{
+	if (!g_isSplit || !g_splitView) return;
+
+	NSView* contentView = g_mainWindow.contentView;
+
+	// Remove second scintilla
+	if (g_scintillaView2)
+	{
+		ScintillaBridge_destroyView(g_scintillaView2);
+		g_scintillaView2 = nullptr;
+	}
+
+	// Remove editor containers from split view
+	[g_editorContainer removeFromSuperview];
+	if (g_editorContainer2)
+	{
+		[g_editorContainer2 removeFromSuperview];
+		g_editorContainer2 = nil;
+	}
+
+	// Remove split view, restore editor container
+	[g_splitView removeFromSuperview];
+	g_splitView = nil;
+
+	// Restore editor container to full size
+	CGFloat tabHeight = 28;
+	CGFloat statusHeight = 22;
+	CGFloat editorHeight = contentView.bounds.size.height - tabHeight - statusHeight;
+	g_editorContainer.frame = NSMakeRect(0, statusHeight, contentView.bounds.size.width, editorHeight);
+	g_editorContainer.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+	[contentView addSubview:g_editorContainer];
+	ScintillaBridge_resizeToFit(g_scintillaView);
+
+	g_documents2.clear();
+	g_activeTab2 = -1;
+	g_activeView = 0;
+	g_isSplit = false;
+}
+
+static void doMoveToOtherView()
+{
+	if (!g_isSplit || !g_scintillaView || !g_scintillaView2) return;
+	if (g_activeTab < 0 || g_activeTab >= static_cast<int>(g_documents.size())) return;
+
+	saveScintillaState();
+	DocumentData doc = g_documents[g_activeTab];
+
+	// Add to other view
+	g_documents2.push_back(doc);
+	g_activeTab2 = static_cast<int>(g_documents2.size()) - 1;
+	ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETTEXT, 0, (intptr_t)doc.content.c_str());
+	ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETFIRSTVISIBLELINE, doc.firstVisibleLine, 0);
+	ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETSEL, doc.anchorPos, doc.cursorPos);
+	if (!doc.modified)
+		ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETSAVEPOINT, 0, 0);
+
+	// Remove from current view
+	closeTab(g_activeTab);
+}
+
+static void doCloneToOtherView()
+{
+	if (!g_isSplit || !g_scintillaView || !g_scintillaView2) return;
+	if (g_activeTab < 0 || g_activeTab >= static_cast<int>(g_documents.size())) return;
+
+	saveScintillaState();
+	DocumentData doc = g_documents[g_activeTab];
+
+	g_documents2.push_back(doc);
+	g_activeTab2 = static_cast<int>(g_documents2.size()) - 1;
+	ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETTEXT, 0, (intptr_t)doc.content.c_str());
+	ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETFIRSTVISIBLELINE, doc.firstVisibleLine, 0);
+	ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETSEL, doc.anchorPos, doc.cursorPos);
+	if (!doc.modified)
+		ScintillaBridge_sendMessage(g_scintillaView2, SCI_SETSAVEPOINT, 0, 0);
+}
+
+// ============================================================
+// WndProc
+// ============================================================
+
+static LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+	switch (msg)
+	{
+		case WM_COMMAND:
+		{
+			UINT cmdId = LOWORD(wParam);
+
+			// Check for recent file commands
+			if (cmdId >= IDM_FILE_RECENT_BASE && cmdId < IDM_FILE_RECENT_BASE + MAX_RECENT_FILES)
+			{
+				openRecentFile(cmdId - IDM_FILE_RECENT_BASE);
+				return 0;
+			}
+
+			// Check for language commands
+			if (cmdId >= IDM_LANG_BASE && cmdId < IDM_LANG_BASE + g_numLanguages)
+			{
+				int langIdx = cmdId - IDM_LANG_BASE;
+				if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+					g_documents[g_activeTab].languageIndex = langIdx;
+				applyLanguage(langIdx);
+				return 0;
+			}
+
+			switch (cmdId)
+			{
+				case IDM_FILE_NEW:
+					addNewTab(L"Untitled", "");
+					return 0;
+				case IDM_FILE_OPEN:
+					openFile();
+					return 0;
+				case IDM_FILE_SAVE:
+					saveCurrentFile();
+					return 0;
+				case IDM_FILE_SAVEAS:
+				{
+					// Force Save As by temporarily clearing the file path
+					if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+					{
+						std::wstring origPath = g_documents[g_activeTab].filePath;
+						g_documents[g_activeTab].filePath.clear();
+						saveCurrentFile();
+						// If user cancelled, restore original path
+						if (g_documents[g_activeTab].filePath.empty())
+							g_documents[g_activeTab].filePath = origPath;
+					}
+					return 0;
+				}
+				case IDM_FILE_CLOSE:
+					closeTab(g_activeTab);
+					return 0;
+				case IDM_FILE_CLOSEALL:
+					while (g_documents.size() > 1)
+						closeTab(static_cast<int>(g_documents.size()) - 1);
+					closeTab(0);
+					return 0;
+				case IDM_FILE_RECENT_CLEAR:
+					g_recentFiles.clear();
+					rebuildRecentMenu();
+					return 0;
+
+				case IDM_EDIT_UNDO:
+					if (g_scintillaView)
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_UNDO, 0, 0);
+					return 0;
+				case IDM_EDIT_REDO:
+					if (g_scintillaView)
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_REDO, 0, 0);
+					return 0;
+				case IDM_EDIT_CUT:
+					if (g_scintillaView)
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_CUT, 0, 0);
+					return 0;
+				case IDM_EDIT_COPY:
+					if (g_scintillaView)
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_COPY, 0, 0);
+					return 0;
+				case IDM_EDIT_PASTE:
+					if (g_scintillaView)
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_PASTE, 0, 0);
+					return 0;
+				case IDM_EDIT_SELECTALL:
+					if (g_scintillaView)
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_SELECTALL, 0, 0);
+					return 0;
+
+				case IDM_VIEW_WORDWRAP:
+					if (g_scintillaView)
+					{
+						intptr_t mode = ScintillaBridge_sendMessage(g_scintillaView, SCI_GETWRAPMODE, 0, 0);
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_SETWRAPMODE, mode == 0 ? 1 : 0, 0);
+						HMENU hMenu = GetMenu(hWnd);
+						if (hMenu)
+							CheckMenuItem(hMenu, IDM_VIEW_WORDWRAP,
+							              MF_BYCOMMAND | (mode == 0 ? MF_CHECKED : MF_UNCHECKED));
+					}
+					return 0;
+				case IDM_VIEW_LINENUMBER:
+					if (g_scintillaView)
+					{
+						g_showLineNumbers = !g_showLineNumbers;
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_SETMARGINWIDTHN, 0,
+						                           g_showLineNumbers ? 50 : 0);
+						HMENU hMenu = GetMenu(hWnd);
+						if (hMenu)
+							CheckMenuItem(hMenu, IDM_VIEW_LINENUMBER,
+							              MF_BYCOMMAND | (g_showLineNumbers ? MF_CHECKED : MF_UNCHECKED));
+					}
+					return 0;
+				case IDM_VIEW_FOLDALL:
+					if (g_scintillaView)
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_FOLDALL, SC_FOLDACTION_CONTRACT, 0);
+					return 0;
+				case IDM_VIEW_UNFOLDALL:
+					if (g_scintillaView)
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_FOLDALL, SC_FOLDACTION_EXPAND, 0);
+					return 0;
+				case IDM_VIEW_PREFERENCES:
+					showPreferencesDlg();
+					return 0;
+
+				case IDM_SEARCH_FIND:
+					createFindReplaceDlg(false);
+					return 0;
+				case IDM_SEARCH_REPLACE:
+					createFindReplaceDlg(true);
+					return 0;
+				case IDM_SEARCH_FINDNEXT:
+					if (g_findText.empty())
+						createFindReplaceDlg(false);
+					else
+						doFindNext(true);
+					return 0;
+				case IDM_SEARCH_FINDPREV:
+					if (g_findText.empty())
+						createFindReplaceDlg(false);
+					else
+						doFindNext(false);
+					return 0;
+				case IDM_SEARCH_GOTOLINE:
+					showGoToLineDlg();
+					return 0;
+
+				case IDM_SEARCH_BOOKMARK_TOGGLE:
+					toggleBookmark();
+					return 0;
+				case IDM_SEARCH_BOOKMARK_NEXT:
+					nextBookmark();
+					return 0;
+				case IDM_SEARCH_BOOKMARK_PREV:
+					prevBookmark();
+					return 0;
+				case IDM_SEARCH_BOOKMARK_CLEARALL:
+					clearAllBookmarks();
+					return 0;
+
+				case IDM_EDIT_AUTOCOMPLETE:
+					showAutoComplete();
+					return 0;
+
+				// Phase 7 — Edit commands
+				case IDM_EDIT_UPPERCASE:
+					if (g_scintillaView)
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_UPPERCASE, 0, 0);
+					return 0;
+				case IDM_EDIT_LOWERCASE:
+					if (g_scintillaView)
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_LOWERCASE, 0, 0);
+					return 0;
+				case IDM_EDIT_TITLECASE:
+					doTitleCase();
+					return 0;
+				case IDM_EDIT_DUP_LINE:
+					if (g_scintillaView)
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEDUPLICATE, 0, 0);
+					return 0;
+				case IDM_EDIT_DEL_LINE:
+					if (g_scintillaView)
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_LINEDELETE, 0, 0);
+					return 0;
+				case IDM_EDIT_MOVEUP:
+					if (g_scintillaView)
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_MOVESELECTEDLINESUP, 0, 0);
+					return 0;
+				case IDM_EDIT_MOVEDOWN:
+					if (g_scintillaView)
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_MOVESELECTEDLINESDOWN, 0, 0);
+					return 0;
+				case IDM_EDIT_TRIMTRAILING:
+					doTrimTrailingWhitespace();
+					return 0;
+				case IDM_EDIT_REMOVEEMPTY:
+					doRemoveEmptyLines();
+					return 0;
+				case IDM_EDIT_TOGGLECOMMENT:
+					doToggleLineComment();
+					return 0;
+				case IDM_EDIT_SORTASC:
+					doSortLines(true);
+					return 0;
+				case IDM_EDIT_SORTDESC:
+					doSortLines(false);
+					return 0;
+				case IDM_EDIT_JOINLINES:
+					doJoinLines();
+					return 0;
+
+				// Phase 7 — Split view
+				case IDM_VIEW_SPLIT:
+					doSplit();
+					return 0;
+				case IDM_VIEW_UNSPLIT:
+					doUnsplit();
+					return 0;
+				case IDM_VIEW_MOVETOOTHER:
+					doMoveToOtherView();
+					return 0;
+				case IDM_VIEW_CLONETOOTHER:
+					doCloneToOtherView();
+					return 0;
+
+				// Phase 7 — EOL conversion
+				case IDM_FORMAT_EOL_LF:
+					if (g_scintillaView && g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+					{
+						g_documents[g_activeTab].eolMode = SC_EOL_LF;
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_SETEOLMODE, SC_EOL_LF, 0);
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_CONVERTEOLS, SC_EOL_LF, 0);
+						updateStatusBar();
+					}
+					return 0;
+				case IDM_FORMAT_EOL_CRLF:
+					if (g_scintillaView && g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+					{
+						g_documents[g_activeTab].eolMode = SC_EOL_CRLF;
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_SETEOLMODE, SC_EOL_CRLF, 0);
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_CONVERTEOLS, SC_EOL_CRLF, 0);
+						updateStatusBar();
+					}
+					return 0;
+				case IDM_FORMAT_EOL_CR:
+					if (g_scintillaView && g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+					{
+						g_documents[g_activeTab].eolMode = SC_EOL_CR;
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_SETEOLMODE, SC_EOL_CR, 0);
+						ScintillaBridge_sendMessage(g_scintillaView, SCI_CONVERTEOLS, SC_EOL_CR, 0);
+						updateStatusBar();
+					}
+					return 0;
+
+				// Phase 7 — Encoding change
+				case IDM_FORMAT_ENC_UTF8:
+				case IDM_FORMAT_ENC_UTF8BOM:
+				case IDM_FORMAT_ENC_UTF16LE:
+				case IDM_FORMAT_ENC_UTF16BE:
+				case IDM_FORMAT_ENC_ANSI:
+					if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+					{
+						int newEnc = ENC_UTF8;
+						if (cmdId == IDM_FORMAT_ENC_UTF8BOM)  newEnc = ENC_UTF8_BOM;
+						if (cmdId == IDM_FORMAT_ENC_UTF16LE)  newEnc = ENC_UTF16_LE;
+						if (cmdId == IDM_FORMAT_ENC_UTF16BE)  newEnc = ENC_UTF16_BE;
+						if (cmdId == IDM_FORMAT_ENC_ANSI)     newEnc = ENC_ANSI;
+						g_documents[g_activeTab].encoding = newEnc;
+						updateStatusBar();
+					}
+					return 0;
+			}
+			break;
+		}
+
+		case WM_NOTIFY:
+		{
+			NMHDR* pNmhdr = reinterpret_cast<NMHDR*>(lParam);
+			if (pNmhdr && pNmhdr->code == TCN_SELCHANGE)
+			{
+				int newSel = static_cast<int>(SendMessageW(g_tabHwnd, TCM_GETCURSEL, 0, 0));
+				if (newSel != g_activeTab && newSel >= 0)
+					switchToTab(newSel);
+				return 0;
+			}
+			break;
+		}
+
+		case WM_TIMER:
+			if (wParam == IDT_STATUSBAR)
+			{
+				updateStatusBar();
+				return 0;
+			}
+			break;
+
+		case WM_SIZE:
+			if (g_scintillaView)
+				ScintillaBridge_resizeToFit(g_scintillaView);
+			return 0;
+
+		case WM_CLOSE:
+			KillTimer(hWnd, IDT_STATUSBAR);
+			PostQuitMessage(0);
+			return 0;
+	}
+
+	return DefWindowProcW(hWnd, msg, wParam, lParam);
+}
+
+// ============================================================
+// Build menus
+// ============================================================
+
+static HMENU buildMenuBar()
+{
+	HMENU hMenuBar = CreateMenu();
+
+	// File menu
+	HMENU hFileMenu = CreatePopupMenu();
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_NEW, L"&New\tCtrl+N");
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_OPEN, L"&Open...\tCtrl+O");
+	AppendMenuW(hFileMenu, MF_SEPARATOR, 0, nullptr);
+
+	// Recent files submenu
+	g_recentMenu = CreatePopupMenu();
+	AppendMenuW(g_recentMenu, MF_STRING | MF_GRAYED, 0, L"(No recent files)");
+	AppendMenuW(hFileMenu, MF_POPUP, reinterpret_cast<UINT_PTR>(g_recentMenu), L"Recent &Files");
+
+	AppendMenuW(hFileMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_SAVE, L"&Save\tCtrl+S");
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_SAVEAS, L"Save &As...\tCtrl+Shift+S");
+	AppendMenuW(hFileMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_CLOSE, L"&Close\tCtrl+W");
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_CLOSEALL, L"Close &All");
+	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hFileMenu), L"&File");
+
+	// Edit menu
+	HMENU hEditMenu = CreatePopupMenu();
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_UNDO, L"&Undo\tCtrl+Z");
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_REDO, L"&Redo\tCtrl+Shift+Z");
+	AppendMenuW(hEditMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_CUT, L"Cu&t\tCtrl+X");
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_COPY, L"&Copy\tCtrl+C");
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_PASTE, L"&Paste\tCtrl+V");
+	AppendMenuW(hEditMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_SELECTALL, L"Select &All\tCtrl+A");
+	AppendMenuW(hEditMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_AUTOCOMPLETE, L"Auto-&Complete\tCtrl+Space");
+	AppendMenuW(hEditMenu, MF_SEPARATOR, 0, nullptr);
+
+	// Case Conversion submenu
+	HMENU hCaseMenu = CreatePopupMenu();
+	AppendMenuW(hCaseMenu, MF_STRING, IDM_EDIT_UPPERCASE, L"&UPPERCASE\tCtrl+Shift+U");
+	AppendMenuW(hCaseMenu, MF_STRING, IDM_EDIT_LOWERCASE, L"&lowercase\tCtrl+U");
+	AppendMenuW(hCaseMenu, MF_STRING, IDM_EDIT_TITLECASE, L"&Title Case");
+	AppendMenuW(hEditMenu, MF_POPUP, reinterpret_cast<UINT_PTR>(hCaseMenu), L"Case Conversion");
+
+	// Line Operations submenu
+	HMENU hLineMenu = CreatePopupMenu();
+	AppendMenuW(hLineMenu, MF_STRING, IDM_EDIT_DUP_LINE, L"&Duplicate Line\tCtrl+D");
+	AppendMenuW(hLineMenu, MF_STRING, IDM_EDIT_DEL_LINE, L"D&elete Line\tCtrl+Shift+K");
+	AppendMenuW(hLineMenu, MF_STRING, IDM_EDIT_MOVEUP, L"Move Line &Up\tAlt+Up");
+	AppendMenuW(hLineMenu, MF_STRING, IDM_EDIT_MOVEDOWN, L"Move Line &Down\tAlt+Down");
+	AppendMenuW(hLineMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hLineMenu, MF_STRING, IDM_EDIT_SORTASC, L"&Sort Lines (Ascending)");
+	AppendMenuW(hLineMenu, MF_STRING, IDM_EDIT_SORTDESC, L"Sort Lines (&Descending)");
+	AppendMenuW(hLineMenu, MF_STRING, IDM_EDIT_JOINLINES, L"&Join Lines");
+	AppendMenuW(hEditMenu, MF_POPUP, reinterpret_cast<UINT_PTR>(hLineMenu), L"Line Operations");
+
+	AppendMenuW(hEditMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_TOGGLECOMMENT, L"Toggle &Comment\tCtrl+/");
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_TRIMTRAILING, L"&Trim Trailing Whitespace");
+	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_REMOVEEMPTY, L"&Remove Empty Lines");
+
+	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hEditMenu), L"&Edit");
+
+	// Search menu
+	HMENU hSearchMenu = CreatePopupMenu();
+	AppendMenuW(hSearchMenu, MF_STRING, IDM_SEARCH_FIND, L"&Find...\tCtrl+F");
+	AppendMenuW(hSearchMenu, MF_STRING, IDM_SEARCH_REPLACE, L"&Replace...\tCtrl+H");
+	AppendMenuW(hSearchMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hSearchMenu, MF_STRING, IDM_SEARCH_FINDNEXT, L"Find &Next\tF3");
+	AppendMenuW(hSearchMenu, MF_STRING, IDM_SEARCH_FINDPREV, L"Find &Previous\tShift+F3");
+	AppendMenuW(hSearchMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hSearchMenu, MF_STRING, IDM_SEARCH_GOTOLINE, L"&Go to Line...\tCtrl+G");
+	AppendMenuW(hSearchMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hSearchMenu, MF_STRING, IDM_SEARCH_BOOKMARK_TOGGLE, L"Toggle &Bookmark\tCtrl+F2");
+	AppendMenuW(hSearchMenu, MF_STRING, IDM_SEARCH_BOOKMARK_NEXT, L"Ne&xt Bookmark\tF2");
+	AppendMenuW(hSearchMenu, MF_STRING, IDM_SEARCH_BOOKMARK_PREV, L"Pre&vious Bookmark\tShift+F2");
+	AppendMenuW(hSearchMenu, MF_STRING, IDM_SEARCH_BOOKMARK_CLEARALL, L"Clear All Book&marks");
+	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hSearchMenu), L"&Search");
+
+	// View menu
+	HMENU hViewMenu = CreatePopupMenu();
+	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_WORDWRAP, L"&Word Wrap");
+	AppendMenuW(hViewMenu, MF_STRING | (g_showLineNumbers ? MF_CHECKED : MF_UNCHECKED), IDM_VIEW_LINENUMBER, L"&Line Numbers");
+	AppendMenuW(hViewMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_FOLDALL, L"&Fold All");
+	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_UNFOLDALL, L"&Unfold All");
+	AppendMenuW(hViewMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_SPLIT, L"&Split View");
+	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_UNSPLIT, L"&Unsplit View");
+	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_MOVETOOTHER, L"&Move to Other View");
+	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_CLONETOOTHER, L"&Clone to Other View");
+	AppendMenuW(hViewMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_PREFERENCES, L"&Preferences...\tCtrl+,");
+	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hViewMenu), L"&View");
+
+	// Format menu
+	HMENU hFormatMenu = CreatePopupMenu();
+
+	HMENU hEolMenu = CreatePopupMenu();
+	AppendMenuW(hEolMenu, MF_STRING, IDM_FORMAT_EOL_LF, L"Unix (LF)");
+	AppendMenuW(hEolMenu, MF_STRING, IDM_FORMAT_EOL_CRLF, L"Windows (CR LF)");
+	AppendMenuW(hEolMenu, MF_STRING, IDM_FORMAT_EOL_CR, L"Mac Classic (CR)");
+	AppendMenuW(hFormatMenu, MF_POPUP, reinterpret_cast<UINT_PTR>(hEolMenu), L"&EOL Conversion");
+
+	HMENU hEncMenu = CreatePopupMenu();
+	AppendMenuW(hEncMenu, MF_STRING, IDM_FORMAT_ENC_UTF8, L"UTF-8");
+	AppendMenuW(hEncMenu, MF_STRING, IDM_FORMAT_ENC_UTF8BOM, L"UTF-8 BOM");
+	AppendMenuW(hEncMenu, MF_STRING, IDM_FORMAT_ENC_UTF16LE, L"UTF-16 LE");
+	AppendMenuW(hEncMenu, MF_STRING, IDM_FORMAT_ENC_UTF16BE, L"UTF-16 BE");
+	AppendMenuW(hEncMenu, MF_STRING, IDM_FORMAT_ENC_ANSI, L"ANSI");
+	AppendMenuW(hFormatMenu, MF_POPUP, reinterpret_cast<UINT_PTR>(hEncMenu), L"&Encoding");
+
+	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hFormatMenu), L"F&ormat");
+
+	// Language menu
+	HMENU hLangMenu = CreatePopupMenu();
+	for (int i = 0; i < g_numLanguages; ++i)
+	{
+		NSString* name = [NSString stringWithUTF8String:g_languages[i].name];
+		std::wstring wname = NSStringToWide(name);
+		AppendMenuW(hLangMenu, MF_STRING, g_languages[i].menuId, wname.c_str());
+	}
+	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hLangMenu), L"&Language");
+
+	return hMenuBar;
+}
+
+// ============================================================
+// Configure Scintilla
+// ============================================================
+
+static void configureScintilla(void* sci)
+{
+	if (!sci) return;
+
+	ScintillaBridge_sendMessage(sci, SCI_SETCODEPAGE, 65001, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETWRAPMODE, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTABWIDTH, g_tabWidth, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETUSETABS, 0, 0);
+
+	// Line number margin
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINTYPEN, 0, 1); // SC_MARGIN_NUMBER
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINWIDTHN, 0, 50);
+
+	// Bookmark margin (margin 1)
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINTYPEN, 1, 0); // SC_MARGIN_SYMBOL
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINWIDTHN, 1, 16);
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINMASKN, 1, BOOKMARK_MASK);
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINSENSITIVEN, 1, 1);
+
+	// Configure bookmark marker appearance
+	ScintillaBridge_sendMessage(sci, SCI_MARKERDEFINE, BOOKMARK_MARKER, SC_MARK_BOOKMARK);
+	ScintillaBridge_sendMessage(sci, SCI_MARKERSETFORE, BOOKMARK_MARKER, 0xFFFFFF);
+	ScintillaBridge_sendMessage(sci, SCI_MARKERSETBACK, BOOKMARK_MARKER, 0xFF8000);
+
+	// Code folding margin (margin 2) — SC_MARGIN_SYMBOL (0), not SC_MARGIN_TEXT (4)
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINTYPEN, 2, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINMASKN, 2, SC_MASK_FOLDERS);
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINWIDTHN, 2, 16);
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINSENSITIVEN, 2, 1);
+
+	// Define fold marker symbols (box tree style)
+	ScintillaBridge_sendMessage(sci, SCI_MARKERDEFINE, SC_MARKNUM_FOLDEROPEN,    SC_MARK_BOXMINUS);
+	ScintillaBridge_sendMessage(sci, SCI_MARKERDEFINE, SC_MARKNUM_FOLDER,        SC_MARK_BOXPLUS);
+	ScintillaBridge_sendMessage(sci, SCI_MARKERDEFINE, SC_MARKNUM_FOLDERSUB,     SC_MARK_VLINE);
+	ScintillaBridge_sendMessage(sci, SCI_MARKERDEFINE, SC_MARKNUM_FOLDERTAIL,    SC_MARK_LCORNER);
+	ScintillaBridge_sendMessage(sci, SCI_MARKERDEFINE, SC_MARKNUM_FOLDEREND,     SC_MARK_BOXPLUSCONNECTED);
+	ScintillaBridge_sendMessage(sci, SCI_MARKERDEFINE, SC_MARKNUM_FOLDEROPENMID, SC_MARK_BOXMINUSCONNECTED);
+	ScintillaBridge_sendMessage(sci, SCI_MARKERDEFINE, SC_MARKNUM_FOLDERMIDTAIL, SC_MARK_TCORNER);
+
+	// Fold flags and automatic fold on margin click
+	ScintillaBridge_sendMessage(sci, SCI_SETFOLDFLAGS, 16, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETAUTOMATICFOLD, SC_AUTOMATICFOLD_CLICK, 0);
+
+	ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEVISIBLE, 1, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEBACK, 0xF0F0F0, 0);
+}
+
+// ============================================================
+// Dark mode support
+// ============================================================
+
+static void applyFoldMarkerColors(bool isDark)
+{
+	if (!g_scintillaView) return;
+	int fgColor = isDark ? 0xD4D4D4 : 0x808080;
+	int bgColor = isDark ? 0x2D2D2D : 0xF0F0F0;
+	for (int m = SC_MARKNUM_FOLDEREND; m <= SC_MARKNUM_FOLDEROPEN; ++m)
+	{
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERSETFORE, m, fgColor);
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERSETBACK, m, bgColor);
+	}
+}
+
+static void applyAppearance()
+{
+	if (!g_scintillaView) return;
+
+	NSAppearanceName appearanceName = [NSApp.effectiveAppearance
+		bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
+	bool isDark = [appearanceName isEqualToString:NSAppearanceNameDarkAqua];
+
+	// Set STYLE_DEFAULT colors
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETFORE, 32, isDark ? 0xD4D4D4 : 0x000000);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETBACK, 32, isDark ? 0x1E1E1E : 0xFFFFFF);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLECLEARALL, 0, 0); // propagate to all
+
+	// Apply per-lexer syntax styles
+	int langIdx = 0;
+	if (g_activeTab >= 0 && g_activeTab < static_cast<int>(g_documents.size()))
+		langIdx = g_documents[g_activeTab].languageIndex;
+	if (langIdx >= 0 && langIdx < g_numLanguages)
+	{
+		const LexerStyles* ls = findLexerStyles(g_languages[langIdx].lexerName);
+		if (ls)
+		{
+			for (int i = 0; i < ls->numStyles; ++i)
+			{
+				const auto& s = ls->styles[i];
+				ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETFORE, s.styleId,
+					isDark ? s.darkFore : s.lightFore);
+				if (s.bold)
+					ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETBOLD, s.styleId, 1);
+				if (s.italic)
+					ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETITALIC, s.styleId, 1);
+			}
+		}
+	}
+
+	// Caret, caret line
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETCARETFORE, isDark ? 0xAEAFAD : 0x000000, 0);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_SETCARETLINEBACK, isDark ? 0x2A2A2A : 0xF0F0F0, 0);
+
+	// Line number margin
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETFORE, 33, isDark ? 0x858585 : 0x808080);
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_STYLESETBACK, 33, isDark ? 0x1E1E1E : 0xF0F0F0);
+
+	// Bookmark marker
+	ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERSETBACK, BOOKMARK_MARKER,
+		isDark ? 0xFFA050 : 0xFF8000);
+
+	// Fold marker colors
+	applyFoldMarkerColors(isDark);
+}
+
+// ============================================================
+// Application Delegate
+// ============================================================
+
+// Drag-and-drop support view
+@interface NppDropTargetView : NSView
+@end
+
+@implementation NppDropTargetView
+
+- (NSDragOperation)draggingEntered:(id<NSDraggingInfo>)sender
+{
+	NSPasteboard* pb = [sender draggingPasteboard];
+	if ([pb canReadObjectForClasses:@[[NSURL class]] options:@{NSPasteboardURLReadingFileURLsOnlyKey: @YES}])
+		return NSDragOperationCopy;
+	return NSDragOperationNone;
+}
+
+- (BOOL)performDragOperation:(id<NSDraggingInfo>)sender
+{
+	NSPasteboard* pb = [sender draggingPasteboard];
+	NSArray<NSURL*>* urls = [pb readObjectsForClasses:@[[NSURL class]]
+	                                          options:@{NSPasteboardURLReadingFileURLsOnlyKey: @YES}];
+	if (!urls || urls.count == 0) return NO;
+
+	for (NSURL* url in urls)
+	{
+		if (url.isFileURL)
+			openFileAtPath(url.path);
+	}
+	return YES;
+}
+
+// Pass through all mouse events to underlying views
+- (NSView*)hitTest:(NSPoint)point
+{
+	return nil;
+}
+
+@end
+
+@interface NppPhase7Delegate : NSObject <NSApplicationDelegate, NSWindowDelegate>
+- (void)performContextAction:(NSMenuItem*)sender;
+@end
+
+@implementation NppPhase7Delegate
+
+- (void)applicationDidFinishLaunching:(NSNotification*)notification
+{
+	// Load persisted settings
+	SettingsManager::instance().load();
+	auto& s = SettingsManager::instance().settings;
+	g_fontName = s.fontName;
+	g_fontSize = s.fontSize;
+	g_tabWidth = s.tabWidth;
+	g_showLineNumbers = s.showLineNumbers;
+
+	// Restore recent files from settings
+	g_recentFiles.clear();
+	for (const auto& f : s.recentFiles)
+	{
+		NSString* nsf = [NSString stringWithUTF8String:f.c_str()];
+		g_recentFiles.push_back(NSStringToWide(nsf));
+	}
+
+	// Register window class
+	WNDCLASSEXW wc = {};
+	wc.cbSize = sizeof(wc);
+	wc.lpfnWndProc = MainWndProc;
+	wc.lpszClassName = L"Notepad++Phase7";
+	RegisterClassExW(&wc);
+
+	// Build menu bar
+	HMENU hMenuBar = buildMenuBar();
+
+	// Create main window with saved geometry
+	g_mainHwnd = CreateWindowExW(
+		0, L"Notepad++Phase7", L"Notepad++ (macOS) — Phase 7",
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT, CW_USEDEFAULT,
+		static_cast<int>(s.windowWidth), static_cast<int>(s.windowHeight),
+		nullptr, hMenuBar, nullptr, nullptr
+	);
+
+	if (!g_mainHwnd)
+	{
+		NSLog(@"ERROR: Failed to create main window!");
+		return;
+	}
+
+	auto* mainInfo = HandleRegistry::getWindowInfo(g_mainHwnd);
+	if (mainInfo && mainInfo->nativeWindow)
+	{
+		g_mainWindow = (__bridge NSWindow*)mainInfo->nativeWindow;
+		g_mainWindow.delegate = self;
+		[g_mainWindow setMinSize:NSMakeSize(500, 400)];
+
+		// Restore window position
+		if (s.windowX != 100 || s.windowY != 100)
+		{
+			NSRect frame = g_mainWindow.frame;
+			frame.origin.x = s.windowX;
+			frame.origin.y = s.windowY;
+			[g_mainWindow setFrame:frame display:YES];
+		}
+	}
+
+	SetMenu(g_mainHwnd, hMenuBar);
+
+	NSView* contentView = g_mainWindow.contentView;
+
+	// Create tab control at top
+	g_tabHwnd = CreateWindowExW(
+		0, L"SysTabControl32", L"",
+		WS_CHILD | WS_VISIBLE | TCS_FOCUSNEVER,
+		0, 0,
+		static_cast<int>(contentView.bounds.size.width), 28,
+		g_mainHwnd,
+		reinterpret_cast<HMENU>(IDC_TABBAR),
+		nullptr, nullptr
+	);
+
+	// Create status bar at bottom
+	g_statusBarHwnd = CreateWindowExW(
+		0, L"msctls_statusbar32", L"",
+		WS_CHILD | WS_VISIBLE | SBARS_SIZEGRIP,
+		0, 0, 0, 0,
+		g_mainHwnd,
+		reinterpret_cast<HMENU>(IDC_STATUSBAR),
+		nullptr, nullptr
+	);
+
+	int parts[] = {180, 360, 480, 570, 630, -1};
+	SendMessageW(g_statusBarHwnd, SB_SETPARTS, 6, reinterpret_cast<LPARAM>(parts));
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 0, reinterpret_cast<LPARAM>(L"Ln 1, Col 1"));
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 1, reinterpret_cast<LPARAM>(L"0 lines"));
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 2, reinterpret_cast<LPARAM>(L"C++"));
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 3, reinterpret_cast<LPARAM>(L"UTF-8"));
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 4, reinterpret_cast<LPARAM>(L"LF"));
+	SendMessageW(g_statusBarHwnd, SB_SETTEXTW, 5, reinterpret_cast<LPARAM>(L"Ready"));
+
+	// Create Scintilla editor
+	CGFloat tabHeight = 28;
+	CGFloat statusHeight = 22;
+	CGFloat editorHeight = contentView.bounds.size.height - tabHeight - statusHeight;
+
+	if (g_statusBarHwnd)
+	{
+		auto* sbInfo = HandleRegistry::getWindowInfo(g_statusBarHwnd);
+		if (sbInfo && sbInfo->nativeView)
+		{
+			NSView* sbView = (__bridge NSView*)sbInfo->nativeView;
+			sbView.frame = NSMakeRect(0, 0, contentView.bounds.size.width, statusHeight);
+			sbView.autoresizingMask = NSViewWidthSizable | NSViewMaxYMargin;
+		}
+	}
+
+	NSRect editorFrame = NSMakeRect(0, statusHeight, contentView.bounds.size.width, editorHeight);
+	g_editorContainer = [[NSView alloc] initWithFrame:editorFrame];
+	g_editorContainer.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+	[contentView addSubview:g_editorContainer];
+
+	g_scintillaView = ScintillaBridge_createView((__bridge void*)g_editorContainer, 0, 0, 0, 0);
+	if (!g_scintillaView)
+	{
+		NSLog(@"ERROR: Failed to create ScintillaView!");
+		return;
+	}
+
+	configureScintilla(g_scintillaView);
+	applyAppearance();
+
+	// Register Scintilla notification callback for margin clicks
+	ScintillaBridge_setNotifyCallback(g_scintillaView, (intptr_t)g_mainHwnd,
+		[](intptr_t windowid, unsigned int iMessage, uintptr_t wParam, uintptr_t lParam) {
+			// iMessage 1002 = WM_NOTIFY in Cocoa Scintilla convention
+			if (iMessage == 1002 && lParam)
+			{
+				// lParam points to a Cocoa Scintilla notification struct
+				// The notification code is at offset of nmhdr.code
+				struct SciNotifyHeader {
+					void* hwndFrom;
+					uintptr_t idFrom;
+					unsigned int code;
+				};
+				struct SciNotify {
+					SciNotifyHeader nmhdr;
+					intptr_t position;
+					int ch;
+					int modifiers;
+					int modificationType;
+					const char* text;
+					intptr_t length;
+					intptr_t linesAdded;
+					int message;
+					uintptr_t wParam;
+					intptr_t sLParam;
+					intptr_t line;
+					int foldLevelNow;
+					int foldLevelPrev;
+					int margin;
+				};
+				auto* scn = reinterpret_cast<const SciNotify*>(lParam);
+
+				if (scn->nmhdr.code == 2010) // SCN_MARGINCLICK
+				{
+					if (scn->margin == 1 && g_scintillaView) // Bookmark margin
+					{
+						intptr_t line = ScintillaBridge_sendMessage(g_scintillaView,
+							SCI_LINEFROMPOSITION, scn->position, 0);
+						intptr_t markers = ScintillaBridge_sendMessage(g_scintillaView,
+							SCI_MARKERGET, line, 0);
+						if (markers & BOOKMARK_MASK)
+							ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERDELETE, line, BOOKMARK_MARKER);
+						else
+							ScintillaBridge_sendMessage(g_scintillaView, SCI_MARKERADD, line, BOOKMARK_MARKER);
+					}
+					// Fold margin (margin 2) is handled automatically by SC_AUTOMATICFOLD_CLICK
+				}
+			}
+		});
+
+	// Create first document
+		const char* welcomeText =
+		"// Welcome to Notepad++ on macOS \xe2\x80\x94 Phase 7!\n"
+		"//\n"
+		"// What's new in Phase 7:\n"
+		"//   - Settings persistence (window pos, font, recent files)\n"
+		"//   - Session management (restores tabs on relaunch)\n"
+		"//   - Split view (View > Split View)\n"
+		"//   - Edit commands (case conversion, line ops, comments, sort)\n"
+		"//   - Encoding support (UTF-8, UTF-16 LE/BE, ANSI, BOM)\n"
+		"//   - EOL conversion (LF, CRLF, CR) via Format menu\n"
+		"//   - Drag and drop files from Finder\n"
+		"//\n"
+		"// Includes all Phase 1-6 features:\n"
+		"//   Syntax highlighting, code folding, regex search, bookmarks,\n"
+		"//   auto-completion, recent files, preferences, language selection\n"
+		"\n"
+		"#include <iostream>\n"
+		"#include <string>\n"
+		"#include <vector>\n"
+		"#include <memory>\n"
+		"\n"
+		"namespace demo {\n"
+		"\n"
+		"// A template class to demonstrate syntax highlighting\n"
+		"template <typename T>\n"
+		"class Container {\n"
+		"public:\n"
+		"    explicit Container(size_t capacity)\n"
+		"        : _data(std::make_unique<T[]>(capacity))\n"
+		"        , _capacity(capacity)\n"
+		"        , _size(0) {}\n"
+		"\n"
+		"    void push_back(const T& value) {\n"
+		"        if (_size < _capacity) {\n"
+		"            _data[_size++] = value;\n"
+		"        }\n"
+		"    }\n"
+		"\n"
+		"    T& operator[](size_t index) {\n"
+		"        return _data[index];\n"
+		"    }\n"
+		"\n"
+		"    size_t size() const { return _size; }\n"
+		"\n"
+		"private:\n"
+		"    std::unique_ptr<T[]> _data;\n"
+		"    size_t _capacity;\n"
+		"    size_t _size;\n"
+		"};\n"
+		"\n"
+		"} // namespace demo\n"
+		"\n"
+		"/* Multi-line comment:\n"
+		"   Demonstrates comment folding and styling */\n"
+		"\n"
+		"int main() {\n"
+		"    demo::Container<std::string> names(10);\n"
+		"    names.push_back(\"Hello\");\n"
+		"    names.push_back(\"World\");\n"
+		"\n"
+		"    for (size_t i = 0; i < names.size(); ++i) {\n"
+		"        std::cout << \"Item \" << i << \": \" << names[i] << std::endl;\n"
+		"    }\n"
+		"\n"
+		"    constexpr double pi = 3.14159;\n"
+		"    int count = 42;\n"
+		"    bool found = true;\n"
+		"\n"
+		"    #ifdef DEBUG\n"
+		"    std::cout << \"Debug mode\" << std::endl;\n"
+		"    #endif\n"
+		"\n"
+		"    return 0;\n"
+		"}\n";
+
+	addNewTab(L"Welcome", std::string(welcomeText));
+
+	// Apply saved view state
+	if (s.wordWrap && g_scintillaView)
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETWRAPMODE, 1, 0);
+	if (!g_showLineNumbers && g_scintillaView)
+		ScintillaBridge_sendMessage(g_scintillaView, SCI_SETMARGINWIDTHN, 0, 0);
+
+	// Rebuild recent files menu
+	rebuildRecentMenu();
+
+	// Start status bar update timer
+	SetTimer(g_mainHwnd, IDT_STATUSBAR, 500, nullptr);
+
+	// Initialize file monitor
+	g_fileMonitor = new FileMonitorMac();
+
+	// Show the window
+	ShowWindow(g_mainHwnd, SW_SHOW);
+	[NSApp activateIgnoringOtherApps:YES];
+
+	// Register for drag and drop
+	{
+		NppDropTargetView* dropView = [[NppDropTargetView alloc] initWithFrame:contentView.bounds];
+		dropView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+		[dropView registerForDraggedTypes:@[NSPasteboardTypeFileURL]];
+		// Add as top-most subview but let events pass through
+		[contentView addSubview:dropView positioned:NSWindowAbove relativeTo:nil];
+	}
+
+	// Listen for appearance changes
+	[NSDistributedNotificationCenter.defaultCenter
+		addObserver:self
+		   selector:@selector(appearanceChanged:)
+		       name:@"AppleInterfaceThemeChangedNotification"
+		     object:nil];
+
+	// Restore session
+	restoreSession();
+
+	NSLog(@"=== Notepad++ macOS Port — Phase 7 ===");
+	NSLog(@"Settings, split view, edit commands, encoding, session, drag-and-drop!");
+}
+
+- (void)appearanceChanged:(NSNotification*)notification
+{
+	dispatch_async(dispatch_get_main_queue(), ^{
+		applyAppearance();
+		if (g_scintillaView)
+			ScintillaBridge_sendMessage(g_scintillaView, SCI_COLOURISE, 0, -1);
+	});
+}
+
+- (void)performContextAction:(NSMenuItem*)sender
+{
+	if (g_mainHwnd)
+		SendMessageW(g_mainHwnd, WM_COMMAND, MAKEWPARAM(static_cast<WORD>(sender.tag), 0), 0);
+}
+
+- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication*)sender
+{
+	return YES;
+}
+
+- (void)applicationWillTerminate:(NSNotification*)notification
+{
+	// Save session
+	saveSession();
+
+	// Save settings
+	auto& s = SettingsManager::instance().settings;
+	if (g_mainWindow)
+	{
+		NSRect frame = g_mainWindow.frame;
+		s.windowX = frame.origin.x;
+		s.windowY = frame.origin.y;
+		s.windowWidth = frame.size.width;
+		s.windowHeight = frame.size.height;
+	}
+	s.fontName = g_fontName;
+	s.fontSize = g_fontSize;
+	s.tabWidth = g_tabWidth;
+	s.showLineNumbers = g_showLineNumbers;
+	s.wordWrap = g_scintillaView ?
+		(ScintillaBridge_sendMessage(g_scintillaView, SCI_GETWRAPMODE, 0, 0) != 0) : false;
+
+	s.recentFiles.clear();
+	for (const auto& rf : g_recentFiles)
+	{
+		NSString* ns = WideToNSString(rf.c_str());
+		s.recentFiles.push_back([ns UTF8String]);
+	}
+	SettingsManager::instance().save();
+
+	if (g_fileMonitor)
+	{
+		g_fileMonitor->terminate();
+		delete g_fileMonitor;
+		g_fileMonitor = nullptr;
+	}
+}
+
+- (void)windowDidResize:(NSNotification*)notification
+{
+	if (g_scintillaView)
+		ScintillaBridge_resizeToFit(g_scintillaView);
+	if (g_isSplit && g_scintillaView2)
+		ScintillaBridge_resizeToFit(g_scintillaView2);
+
+	if (g_tabHwnd && g_mainWindow)
+	{
+		auto* tabInfo = HandleRegistry::getWindowInfo(g_tabHwnd);
+		if (tabInfo && tabInfo->nativeView)
+		{
+			NSView* tabView = (__bridge NSView*)tabInfo->nativeView;
+			NSRect f = tabView.frame;
+			f.size.width = g_mainWindow.contentView.bounds.size.width;
+			tabView.frame = f;
+		}
+	}
+}
+
+@end
+
+// ============================================================
+// Entry point
+// ============================================================
+
+int main(int argc, const char* argv[])
+{
+	@autoreleasepool
+	{
+		NSApplication* app = [NSApplication sharedApplication];
+		[app setActivationPolicy:NSApplicationActivationPolicyRegular];
+
+		NppPhase7Delegate* delegate = [[NppPhase7Delegate alloc] init];
+		app.delegate = delegate;
+
+		[app run];
+	}
+	return 0;
+}

--- a/macos/platform/settings_manager.h
+++ b/macos/platform/settings_manager.h
@@ -1,0 +1,50 @@
+#pragma once
+// Settings Manager for Notepad++ macOS Port
+// Reads/writes settings to ~/.npp-macos/settings.json using NSJSONSerialization.
+
+#include <string>
+#include <vector>
+
+struct AppSettings
+{
+	// Window geometry
+	double windowX = 100;
+	double windowY = 100;
+	double windowWidth = 1000;
+	double windowHeight = 750;
+
+	// Editor preferences
+	std::string fontName = "Menlo";
+	int fontSize = 13;
+	int tabWidth = 4;
+
+	// View state
+	bool wordWrap = false;
+	bool showLineNumbers = true;
+
+	// Dark mode: 0=follow system, 1=force light, 2=force dark
+	int darkModePreference = 0;
+
+	// Recent files
+	std::vector<std::string> recentFiles;
+};
+
+class SettingsManager
+{
+public:
+	static SettingsManager& instance();
+
+	// Load settings from ~/.npp-macos/settings.json
+	// Returns true if file was found and parsed successfully.
+	bool load();
+
+	// Save current settings to ~/.npp-macos/settings.json
+	bool save();
+
+	AppSettings settings;
+
+private:
+	SettingsManager() = default;
+	std::string settingsDir() const;
+	std::string settingsPath() const;
+};

--- a/macos/platform/settings_manager.mm
+++ b/macos/platform/settings_manager.mm
@@ -1,0 +1,103 @@
+// Settings Manager for Notepad++ macOS Port
+// Persists user settings to ~/.npp-macos/settings.json using NSJSONSerialization.
+
+#import <Foundation/Foundation.h>
+#include "settings_manager.h"
+
+SettingsManager& SettingsManager::instance()
+{
+	static SettingsManager mgr;
+	return mgr;
+}
+
+std::string SettingsManager::settingsDir() const
+{
+	NSString* home = NSHomeDirectory();
+	return std::string([home UTF8String]) + "/.npp-macos";
+}
+
+std::string SettingsManager::settingsPath() const
+{
+	return settingsDir() + "/settings.json";
+}
+
+bool SettingsManager::load()
+{
+	NSString* path = [NSString stringWithUTF8String:settingsPath().c_str()];
+	NSData* data = [NSData dataWithContentsOfFile:path];
+	if (!data) return false;
+
+	NSError* error = nil;
+	NSDictionary* json = [NSJSONSerialization JSONObjectWithData:data
+	                                                    options:0
+	                                                      error:&error];
+	if (!json || error) return false;
+
+	// Window geometry
+	if (json[@"windowX"])      settings.windowX = [json[@"windowX"] doubleValue];
+	if (json[@"windowY"])      settings.windowY = [json[@"windowY"] doubleValue];
+	if (json[@"windowWidth"])  settings.windowWidth = [json[@"windowWidth"] doubleValue];
+	if (json[@"windowHeight"]) settings.windowHeight = [json[@"windowHeight"] doubleValue];
+
+	// Editor preferences
+	if (json[@"fontName"])  settings.fontName = [json[@"fontName"] UTF8String];
+	if (json[@"fontSize"])  settings.fontSize = [json[@"fontSize"] intValue];
+	if (json[@"tabWidth"])  settings.tabWidth = [json[@"tabWidth"] intValue];
+
+	// View state
+	if (json[@"wordWrap"])        settings.wordWrap = [json[@"wordWrap"] boolValue];
+	if (json[@"showLineNumbers"]) settings.showLineNumbers = [json[@"showLineNumbers"] boolValue];
+	if (json[@"darkModePreference"]) settings.darkModePreference = [json[@"darkModePreference"] intValue];
+
+	// Recent files
+	settings.recentFiles.clear();
+	NSArray* recent = json[@"recentFiles"];
+	if ([recent isKindOfClass:[NSArray class]])
+	{
+		for (NSString* f in recent)
+		{
+			if ([f isKindOfClass:[NSString class]])
+				settings.recentFiles.push_back([f UTF8String]);
+		}
+	}
+
+	return true;
+}
+
+bool SettingsManager::save()
+{
+	// Ensure directory exists
+	NSString* dir = [NSString stringWithUTF8String:settingsDir().c_str()];
+	[[NSFileManager defaultManager] createDirectoryAtPath:dir
+	                          withIntermediateDirectories:YES
+	                                          attributes:nil
+	                                               error:nil];
+
+	// Build JSON dictionary
+	NSMutableArray* recentArr = [NSMutableArray array];
+	for (const auto& f : settings.recentFiles)
+		[recentArr addObject:[NSString stringWithUTF8String:f.c_str()]];
+
+	NSDictionary* json = @{
+		@"windowX":      @(settings.windowX),
+		@"windowY":      @(settings.windowY),
+		@"windowWidth":  @(settings.windowWidth),
+		@"windowHeight": @(settings.windowHeight),
+		@"fontName":     [NSString stringWithUTF8String:settings.fontName.c_str()],
+		@"fontSize":     @(settings.fontSize),
+		@"tabWidth":     @(settings.tabWidth),
+		@"wordWrap":     @(settings.wordWrap),
+		@"showLineNumbers": @(settings.showLineNumbers),
+		@"darkModePreference": @(settings.darkModePreference),
+		@"recentFiles":  recentArr,
+	};
+
+	NSError* error = nil;
+	NSData* data = [NSJSONSerialization dataWithJSONObject:json
+	                                              options:NSJSONWritingPrettyPrinted
+	                                                error:&error];
+	if (!data || error) return false;
+
+	NSString* path = [NSString stringWithUTF8String:settingsPath().c_str()];
+	return [data writeToFile:path atomically:YES];
+}

--- a/macos/shim/src/win32_menu.mm
+++ b/macos/shim/src/win32_menu.mm
@@ -352,6 +352,11 @@ BOOL SetMenu(HWND hWnd, HMENU hMenu)
 	}
 
 	[NSApp setMainMenu:mainMenu];
+
+	// Update the menu registry so hMenu now resolves to mainMenu
+	// (the original NSMenu is empty after moving items)
+	s_menuMap[@(reinterpret_cast<uintptr_t>(hMenu))] = mainMenu;
+
 	return TRUE;
 }
 


### PR DESCRIPTION
## Summary
- **Settings persistence**: SettingsManager singleton with JSON storage (~/.npp-macos/settings.json) for window geometry, font, tab width, word wrap, line numbers, recent files, dark mode
- **Session management**: Save/restore open tabs with cursor positions, language, encoding, and EOL mode (~/.npp-macos/session.json)
- **Split view**: NSSplitView-based dual editor with Move to Other View and Clone to Other View
- **Edit commands**: Case conversion (upper/lower/title), line operations (duplicate, delete, sort, join, trim trailing, remove empty), toggle comment
- **Encoding support**: UTF-8, UTF-8 BOM, UTF-16 LE/BE, ANSI with uchardet auto-detection; encoding/EOL conversion menus
- **Drag-and-drop**: File opening via NppDropTargetView overlay
- **Bug fixes**: Line numbers not displaying (wrong margin type), menu checkmarks not updating (SetMenu registry bug in win32_menu.mm)

## Test plan
- [ ] Build: `cd macos/build && cmake --build . --target npp_phase7_app`
- [ ] Launch and verify line numbers display in left margin
- [ ] Toggle View > Line Numbers — checkmark and margin should sync
- [ ] Toggle View > Word Wrap — checkmark should sync
- [ ] Open multiple files, close and relaunch — session should restore tabs
- [ ] Test split view: View > Split View, move/clone tabs between panes
- [ ] Test edit commands: case conversion, line duplicate/delete, toggle comment
- [ ] Open files with different encodings (UTF-8 BOM, UTF-16) — verify correct display
- [ ] Drag-and-drop a file onto the window — should open in a new tab
- [ ] Change preferences (font, tab width) — should persist across relaunch

🤖 Generated with [Claude Code](https://claude.com/claude-code)