### PR TITLE
Sprint: Data safety, Finder integration, app polish (6 P0 issues)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,35 @@ Notepad++ is a Windows-native source code editor written in C++20. It wraps the 
 
 ## Build Commands
 
-### MSBuild (primary, requires Visual Studio 2022 v143 toolset)
+### macOS Port (CMake + Xcode generator)
+
+Working directory: `macos/build/`
+
+```bash
+# First-time setup (or full clean rebuild)
+cd macos/build
+rm -rf *
+cmake -G Xcode ..
+
+# Build the app (development binary)
+cmake --build . --target MacOSNotePP
+
+# Build the .app bundle (for testing Finder integration, icon, etc.)
+cmake --build . --target MacOSNotePP_package
+
+# Build unsigned DMG for distribution
+cmake --build . --target MacOSNotePP_dmg
+
+# Run the app (development build)
+./Debug/MacOSNotePP
+
+# Run the packaged app
+open ../dist/MacNote++.app
+```
+
+**Important:** Use the Xcode generator (`-G Xcode`). The default Makefiles generator fails on deeply nested object paths in this repo. The Xcode generator is required for reliable builds.
+
+### MSBuild — Windows (primary, requires Visual Studio 2022 v143 toolset)
 
 ```
 msbuild PowerEditor\visual.net\notepadPlus.sln /p:Configuration=Debug /p:Platform=x64

--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -284,6 +284,29 @@ target_link_libraries(win32shim PUBLIC
 )
 
 # ============================================================
+# App icon generation (.icns from logo.png)
+# ============================================================
+set(ICONSET_DIR "${CMAKE_BINARY_DIR}/AppIcon.iconset")
+add_custom_command(
+    OUTPUT "${CMAKE_BINARY_DIR}/AppIcon.icns"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${ICONSET_DIR}"
+    COMMAND sips -z 16 16     "${NPP_ROOT}/logo.png" --out "${ICONSET_DIR}/icon_16x16.png"
+    COMMAND sips -z 32 32     "${NPP_ROOT}/logo.png" --out "${ICONSET_DIR}/icon_16x16@2x.png"
+    COMMAND sips -z 32 32     "${NPP_ROOT}/logo.png" --out "${ICONSET_DIR}/icon_32x32.png"
+    COMMAND sips -z 64 64     "${NPP_ROOT}/logo.png" --out "${ICONSET_DIR}/icon_32x32@2x.png"
+    COMMAND sips -z 128 128   "${NPP_ROOT}/logo.png" --out "${ICONSET_DIR}/icon_128x128.png"
+    COMMAND sips -z 256 256   "${NPP_ROOT}/logo.png" --out "${ICONSET_DIR}/icon_128x128@2x.png"
+    COMMAND sips -z 256 256   "${NPP_ROOT}/logo.png" --out "${ICONSET_DIR}/icon_256x256.png"
+    COMMAND sips -z 512 512   "${NPP_ROOT}/logo.png" --out "${ICONSET_DIR}/icon_256x256@2x.png"
+    COMMAND sips -z 512 512   "${NPP_ROOT}/logo.png" --out "${ICONSET_DIR}/icon_512x512.png"
+    COMMAND sips -z 583 583   "${NPP_ROOT}/logo.png" --out "${ICONSET_DIR}/icon_512x512@2x.png"
+    COMMAND iconutil -c icns "${ICONSET_DIR}" -o "${CMAKE_BINARY_DIR}/AppIcon.icns"
+    DEPENDS "${NPP_ROOT}/logo.png"
+    COMMENT "Generating AppIcon.icns from logo.png"
+)
+add_custom_target(AppIcon DEPENDS "${CMAKE_BINARY_DIR}/AppIcon.icns")
+
+# ============================================================
 # Main macOS app target
 # ============================================================
 add_executable(MacOSNotePP
@@ -310,6 +333,8 @@ add_executable(MacOSNotePP
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/recent_files.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/settings_manager.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/file_monitor_mac.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/save_prompt.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/about_dialog.mm"
 )
 target_include_directories(MacOSNotePP PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/platform"
@@ -335,11 +360,15 @@ target_compile_options(MacOSNotePP PRIVATE
     -fobjc-arc
     -Wno-deprecated-declarations
 )
+add_dependencies(MacOSNotePP AppIcon)
 add_custom_command(TARGET MacOSNotePP POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "${NPP_ROOT}/logo.png"
         "$<TARGET_FILE_DIR:MacOSNotePP>/logo.png"
-    COMMENT "Copying logo.png for Dock icon"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${CMAKE_BINARY_DIR}/AppIcon.icns"
+        "$<TARGET_FILE_DIR:MacOSNotePP>/AppIcon.icns"
+    COMMENT "Copying logo.png and AppIcon.icns"
 )
 
 # ============================================================
@@ -375,6 +404,9 @@ add_custom_target(MacOSNotePP_package
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "${NPP_ROOT}/logo.png"
         "${NPP_MACOS_APP_RESOURCES}/logo.png"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${CMAKE_BINARY_DIR}/AppIcon.icns"
+        "${NPP_MACOS_APP_RESOURCES}/AppIcon.icns"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "${NPP_MACOS_INFO_PLIST}"
         "${NPP_MACOS_APP_CONTENTS}/Info.plist"

--- a/macos/platform/MacNoteInfo.plist.in
+++ b/macos/platform/MacNoteInfo.plist.in
@@ -30,5 +30,69 @@
   <string>13.0</string>
   <key>LSApplicationCategoryType</key>
   <string>public.app-category.developer-tools</string>
+  <key>CFBundleDocumentTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>Plain Text</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>public.plain-text</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>Source Code</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>public.source-code</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>XML Document</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>public.xml</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>JSON Document</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>public.json</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>Shell Script</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>public.shell-script</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>All Documents</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>public.text</string>
+        <string>public.data</string>
+      </array>
+    </dict>
+  </array>
 </dict>
 </plist>

--- a/macos/platform/MacNoteInfo.plist.in
+++ b/macos/platform/MacNoteInfo.plist.in
@@ -9,10 +9,12 @@
   <key>CFBundleIdentifier</key>
   <string>com.softcentral.macnotepp</string>
   <key>CFBundleIconFile</key>
-  <string>logo.png</string>
+  <string>AppIcon</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundleName</key>
+  <string>MacNote++</string>
+  <key>CFBundleDisplayName</key>
   <string>MacNote++</string>
   <key>CFBundlePackageType</key>
   <string>APPL</string>
@@ -22,5 +24,11 @@
   <string>1.0.0</string>
   <key>NSHighResolutionCapable</key>
   <true/>
+  <key>NSHumanReadableCopyright</key>
+  <string>Copyright © 2024-2026. Based on Notepad++ by Don Ho.</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>13.0</string>
+  <key>LSApplicationCategoryType</key>
+  <string>public.app-category.developer-tools</string>
 </dict>
 </plist>

--- a/macos/platform/about_dialog.h
+++ b/macos/platform/about_dialog.h
@@ -1,0 +1,6 @@
+// about_dialog.h — About dialog
+// Part of the Notepad++ macOS port modular refactor.
+
+#pragma once
+
+void showAboutDlg();

--- a/macos/platform/about_dialog.mm
+++ b/macos/platform/about_dialog.mm
@@ -4,7 +4,7 @@
 #import <Cocoa/Cocoa.h>
 #include "about_dialog.h"
 
-@interface AboutDialogController : NSObject
+@interface AboutDialogController : NSObject <NSWindowDelegate>
 - (void)openRepository:(id)sender;
 @end
 
@@ -13,6 +13,11 @@
 {
 	[[NSWorkspace sharedWorkspace] openURL:
 		[NSURL URLWithString:@"https://github.com/hybridmachine/MacOS-NotePP"]];
+}
+
+- (void)windowWillClose:(NSNotification*)notification
+{
+	[NSApp stopModal];
 }
 @end
 
@@ -26,6 +31,7 @@ void showAboutDlg()
 			defer:NO];
 		[panel setTitle:@"About MacNote++"];
 		[panel center];
+		[panel setReleasedWhenClosed:NO];
 
 		// Keep the controller alive during modal
 		AboutDialogController* controller = [[AboutDialogController alloc] init];
@@ -146,8 +152,9 @@ void showAboutDlg()
 		[okButton setKeyEquivalent:@"\r"];
 		[contentView addSubview:okButton];
 
-		// Also handle Escape to close
+		// Escape triggers the panel's close, which calls windowWillClose: → stopModal
 		[panel setDefaultButtonCell:[okButton cell]];
+		[panel setDelegate:controller];
 
 		[NSApp runModalForWindow:panel];
 		[panel close];

--- a/macos/platform/about_dialog.mm
+++ b/macos/platform/about_dialog.mm
@@ -1,0 +1,158 @@
+// about_dialog.mm — About dialog
+// Part of the Notepad++ macOS port modular refactor.
+
+#import <Cocoa/Cocoa.h>
+#include "about_dialog.h"
+
+@interface AboutDialogController : NSObject
+- (void)openRepository:(id)sender;
+@end
+
+@implementation AboutDialogController
+- (void)openRepository:(id)sender
+{
+	[[NSWorkspace sharedWorkspace] openURL:
+		[NSURL URLWithString:@"https://github.com/hybridmachine/MacOS-NotePP"]];
+}
+@end
+
+void showAboutDlg()
+{
+	@autoreleasepool {
+		NSPanel* panel = [[NSPanel alloc]
+			initWithContentRect:NSMakeRect(0, 0, 400, 360)
+			styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable
+			backing:NSBackingStoreBuffered
+			defer:NO];
+		[panel setTitle:@"About MacNote++"];
+		[panel center];
+
+		// Keep the controller alive during modal
+		AboutDialogController* controller = [[AboutDialogController alloc] init];
+
+		NSView* contentView = [panel contentView];
+		CGFloat y = 310;
+
+		// App icon
+		NSImage* logo = [NSApp applicationIconImage];
+		if (!logo)
+		{
+			NSString* dir = [[[NSBundle mainBundle] executablePath] stringByDeletingLastPathComponent];
+			logo = [[NSImage alloc] initWithContentsOfFile:[dir stringByAppendingPathComponent:@"logo.png"]];
+		}
+		if (logo)
+		{
+			NSImageView* iconView = [[NSImageView alloc] initWithFrame:NSMakeRect(168, y - 64, 64, 64)];
+			[iconView setImage:logo];
+			[iconView setImageScaling:NSImageScaleProportionallyUpOrDown];
+			[contentView addSubview:iconView];
+		}
+		y -= 80;
+
+		// App name
+		NSTextField* nameLabel = [NSTextField labelWithString:@"MacNote++"];
+		[nameLabel setFont:[NSFont boldSystemFontOfSize:18]];
+		[nameLabel setAlignment:NSTextAlignmentCenter];
+		[nameLabel setFrame:NSMakeRect(20, y, 360, 24)];
+		[contentView addSubview:nameLabel];
+		y -= 22;
+
+		// Version — read from bundle at runtime
+		NSString* version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+		if (!version) version = @"1.0.0";
+		NSString* build = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
+		NSString* versionStr = build && ![build isEqualToString:version]
+			? [NSString stringWithFormat:@"Version %@ (%@)", version, build]
+			: [NSString stringWithFormat:@"Version %@", version];
+		NSTextField* versionLabel = [NSTextField labelWithString:versionStr];
+		[versionLabel setFont:[NSFont systemFontOfSize:13]];
+		[versionLabel setTextColor:[NSColor secondaryLabelColor]];
+		[versionLabel setAlignment:NSTextAlignmentCenter];
+		[versionLabel setFrame:NSMakeRect(20, y, 360, 18)];
+		[contentView addSubview:versionLabel];
+		y -= 28;
+
+		// Attribution
+		NSTextField* creditLabel = [NSTextField labelWithString:@"Based on Notepad++ by Don Ho"];
+		[creditLabel setFont:[NSFont systemFontOfSize:13]];
+		[creditLabel setAlignment:NSTextAlignmentCenter];
+		[creditLabel setFrame:NSMakeRect(20, y, 360, 18)];
+		[contentView addSubview:creditLabel];
+		y -= 30;
+
+		// Separator
+		NSBox* separator = [[NSBox alloc] initWithFrame:NSMakeRect(40, y, 320, 1)];
+		[separator setBoxType:NSBoxSeparator];
+		[contentView addSubview:separator];
+		y -= 24;
+
+		// Component versions
+		NSTextField* compLabel = [NSTextField labelWithString:
+			@"Scintilla 5.5.3  \u2022  Lexilla 5.4.0  \u2022  Boost.Regex 1.90.0"];
+		[compLabel setFont:[NSFont systemFontOfSize:11]];
+		[compLabel setTextColor:[NSColor tertiaryLabelColor]];
+		[compLabel setAlignment:NSTextAlignmentCenter];
+		[compLabel setFrame:NSMakeRect(20, y, 360, 16)];
+		[contentView addSubview:compLabel];
+		y -= 22;
+
+		// Build date
+		NSString* buildDate = [NSString stringWithFormat:@"Built: %s", __DATE__];
+		NSTextField* buildLabel = [NSTextField labelWithString:buildDate];
+		[buildLabel setFont:[NSFont systemFontOfSize:11]];
+		[buildLabel setTextColor:[NSColor tertiaryLabelColor]];
+		[buildLabel setAlignment:NSTextAlignmentCenter];
+		[buildLabel setFrame:NSMakeRect(20, y, 360, 16)];
+		[contentView addSubview:buildLabel];
+		y -= 28;
+
+		// Repository link (clickable button styled as link)
+		NSButton* linkButton = [[NSButton alloc] initWithFrame:NSMakeRect(60, y, 280, 20)];
+		[linkButton setTitle:@"github.com/hybridmachine/MacOS-NotePP"];
+		[linkButton setBezelStyle:NSBezelStyleInline];
+		[linkButton setBordered:NO];
+		[linkButton setTarget:controller];
+		[linkButton setAction:@selector(openRepository:)];
+		NSMutableAttributedString* linkAttr = [[NSMutableAttributedString alloc]
+			initWithString:@"github.com/hybridmachine/MacOS-NotePP"];
+		[linkAttr addAttribute:NSForegroundColorAttributeName
+		                 value:[NSColor linkColor]
+		                 range:NSMakeRange(0, linkAttr.length)];
+		[linkAttr addAttribute:NSUnderlineStyleAttributeName
+		                 value:@(NSUnderlineStyleSingle)
+		                 range:NSMakeRange(0, linkAttr.length)];
+		[linkAttr addAttribute:NSFontAttributeName
+		                 value:[NSFont systemFontOfSize:11]
+		                 range:NSMakeRange(0, linkAttr.length)];
+		[linkButton setAttributedTitle:linkAttr];
+		[linkButton setAlignment:NSTextAlignmentCenter];
+		[contentView addSubview:linkButton];
+		y -= 24;
+
+		// License
+		NSTextField* licenseLabel = [NSTextField labelWithString:@"GNU General Public License v3"];
+		[licenseLabel setFont:[NSFont systemFontOfSize:11]];
+		[licenseLabel setTextColor:[NSColor secondaryLabelColor]];
+		[licenseLabel setAlignment:NSTextAlignmentCenter];
+		[licenseLabel setFrame:NSMakeRect(20, y, 360, 16)];
+		[contentView addSubview:licenseLabel];
+
+		// OK button
+		NSButton* okButton = [[NSButton alloc] initWithFrame:NSMakeRect(160, 12, 80, 32)];
+		[okButton setTitle:@"OK"];
+		[okButton setBezelStyle:NSBezelStyleRounded];
+		[okButton setTarget:NSApp];
+		[okButton setAction:@selector(stopModal)];
+		[okButton setKeyEquivalent:@"\r"];
+		[contentView addSubview:okButton];
+
+		// Also handle Escape to close
+		[panel setDefaultButtonCell:[okButton cell]];
+
+		[NSApp runModalForWindow:panel];
+		[panel close];
+
+		// prevent ARC from releasing controller during modal
+		(void)controller;
+	}
+}

--- a/macos/platform/app_delegate.mm
+++ b/macos/platform/app_delegate.mm
@@ -8,6 +8,7 @@
 #include "string_utils.h"
 #include "document_manager.h"
 #include "file_operations.h"
+#include "save_prompt.h"
 #include "menu_builder.h"
 #include "wndproc.h"
 #include "scintilla_config.h"
@@ -65,12 +66,28 @@
 
 static void setDockIconFromLogo()
 {
+	// In a proper app bundle, macOS loads the icon from CFBundleIconFile automatically.
+	// Check if the bundle icon is already loaded and usable.
+	NSImage* bundleIcon = [NSApp applicationIconImage];
+	if (bundleIcon && bundleIcon.size.width > 32)
+		return;
+
+	// Fallback for development builds: load logo.png from alongside the executable
 	NSString* executablePath = [[NSBundle mainBundle] executablePath];
 	if (!executablePath)
 		return;
 
-	NSString* logoPath = [[executablePath stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"logo.png"];
-	NSImage* dockIcon = [[NSImage alloc] initWithContentsOfFile:logoPath];
+	NSString* dir = [executablePath stringByDeletingLastPathComponent];
+
+	// Try .icns first
+	NSString* icnsPath = [dir stringByAppendingPathComponent:@"AppIcon.icns"];
+	NSImage* dockIcon = [[NSImage alloc] initWithContentsOfFile:icnsPath];
+	if (!dockIcon)
+	{
+		// Fall back to logo.png
+		NSString* logoPath = [dir stringByAppendingPathComponent:@"logo.png"];
+		dockIcon = [[NSImage alloc] initWithContentsOfFile:logoPath];
+	}
 	if (dockIcon)
 		[NSApp setApplicationIconImage:dockIcon];
 }
@@ -230,6 +247,26 @@ static void setDockIconFromLogo()
 
 				if (scn->nmhdr.code == 2028) // SCN_FOCUSIN
 					ctx().activeView = 0;
+				else if (scn->nmhdr.code == SCN_SAVEPOINTLEFT)
+				{
+					int tabIdx = ctx().activeTab;
+					if (tabIdx >= 0 && tabIdx < static_cast<int>(ctx().documents.size()))
+					{
+						ctx().documents[tabIdx].modified = true;
+						updateTabModifiedIndicator(0, tabIdx);
+						updateWindowDocumentEdited();
+					}
+				}
+				else if (scn->nmhdr.code == SCN_SAVEPOINTREACHED)
+				{
+					int tabIdx = ctx().activeTab;
+					if (tabIdx >= 0 && tabIdx < static_cast<int>(ctx().documents.size()))
+					{
+						ctx().documents[tabIdx].modified = false;
+						updateTabModifiedIndicator(0, tabIdx);
+						updateWindowDocumentEdited();
+					}
+				}
 				else if (scn->nmhdr.code == 2010) // SCN_MARGINCLICK
 				{
 					if (scn->margin == 1 && ctx().scintillaView)
@@ -353,8 +390,39 @@ static void setDockIconFromLogo()
 
 	restoreSession();
 
+	// Handle CLI arguments (for direct executable launch: ./MacOSNotePP file.txt)
+	NSArray<NSString*>* args = [[NSProcessInfo processInfo] arguments];
+	for (NSUInteger i = 1; i < args.count; ++i)
+	{
+		NSString* arg = args[i];
+		if ([arg hasPrefix:@"-"]) continue;
+		BOOL isDir = NO;
+		if ([[NSFileManager defaultManager] fileExistsAtPath:arg isDirectory:&isDir] && !isDir)
+			openFileAtPath(arg);
+	}
+
 	NSLog(@"=== Notepad++ macOS Port — Phase 7 ===");
 	NSLog(@"Settings, split view, edit commands, encoding, session, drag-and-drop!");
+}
+
+- (void)application:(NSApplication*)sender openFiles:(NSArray<NSString*>*)filenames
+{
+	BOOL anyOpened = NO;
+	for (NSString* path in filenames)
+	{
+		BOOL isDir = NO;
+		if ([[NSFileManager defaultManager] fileExistsAtPath:path isDirectory:&isDir] && !isDir)
+		{
+			if (openFileAtPath(path))
+				anyOpened = YES;
+		}
+	}
+
+	[sender activateIgnoringOtherApps:YES];
+	if (ctx().mainWindow)
+		[ctx().mainWindow makeKeyAndOrderFront:nil];
+
+	[sender replyToOpenOrPrint:anyOpened ? NSApplicationDelegateReplySuccess : NSApplicationDelegateReplyFailure];
 }
 
 - (void)appearanceChanged:(NSNotification*)notification
@@ -372,6 +440,18 @@ static void setDockIconFromLogo()
 {
 	if (ctx().mainHwnd)
 		SendMessageW(ctx().mainHwnd, WM_COMMAND, MAKEWPARAM(static_cast<WORD>(sender.tag), 0), 0);
+}
+
+- (BOOL)windowShouldClose:(NSWindow*)sender
+{
+	return promptAndHandleQuit() ? YES : NO;
+}
+
+- (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication*)sender
+{
+	if (promptAndHandleQuit())
+		return NSTerminateNow;
+	return NSTerminateCancel;
 }
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication*)sender

--- a/macos/platform/app_delegate.mm
+++ b/macos/platform/app_delegate.mm
@@ -249,22 +249,29 @@ static void setDockIconFromLogo()
 					ctx().activeView = 0;
 				else if (scn->nmhdr.code == SCN_SAVEPOINTLEFT)
 				{
-					int tabIdx = ctx().activeTab;
-					if (tabIdx >= 0 && tabIdx < static_cast<int>(ctx().documents.size()))
+					if (!ctx().suppressSavePointNotifications)
 					{
-						ctx().documents[tabIdx].modified = true;
-						updateTabModifiedIndicator(0, tabIdx);
-						updateWindowDocumentEdited();
+						int tabIdx = ctx().activeTab;
+						if (tabIdx >= 0 && tabIdx < static_cast<int>(ctx().documents.size()))
+						{
+							ctx().documents[tabIdx].modified = true;
+							updateTabModifiedIndicator(0, tabIdx);
+							updateWindowDocumentEdited();
+						}
 					}
 				}
 				else if (scn->nmhdr.code == SCN_SAVEPOINTREACHED)
 				{
-					int tabIdx = ctx().activeTab;
-					if (tabIdx >= 0 && tabIdx < static_cast<int>(ctx().documents.size()))
+					if (!ctx().suppressSavePointNotifications)
 					{
-						ctx().documents[tabIdx].modified = false;
-						updateTabModifiedIndicator(0, tabIdx);
-						updateWindowDocumentEdited();
+						int tabIdx = ctx().activeTab;
+						if (tabIdx >= 0 && tabIdx < static_cast<int>(ctx().documents.size())
+						    && ctx().documents[tabIdx].savePointValid)
+						{
+							ctx().documents[tabIdx].modified = false;
+							updateTabModifiedIndicator(0, tabIdx);
+							updateWindowDocumentEdited();
+						}
 					}
 				}
 				else if (scn->nmhdr.code == 2010) // SCN_MARGINCLICK

--- a/macos/platform/app_state.h
+++ b/macos/platform/app_state.h
@@ -64,6 +64,9 @@ struct AppContext
 	NSView* editorContainer2 = nil;
 	NSView* sciContainer2 = nil;
 
+	// Notification suppression (prevents false dirty indicators during tab switches)
+	bool suppressSavePointNotifications = false;
+
 	// Accessor helpers for split view
 	void*& activeScintillaView() { return activeView == 0 ? scintillaView : scintillaView2; }
 	std::vector<DocumentData>& activeDocuments() { return activeView == 0 ? documents : documents2; }

--- a/macos/platform/document_data.h
+++ b/macos/platform/document_data.h
@@ -50,6 +50,7 @@ struct DocumentData
 	intptr_t anchorPos = 0;
 	intptr_t firstVisibleLine = 0;
 	bool modified = false;
+	bool savePointValid = true; // false when Scintilla's save point doesn't reflect real saved state
 	int languageIndex = 2; // Default: C++
 	std::vector<int> bookmarkedLines; // Persisted across tab switches
 	int encoding = ENC_UTF8;

--- a/macos/platform/document_manager.h
+++ b/macos/platform/document_manager.h
@@ -9,7 +9,7 @@
 
 void saveViewState(void* sci, std::vector<DocumentData>& docs, int tabIdx);
 void saveScintillaState();
-void restoreViewToScintilla(void* sci, const std::vector<DocumentData>& docs, int tabIndex);
+void restoreViewToScintilla(void* sci, std::vector<DocumentData>& docs, int tabIndex);
 void restoreScintillaState(int tabIndex);
 
 void switchToTabInView(int viewIndex, int tabIndex);

--- a/macos/platform/document_manager.h
+++ b/macos/platform/document_manager.h
@@ -20,3 +20,6 @@ int addNewTab(const std::wstring& title, const std::string& content,
               const std::wstring& filePath = L"", int langIndex = 2);
 void closeTabFromView(int viewIndex, int tabIndex);
 void closeTab(int tabIndex);
+
+void updateTabModifiedIndicator(int viewIndex, int tabIndex);
+void updateWindowDocumentEdited();

--- a/macos/platform/document_manager.mm
+++ b/macos/platform/document_manager.mm
@@ -28,7 +28,8 @@ void saveViewState(void* sci, std::vector<DocumentData>& docs, int tabIdx)
 	doc.cursorPos = ScintillaBridge_sendMessage(sci, SCI_GETCURRENTPOS, 0, 0);
 	doc.anchorPos = ScintillaBridge_sendMessage(sci, SCI_GETANCHOR, 0, 0);
 	doc.firstVisibleLine = ScintillaBridge_sendMessage(sci, SCI_GETFIRSTVISIBLELINE, 0, 0);
-	doc.modified = ScintillaBridge_sendMessage(sci, SCI_GETMODIFY, 0, 0) != 0;
+	if (doc.savePointValid)
+		doc.modified = ScintillaBridge_sendMessage(sci, SCI_GETMODIFY, 0, 0) != 0;
 
 	doc.bookmarkedLines.clear();
 	intptr_t lineCount = ScintillaBridge_sendMessage(sci, SCI_GETLINECOUNT, 0, 0);
@@ -47,19 +48,25 @@ void saveScintillaState()
 	saveViewState(ctx().scintillaView, ctx().documents, ctx().activeTab);
 }
 
-void restoreViewToScintilla(void* sci, const std::vector<DocumentData>& docs, int tabIndex)
+void restoreViewToScintilla(void* sci, std::vector<DocumentData>& docs, int tabIndex)
 {
 	if (tabIndex < 0 || tabIndex >= static_cast<int>(docs.size()))
 		return;
 	if (!sci) return;
 
-	const auto& doc = docs[tabIndex];
+	auto& doc = docs[tabIndex];
+	ctx().suppressSavePointNotifications = true;
 	ScintillaBridge_sendMessage(sci, SCI_SETTEXT, 0, (intptr_t)doc.content.c_str());
-	ScintillaBridge_sendMessage(sci, SCI_SETFIRSTVISIBLELINE, doc.firstVisibleLine, 0);
-	ScintillaBridge_sendMessage(sci, SCI_SETSEL, doc.anchorPos, doc.cursorPos);
 	if (!doc.modified)
 		ScintillaBridge_sendMessage(sci, SCI_SETSAVEPOINT, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETFIRSTVISIBLELINE, doc.firstVisibleLine, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETSEL, doc.anchorPos, doc.cursorPos);
 	ScintillaBridge_sendMessage(sci, SCI_EMPTYUNDOBUFFER, 0, 0);
+	// SCI_EMPTYUNDOBUFFER resets Scintilla's save point to current position.
+	// For modified documents, this makes Scintilla think it's clean when it isn't.
+	// Mark the save point as invalid so SCN_SAVEPOINTREACHED won't clear modified.
+	doc.savePointValid = !doc.modified;
+	ctx().suppressSavePointNotifications = false;
 
 	for (int bkLine : doc.bookmarkedLines)
 		ScintillaBridge_sendMessage(sci, SCI_MARKERADD, bkLine, BOOKMARK_MARKER);
@@ -136,10 +143,12 @@ int addNewTabToView(int viewIndex, const std::wstring& title, const std::string&
 
 	activeTab = newIndex;
 
+	ctx().suppressSavePointNotifications = true;
 	ScintillaBridge_sendMessage(sci, SCI_SETTEXT, 0, (intptr_t)content.c_str());
+	ScintillaBridge_sendMessage(sci, SCI_SETSAVEPOINT, 0, 0);
 	ScintillaBridge_sendMessage(sci, SCI_GOTOPOS, 0, 0);
 	ScintillaBridge_sendMessage(sci, SCI_EMPTYUNDOBUFFER, 0, 0);
-	ScintillaBridge_sendMessage(sci, SCI_SETSAVEPOINT, 0, 0);
+	ctx().suppressSavePointNotifications = false;
 
 	applyLanguageToView(sci, langIndex);
 
@@ -169,9 +178,11 @@ void closeTabFromView(int viewIndex, int tabIndex)
 	if (docs.size() <= 1)
 	{
 		docs[0] = DocumentData();
+		ctx().suppressSavePointNotifications = true;
 		ScintillaBridge_sendMessage(sci, SCI_CLEARALL, 0, 0);
 		ScintillaBridge_sendMessage(sci, SCI_EMPTYUNDOBUFFER, 0, 0);
 		ScintillaBridge_sendMessage(sci, SCI_SETSAVEPOINT, 0, 0);
+		ctx().suppressSavePointNotifications = false;
 		if (tabHwnd)
 		{
 			TCITEMW tcItem = {};

--- a/macos/platform/document_manager.mm
+++ b/macos/platform/document_manager.mm
@@ -93,6 +93,7 @@ void switchToTabInView(int viewIndex, int tabIndex)
 	const auto& doc = docs[tabIndex];
 	NSString* title = WideToNSString(doc.title.c_str());
 	[ctx().mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@", title]];
+	updateWindowDocumentEdited();
 }
 
 void switchToTab(int tabIndex)
@@ -180,6 +181,7 @@ void closeTabFromView(int viewIndex, int tabIndex)
 			SendMessageW(tabHwnd, TCM_SETITEMW, 0, reinterpret_cast<LPARAM>(&tcItem));
 		}
 		[ctx().mainWindow setTitle:@"Notepad++ — Untitled"];
+		updateWindowDocumentEdited();
 		return;
 	}
 
@@ -203,9 +205,47 @@ void closeTabFromView(int viewIndex, int tabIndex)
 	const auto& doc = docs[activeTab];
 	NSString* title = WideToNSString(doc.title.c_str());
 	[ctx().mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@", title]];
+	updateWindowDocumentEdited();
 }
 
 void closeTab(int tabIndex)
 {
 	closeTabFromView(ctx().activeView, tabIndex);
+}
+
+void updateTabModifiedIndicator(int viewIndex, int tabIndex)
+{
+	auto& docs = (viewIndex == 0) ? ctx().documents : ctx().documents2;
+	HWND tabHwnd = (viewIndex == 0) ? ctx().tabHwnd : ctx().tabHwnd2;
+
+	if (tabIndex < 0 || tabIndex >= static_cast<int>(docs.size()))
+		return;
+	if (!tabHwnd) return;
+
+	const auto& doc = docs[tabIndex];
+	std::wstring displayTitle = doc.title;
+	if (doc.modified)
+		displayTitle += L" \u2022";
+
+	TCITEMW tcItem = {};
+	tcItem.mask = TCIF_TEXT;
+	wchar_t titleBuf[256];
+	wcsncpy(titleBuf, displayTitle.c_str(), 255);
+	titleBuf[255] = L'\0';
+	tcItem.pszText = titleBuf;
+	SendMessageW(tabHwnd, TCM_SETITEMW, tabIndex, reinterpret_cast<LPARAM>(&tcItem));
+}
+
+void updateWindowDocumentEdited()
+{
+	if (!ctx().mainWindow) return;
+
+	auto& docs = ctx().activeDocuments();
+	int tabIdx = ctx().activeTabIndex();
+
+	bool isModified = false;
+	if (tabIdx >= 0 && tabIdx < static_cast<int>(docs.size()))
+		isModified = docs[tabIdx].modified;
+
+	[ctx().mainWindow setDocumentEdited:isModified];
 }

--- a/macos/platform/file_operations.h
+++ b/macos/platform/file_operations.h
@@ -10,6 +10,7 @@ int detectEncoding(NSData* data);
 int detectEOLMode(const char* text, size_t len);
 std::string decodeFileData(NSData* data, int encoding);
 NSData* encodeForSave(const char* utf8Text, size_t len, int encoding);
+bool switchToFileIfOpen(const std::wstring& filePath);
 bool openFileAtPath(NSString* path);
 void openFile();
 void saveCurrentFile();

--- a/macos/platform/file_operations.mm
+++ b/macos/platform/file_operations.mm
@@ -307,6 +307,7 @@ void saveCurrentFile()
 		{
 			ScintillaBridge_sendMessage(sci, SCI_SETSAVEPOINT, 0, 0);
 			doc.modified = false;
+			doc.savePointValid = true;
 			updateTabModifiedIndicator(ctx().activeView, tabIdx);
 			updateWindowDocumentEdited();
 			NSString* nsTitle = WideToNSString(doc.title.c_str());

--- a/macos/platform/file_operations.mm
+++ b/macos/platform/file_operations.mm
@@ -2,6 +2,7 @@
 // Part of the Notepad++ macOS port modular refactor.
 
 #include "file_operations.h"
+#include <vector>
 #include "npp_constants.h"
 #include "document_data.h"
 #include "app_state.h"
@@ -121,8 +122,54 @@ NSData* encodeForSave(const char* utf8Text, size_t len, int encoding)
 	}
 }
 
+bool switchToFileIfOpen(const std::wstring& filePath)
+{
+	if (filePath.empty()) return false;
+
+	// Canonicalize the path for comparison
+	NSString* nsPath = WideToNSString(filePath.c_str());
+	NSString* canonical = [[nsPath stringByStandardizingPath] stringByResolvingSymlinksInPath];
+	std::wstring canonicalPath = NSStringToWide(canonical);
+
+	// Check main view
+	for (int i = 0; i < static_cast<int>(ctx().documents.size()); ++i)
+	{
+		if (ctx().documents[i].filePath.empty()) continue;
+		NSString* docPath = WideToNSString(ctx().documents[i].filePath.c_str());
+		NSString* docCanonical = [[docPath stringByStandardizingPath] stringByResolvingSymlinksInPath];
+		if ([canonical isEqualToString:docCanonical])
+		{
+			if (ctx().activeView != 0) ctx().activeView = 0;
+			switchToTabInView(0, i);
+			return true;
+		}
+	}
+	// Check split view
+	if (ctx().isSplit)
+	{
+		for (int i = 0; i < static_cast<int>(ctx().documents2.size()); ++i)
+		{
+			if (ctx().documents2[i].filePath.empty()) continue;
+			NSString* docPath = WideToNSString(ctx().documents2[i].filePath.c_str());
+			NSString* docCanonical = [[docPath stringByStandardizingPath] stringByResolvingSymlinksInPath];
+			if ([canonical isEqualToString:docCanonical])
+			{
+				if (ctx().activeView != 1) ctx().activeView = 1;
+				switchToTabInView(1, i);
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 bool openFileAtPath(NSString* path)
 {
+	// Check if already open; switch to it instead of duplicating
+	std::wstring wcheck = NSStringToWide(path);
+	if (switchToFileIfOpen(wcheck))
+		return true;
+
 	NSData* rawData = [NSData dataWithContentsOfFile:path];
 	if (!rawData) return false;
 
@@ -164,22 +211,30 @@ bool openFileAtPath(NSString* path)
 void openFile()
 {
 	OPENFILENAMEW ofn = {};
-	wchar_t filePath[MAX_PATH] = {0};
+	constexpr DWORD bufSize = 32768;
+	std::vector<wchar_t> fileBuf(bufSize, 0);
 	ofn.lStructSize = sizeof(ofn);
 	ofn.hwndOwner = ctx().mainHwnd;
-	ofn.lpstrFile = filePath;
-	ofn.nMaxFile = MAX_PATH;
+	ofn.lpstrFile = fileBuf.data();
+	ofn.nMaxFile = bufSize;
 	ofn.lpstrTitle = L"Open File";
 	ofn.lpstrFilter = L"All Files\0*.*\0"
 	                   L"C/C++ Files\0*.c;*.cpp;*.cc;*.h;*.hpp\0"
 	                   L"Text Files\0*.txt\0";
 	ofn.nFilterIndex = 1;
-	ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST;
+	ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_ALLOWMULTISELECT;
 
-	if (GetOpenFileNameW(&ofn))
+	if (!GetOpenFileNameW(&ofn))
+		return;
+
+	// Parse null-delimited paths (each is a full path, double-null terminated)
+	const wchar_t* p = fileBuf.data();
+	while (*p)
 	{
-		NSString* path = WideToNSString(filePath);
-		openFileAtPath(path);
+		NSString* path = WideToNSString(p);
+		if (path && path.length > 0)
+			openFileAtPath(path);
+		p += wcslen(p) + 1;
 	}
 }
 
@@ -251,6 +306,9 @@ void saveCurrentFile()
 		else
 		{
 			ScintillaBridge_sendMessage(sci, SCI_SETSAVEPOINT, 0, 0);
+			doc.modified = false;
+			updateTabModifiedIndicator(ctx().activeView, tabIdx);
+			updateWindowDocumentEdited();
 			NSString* nsTitle = WideToNSString(doc.title.c_str());
 			[ctx().mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@", nsTitle]];
 

--- a/macos/platform/menu_builder.mm
+++ b/macos/platform/menu_builder.mm
@@ -129,5 +129,10 @@ HMENU buildMenuBar()
 	}
 	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hLangMenu), L"&Language");
 
+	// Help menu
+	HMENU hHelpMenu = CreatePopupMenu();
+	AppendMenuW(hHelpMenu, MF_STRING, IDM_HELP_ABOUT, L"About MacNote++");
+	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hHelpMenu), L"&Help");
+
 	return hMenuBar;
 }

--- a/macos/platform/npp_constants.h
+++ b/macos/platform/npp_constants.h
@@ -60,6 +60,9 @@
 #define IDM_VIEW_MOVETOOTHER         42072
 #define IDM_VIEW_CLONETOOTHER        42073
 
+// Help menu commands
+#define IDM_HELP_ABOUT           46001
+
 // Phase 7 — Format/Encoding commands
 #define IDM_FORMAT_EOL_LF            45001
 #define IDM_FORMAT_EOL_CRLF          45002
@@ -254,6 +257,10 @@ enum {
 #define SC_FOLDACTION_TOGGLE      2
 #define SC_FOLDLEVELHEADERFLAG    0x2000
 #define SC_AUTOMATICFOLD_CLICK    0x0004
+
+// Scintilla notification codes
+#define SCN_SAVEPOINTREACHED  2002
+#define SCN_SAVEPOINTLEFT     2003
 
 // EOL mode constants matching Scintilla
 #define SC_EOL_CRLF 0

--- a/macos/platform/save_prompt.h
+++ b/macos/platform/save_prompt.h
@@ -1,0 +1,32 @@
+// save_prompt.h — Save-before-close prompts
+// Part of the Notepad++ macOS port modular refactor.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+enum class SavePromptResult
+{
+	Save,
+	DontSave,
+	Cancel
+};
+
+// Prompt for a single dirty document. Returns user's choice.
+SavePromptResult promptSaveSingleDocument(const std::wstring& title);
+
+// Check if a specific document (by view + tab index) is dirty.
+bool isDocumentDirty(int viewIndex, int tabIndex);
+
+// Save a document by view + tab index. Returns true if save succeeded.
+bool saveDocumentAt(int viewIndex, int tabIndex);
+
+// Prompt-and-handle for closing a single tab. Returns true if close should proceed.
+bool promptAndHandleClose(int viewIndex, int tabIndex);
+
+// Prompt-and-handle for closing all tabs in a view. Returns true if close-all should proceed.
+bool promptAndHandleCloseAll(int viewIndex);
+
+// Prompt-and-handle for quitting the app (all tabs in all views). Returns true if quit should proceed.
+bool promptAndHandleQuit();

--- a/macos/platform/save_prompt.mm
+++ b/macos/platform/save_prompt.mm
@@ -1,0 +1,245 @@
+// save_prompt.mm — Save-before-close prompts
+// Part of the Notepad++ macOS port modular refactor.
+
+#import <Cocoa/Cocoa.h>
+#include "save_prompt.h"
+#include "app_state.h"
+#include "string_utils.h"
+#include "document_manager.h"
+#include "file_operations.h"
+#include "scintilla_bridge.h"
+#include "npp_constants.h"
+
+// Re-entry guard to prevent double prompting
+static bool s_promptInProgress = false;
+
+SavePromptResult promptSaveSingleDocument(const std::wstring& title)
+{
+	@autoreleasepool {
+		NSAlert* alert = [[NSAlert alloc] init];
+		NSString* nsTitle = WideToNSString(title.c_str());
+		[alert setMessageText:[NSString stringWithFormat:@"Do you want to save changes to \"%@\"?", nsTitle]];
+		[alert setInformativeText:@"Your changes will be lost if you don't save them."];
+		[alert addButtonWithTitle:@"Save"];
+		[alert addButtonWithTitle:@"Don't Save"];
+		[alert addButtonWithTitle:@"Cancel"];
+		[alert setAlertStyle:NSAlertStyleWarning];
+
+		NSModalResponse response = [alert runModal];
+		if (response == NSAlertFirstButtonReturn)
+			return SavePromptResult::Save;
+		if (response == NSAlertSecondButtonReturn)
+			return SavePromptResult::DontSave;
+		return SavePromptResult::Cancel;
+	}
+}
+
+bool isDocumentDirty(int viewIndex, int tabIndex)
+{
+	auto& docs = (viewIndex == 0) ? ctx().documents : ctx().documents2;
+	void* sci = (viewIndex == 0) ? ctx().scintillaView : ctx().scintillaView2;
+	int activeTab = (viewIndex == 0) ? ctx().activeTab : ctx().activeTab2;
+
+	if (tabIndex < 0 || tabIndex >= static_cast<int>(docs.size()))
+		return false;
+
+	// If this is the currently active tab, sync state from Scintilla
+	if (tabIndex == activeTab && sci)
+		docs[tabIndex].modified = ScintillaBridge_sendMessage(sci, SCI_GETMODIFY, 0, 0) != 0;
+
+	// Untitled buffers with content are dirty even if not "modified"
+	if (docs[tabIndex].filePath.empty() && !docs[tabIndex].content.empty() && !docs[tabIndex].modified)
+	{
+		// Check if there's actually content in Scintilla
+		if (tabIndex == activeTab && sci)
+		{
+			intptr_t len = ScintillaBridge_sendMessage(sci, SCI_GETTEXTLENGTH, 0, 0);
+			if (len > 0)
+				return true;
+		}
+	}
+
+	return docs[tabIndex].modified;
+}
+
+bool saveDocumentAt(int viewIndex, int tabIndex)
+{
+	int origView = ctx().activeView;
+	int origTab = ctx().activeTabIndex();
+
+	// Switch to the target view/tab if not already active
+	bool needSwitch = (viewIndex != origView || tabIndex != ctx().activeTabIndex());
+	if (needSwitch)
+	{
+		ctx().activeView = viewIndex;
+		if (viewIndex == 0)
+		{
+			if (tabIndex != ctx().activeTab)
+				switchToTabInView(0, tabIndex);
+		}
+		else
+		{
+			if (tabIndex != ctx().activeTab2)
+				switchToTabInView(1, tabIndex);
+		}
+	}
+
+	auto& docs = ctx().activeDocuments();
+	std::wstring pathBefore = docs[ctx().activeTabIndex()].filePath;
+
+	saveCurrentFile();
+
+	auto& docsAfter = ctx().activeDocuments();
+	int tabIdx = ctx().activeTabIndex();
+	bool saved = false;
+	if (tabIdx >= 0 && tabIdx < static_cast<int>(docsAfter.size()))
+	{
+		// Save succeeded if: file has a path AND is no longer modified
+		void* sci = ctx().activeScintillaView();
+		saved = !docsAfter[tabIdx].filePath.empty() &&
+		        (sci ? ScintillaBridge_sendMessage(sci, SCI_GETMODIFY, 0, 0) == 0 : !docsAfter[tabIdx].modified);
+	}
+
+	// Restore original context if we switched
+	if (needSwitch)
+	{
+		ctx().activeView = origView;
+	}
+
+	return saved;
+}
+
+bool promptAndHandleClose(int viewIndex, int tabIndex)
+{
+	if (!isDocumentDirty(viewIndex, tabIndex))
+		return true;
+
+	auto& docs = (viewIndex == 0) ? ctx().documents : ctx().documents2;
+	SavePromptResult result = promptSaveSingleDocument(docs[tabIndex].title);
+
+	switch (result)
+	{
+		case SavePromptResult::Save:
+			return saveDocumentAt(viewIndex, tabIndex);
+		case SavePromptResult::DontSave:
+			return true;
+		case SavePromptResult::Cancel:
+			return false;
+	}
+	return false;
+}
+
+bool promptAndHandleCloseAll(int viewIndex)
+{
+	auto& docs = (viewIndex == 0) ? ctx().documents : ctx().documents2;
+
+	// Snapshot dirty tab indices (iterate in reverse to avoid index shifting issues)
+	std::vector<int> dirtyTabs;
+	for (int i = 0; i < static_cast<int>(docs.size()); ++i)
+	{
+		if (isDocumentDirty(viewIndex, i))
+			dirtyTabs.push_back(i);
+	}
+
+	for (int idx : dirtyTabs)
+	{
+		// Re-validate index (docs may have changed)
+		if (idx >= static_cast<int>(docs.size()))
+			continue;
+
+		SavePromptResult result = promptSaveSingleDocument(docs[idx].title);
+		switch (result)
+		{
+			case SavePromptResult::Save:
+				if (!saveDocumentAt(viewIndex, idx))
+					return false; // Save As cancelled — abort entire close-all
+				break;
+			case SavePromptResult::DontSave:
+				break;
+			case SavePromptResult::Cancel:
+				return false;
+		}
+	}
+	return true;
+}
+
+bool promptAndHandleQuit()
+{
+	if (s_promptInProgress)
+		return false;
+	s_promptInProgress = true;
+
+	// Collect all dirty docs across both views
+	struct DirtyDoc {
+		int viewIndex;
+		int tabIndex;
+		std::wstring title;
+	};
+	std::vector<DirtyDoc> dirtyDocs;
+
+	for (int i = 0; i < static_cast<int>(ctx().documents.size()); ++i)
+	{
+		if (isDocumentDirty(0, i))
+			dirtyDocs.push_back({0, i, ctx().documents[i].title});
+	}
+	if (ctx().isSplit)
+	{
+		for (int i = 0; i < static_cast<int>(ctx().documents2.size()); ++i)
+		{
+			if (isDocumentDirty(1, i))
+			{
+				// Dedupe by file path — if same file open in both views, only prompt once
+				bool isDupe = false;
+				if (!ctx().documents2[i].filePath.empty())
+				{
+					for (const auto& dd : dirtyDocs)
+					{
+						auto& ddDocs = (dd.viewIndex == 0) ? ctx().documents : ctx().documents2;
+						if (dd.tabIndex < static_cast<int>(ddDocs.size()) &&
+						    ddDocs[dd.tabIndex].filePath == ctx().documents2[i].filePath)
+						{
+							isDupe = true;
+							break;
+						}
+					}
+				}
+				if (!isDupe)
+					dirtyDocs.push_back({1, i, ctx().documents2[i].title});
+			}
+		}
+	}
+
+	if (dirtyDocs.empty())
+	{
+		s_promptInProgress = false;
+		return true;
+	}
+
+	// Prompt for each dirty document
+	for (const auto& dd : dirtyDocs)
+	{
+		auto& docs = (dd.viewIndex == 0) ? ctx().documents : ctx().documents2;
+		if (dd.tabIndex >= static_cast<int>(docs.size()))
+			continue;
+
+		SavePromptResult result = promptSaveSingleDocument(dd.title);
+		switch (result)
+		{
+			case SavePromptResult::Save:
+				if (!saveDocumentAt(dd.viewIndex, dd.tabIndex))
+				{
+					s_promptInProgress = false;
+					return false;
+				}
+				break;
+			case SavePromptResult::DontSave:
+				break;
+			case SavePromptResult::Cancel:
+				s_promptInProgress = false;
+				return false;
+		}
+	}
+
+	s_promptInProgress = false;
+	return true;
+}

--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -111,22 +111,29 @@ void doSplit()
 						ctx().activeView = 1;
 					else if (scn->nmhdr.code == SCN_SAVEPOINTLEFT)
 					{
-						int tabIdx = ctx().activeTab2;
-						if (tabIdx >= 0 && tabIdx < static_cast<int>(ctx().documents2.size()))
+						if (!ctx().suppressSavePointNotifications)
 						{
-							ctx().documents2[tabIdx].modified = true;
-							updateTabModifiedIndicator(1, tabIdx);
-							updateWindowDocumentEdited();
+							int tabIdx = ctx().activeTab2;
+							if (tabIdx >= 0 && tabIdx < static_cast<int>(ctx().documents2.size()))
+							{
+								ctx().documents2[tabIdx].modified = true;
+								updateTabModifiedIndicator(1, tabIdx);
+								updateWindowDocumentEdited();
+							}
 						}
 					}
 					else if (scn->nmhdr.code == SCN_SAVEPOINTREACHED)
 					{
-						int tabIdx = ctx().activeTab2;
-						if (tabIdx >= 0 && tabIdx < static_cast<int>(ctx().documents2.size()))
+						if (!ctx().suppressSavePointNotifications)
 						{
-							ctx().documents2[tabIdx].modified = false;
-							updateTabModifiedIndicator(1, tabIdx);
-							updateWindowDocumentEdited();
+							int tabIdx = ctx().activeTab2;
+							if (tabIdx >= 0 && tabIdx < static_cast<int>(ctx().documents2.size())
+							    && ctx().documents2[tabIdx].savePointValid)
+							{
+								ctx().documents2[tabIdx].modified = false;
+								updateTabModifiedIndicator(1, tabIdx);
+								updateWindowDocumentEdited();
+							}
 						}
 					}
 					else if (scn->nmhdr.code == 2010 && scn->margin == 1 && ctx().scintillaView2)

--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -109,6 +109,26 @@ void doSplit()
 					auto* scn = reinterpret_cast<const SciNotify*>(lParam);
 					if (scn->nmhdr.code == 2028)
 						ctx().activeView = 1;
+					else if (scn->nmhdr.code == SCN_SAVEPOINTLEFT)
+					{
+						int tabIdx = ctx().activeTab2;
+						if (tabIdx >= 0 && tabIdx < static_cast<int>(ctx().documents2.size()))
+						{
+							ctx().documents2[tabIdx].modified = true;
+							updateTabModifiedIndicator(1, tabIdx);
+							updateWindowDocumentEdited();
+						}
+					}
+					else if (scn->nmhdr.code == SCN_SAVEPOINTREACHED)
+					{
+						int tabIdx = ctx().activeTab2;
+						if (tabIdx >= 0 && tabIdx < static_cast<int>(ctx().documents2.size()))
+						{
+							ctx().documents2[tabIdx].modified = false;
+							updateTabModifiedIndicator(1, tabIdx);
+							updateWindowDocumentEdited();
+						}
+					}
 					else if (scn->nmhdr.code == 2010 && scn->margin == 1 && ctx().scintillaView2)
 					{
 						intptr_t line = ScintillaBridge_sendMessage(ctx().scintillaView2, SCI_LINEFROMPOSITION, scn->position, 0);

--- a/macos/platform/wndproc.mm
+++ b/macos/platform/wndproc.mm
@@ -12,6 +12,8 @@
 #include "autocomplete.h"
 #include "preferences_dialog.h"
 #include "split_view.h"
+#include "save_prompt.h"
+#include "about_dialog.h"
 #include "recent_files.h"
 #include "status_bar.h"
 #include "lexer_styles.h"
@@ -71,10 +73,13 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 					return 0;
 				}
 				case IDM_FILE_CLOSE:
-					closeTabFromView(ctx().activeView, ctx().activeTabIndex());
+					if (promptAndHandleClose(ctx().activeView, ctx().activeTabIndex()))
+						closeTabFromView(ctx().activeView, ctx().activeTabIndex());
 					return 0;
 				case IDM_FILE_CLOSEALL:
 				{
+					if (!promptAndHandleCloseAll(ctx().activeView))
+						return 0;
 					auto& closeDocs = ctx().activeDocuments();
 					while (closeDocs.size() > 1)
 						closeTabFromView(ctx().activeView, static_cast<int>(closeDocs.size()) - 1);
@@ -279,6 +284,10 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 					doCloneToOtherView();
 					return 0;
 
+				case IDM_HELP_ABOUT:
+					showAboutDlg();
+					return 0;
+
 				case IDM_FORMAT_EOL_LF:
 				case IDM_FORMAT_EOL_CRLF:
 				case IDM_FORMAT_EOL_CR:
@@ -361,6 +370,8 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 			return 0;
 
 		case WM_CLOSE:
+			if (!promptAndHandleQuit())
+				return 0;
 			KillTimer(hWnd, IDT_STATUSBAR);
 			PostQuitMessage(0);
 			return 0;

--- a/macos/shim/src/win32_menu.mm
+++ b/macos/shim/src/win32_menu.mm
@@ -1190,28 +1190,61 @@ BOOL GetOpenFileNameW(LPOPENFILENAMEW lpofn)
 		if (response != NSModalResponseOK)
 			return FALSE;
 
-		NSURL* url = panel.URL;
-		if (!url) return FALSE;
+		NSArray<NSURL*>* urls = panel.URLs;
+		if (!urls || urls.count == 0) return FALSE;
 
-		NSString* path = [url path];
 		if (lpofn->lpstrFile && lpofn->nMaxFile > 0)
 		{
-			NSStringToWide(path, lpofn->lpstrFile, lpofn->nMaxFile);
+			if (urls.count == 1)
+			{
+				// Single file: standard behavior
+				NSString* path = [urls[0] path];
+				NSStringToWide(path, lpofn->lpstrFile, lpofn->nMaxFile);
 
-			// Set nFileOffset and nFileExtension
-			NSString* fileName = [path lastPathComponent];
-			NSString* dirPath = [path stringByDeletingLastPathComponent];
-			lpofn->nFileOffset = static_cast<WORD>(dirPath.length + 1);
-			NSRange dotRange = [fileName rangeOfString:@"." options:NSBackwardsSearch];
-			if (dotRange.location != NSNotFound)
-				lpofn->nFileExtension = static_cast<WORD>(lpofn->nFileOffset + dotRange.location + 1);
+				NSString* fileName = [path lastPathComponent];
+				NSString* dirPath = [path stringByDeletingLastPathComponent];
+				lpofn->nFileOffset = static_cast<WORD>(dirPath.length + 1);
+				NSRange dotRange = [fileName rangeOfString:@"." options:NSBackwardsSearch];
+				if (dotRange.location != NSNotFound)
+					lpofn->nFileExtension = static_cast<WORD>(lpofn->nFileOffset + dotRange.location + 1);
+				else
+					lpofn->nFileExtension = 0;
+			}
 			else
+			{
+				// Multiple files: null-delimited full paths, double-null terminated
+				wchar_t* buf = lpofn->lpstrFile;
+				DWORD remaining = lpofn->nMaxFile;
+
+				for (NSURL* fileUrl in urls)
+				{
+					NSString* path = [fileUrl path];
+					NSData* data = [path dataUsingEncoding:NSUTF32LittleEndianStringEncoding];
+					size_t charCount = data.length / sizeof(wchar_t);
+
+					if (charCount + 2 > remaining)
+					{
+						NSLog(@"Warning: multi-select buffer overflow, %lu files could not be included",
+						      (unsigned long)(urls.count));
+						break;
+					}
+
+					memcpy(buf, data.bytes, charCount * sizeof(wchar_t));
+					buf[charCount] = L'\0';
+					buf += charCount + 1;
+					remaining -= (charCount + 1);
+				}
+				*buf = L'\0'; // Double-null terminator
+
+				lpofn->Flags |= OFN_ALLOWMULTISELECT;
+				lpofn->nFileOffset = 0;
 				lpofn->nFileExtension = 0;
+			}
 		}
 
-		if (lpofn->lpstrFileTitle && lpofn->nMaxFileTitle > 0)
+		if (urls.count == 1 && lpofn->lpstrFileTitle && lpofn->nMaxFileTitle > 0)
 		{
-			NSString* fileName = [path lastPathComponent];
+			NSString* fileName = [[urls[0] path] lastPathComponent];
 			NSStringToWide(fileName, lpofn->lpstrFileTitle, lpofn->nMaxFileTitle);
 		}
 


### PR DESCRIPTION
## Summary

Implements all 6 **Ready** items from the MacNotePP 1.0 project board — the first sprint of P0 core-polish work.

- **#11 Tab modified indicator** — Bullet `•` on dirty tabs, macOS window-edited dot via `SCN_SAVEPOINTLEFT`/`REACHED`
- **#8 Save prompt on close/quit** — NSAlert (Save/Don't Save/Cancel) on close tab, close all, window close, Cmd+Q; re-entry guard prevents double prompts
- **#16 Finder file open** — `application:openFiles:` for double-click/Open With/Dock drag; CLI arg handling; duplicate-tab prevention with canonical path comparison
- **#12 Multi-file open** — `OFN_ALLOWMULTISELECT` in open dialog; shim returns null-delimited full paths via `panel.URLs`
- **#17 App icon & bundle metadata** — `.icns` generation via sips+iconutil CMake pipeline; updated Info.plist with `LSMinimumSystemVersion`, `LSApplicationCategoryType`, copyright
- **#10 About dialog** — Help menu; modal NSPanel with icon, version (from bundle), component versions, build date, clickable repo link, license

### New files
| File | Purpose |
|------|---------|
| `save_prompt.h/mm` | Save-before-close prompts with dirty-doc snapshotting |
| `about_dialog.h/mm` | About dialog with app info and credits |

### Modified files (12)
`app_delegate.mm`, `document_manager.h/mm`, `file_operations.h/mm`, `menu_builder.mm`, `npp_constants.h`, `split_view.mm`, `wndproc.mm`, `win32_menu.mm`, `CMakeLists.txt`, `MacNoteInfo.plist.in`

## Test plan
- [ ] Open file, type → tab shows `filename •` and window close button shows dot
- [ ] Save → bullet and dot disappear; Cmd+Z all the way back → also clears
- [ ] Cmd+W on dirty tab → Save/Don't Save/Cancel prompt; Cancel keeps tab open
- [ ] Cmd+Q with dirty tabs → prompted for each; Cancel aborts quit
- [ ] Window red X with dirty tabs → prompted
- [ ] File > Open → Cmd+click multiple files → all open as tabs
- [ ] Open file already in a tab → switches to existing tab (no duplicate)
- [ ] `open -a MacNote++ file.txt` from Terminal → file opens
- [ ] Drag file onto Dock icon → opens (regression check)
- [ ] Help > About → dialog with icon, version, credits, clickable link
- [ ] App icon visible in Dock, Cmd+Tab, Finder Get Info
- [ ] Split view: dirty indicators work independently per view
- [ ] Dark mode: About dialog and save prompts render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #8, closes #10, closes #11, closes #12, closes #16, closes #17