### PR TITLE
macOS: UTI declarations, zoom, keyboard shortcuts, caret line toggle

### DIFF
--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -335,6 +335,7 @@ add_executable(MacOSNotePP
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/file_monitor_mac.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/save_prompt.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/about_dialog.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/keyboard_shortcuts.mm"
 )
 target_include_directories(MacOSNotePP PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/platform"

--- a/macos/platform/MacNoteInfo.plist.in
+++ b/macos/platform/MacNoteInfo.plist.in
@@ -32,11 +32,248 @@
   <string>public.app-category.developer-tools</string>
   <key>CFBundleDocumentTypes</key>
   <array>
+    <!-- Language-specific types (before generic fallbacks for Finder priority) -->
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>C Source</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>public.c-source</string>
+        <string>public.c-header</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>C++ Source</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>public.c-plus-plus-source</string>
+        <string>public.c-plus-plus-header</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>Python Script</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>public.python-script</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>JavaScript Source</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>com.netscape.javascript-source</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>TypeScript Source</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>ts</string>
+        <string>tsx</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>HTML Document</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>public.html</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>CSS Stylesheet</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>css</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>Markdown Document</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>net.daringfireball.markdown</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>Java Source</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>com.sun.java-source</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>Ruby Script</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>public.ruby-script</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>PHP Script</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>public.php-script</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>Swift Source</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>public.swift-source</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>YAML Document</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>public.yaml</string>
+      </array>
+    </dict>
+    <!-- Types without stable public UTIs: use CFBundleTypeExtensions -->
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>Rust Source</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>rs</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>Go Source</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>go</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>SQL Script</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>sql</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>TOML Document</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>toml</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>Configuration File</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>ini</string>
+        <string>cfg</string>
+      </array>
+    </dict>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>Log File</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>log</string>
+      </array>
+    </dict>
+    <!-- Generic fallback types -->
     <dict>
       <key>CFBundleTypeName</key>
       <string>Plain Text</string>
       <key>CFBundleTypeRole</key>
       <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
       <key>LSItemContentTypes</key>
       <array>
         <string>public.plain-text</string>
@@ -47,6 +284,8 @@
       <string>Source Code</string>
       <key>CFBundleTypeRole</key>
       <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
       <key>LSItemContentTypes</key>
       <array>
         <string>public.source-code</string>
@@ -57,6 +296,8 @@
       <string>XML Document</string>
       <key>CFBundleTypeRole</key>
       <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
       <key>LSItemContentTypes</key>
       <array>
         <string>public.xml</string>
@@ -67,6 +308,8 @@
       <string>JSON Document</string>
       <key>CFBundleTypeRole</key>
       <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
       <key>LSItemContentTypes</key>
       <array>
         <string>public.json</string>
@@ -77,6 +320,8 @@
       <string>Shell Script</string>
       <key>CFBundleTypeRole</key>
       <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
       <key>LSItemContentTypes</key>
       <array>
         <string>public.shell-script</string>
@@ -87,6 +332,8 @@
       <string>All Documents</string>
       <key>CFBundleTypeRole</key>
       <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
       <key>LSItemContentTypes</key>
       <array>
         <string>public.text</string>

--- a/macos/platform/app_delegate.h
+++ b/macos/platform/app_delegate.h
@@ -9,5 +9,9 @@
 @end
 
 @interface NppAppDelegate : NSObject <NSApplicationDelegate, NSWindowDelegate, NSSplitViewDelegate>
+{
+	BOOL _finishedLaunching;
+	NSMutableArray<NSString*>* _pendingFiles;
+}
 - (void)performContextAction:(NSMenuItem*)sender;
 @end

--- a/macos/platform/app_delegate.mm
+++ b/macos/platform/app_delegate.mm
@@ -410,12 +410,36 @@ static void setDockIconFromLogo()
 			openFileAtPath(arg);
 	}
 
+	// Mark init complete and open any files that arrived before Scintilla was ready
+	_finishedLaunching = YES;
+	if (_pendingFiles.count > 0)
+	{
+		for (NSString* path in _pendingFiles)
+			openFileAtPath(path);
+		[_pendingFiles removeAllObjects];
+	}
+
 	NSLog(@"=== Notepad++ macOS Port — Phase 7 ===");
 	NSLog(@"Settings, split view, edit commands, encoding, session, drag-and-drop!");
 }
 
 - (void)application:(NSApplication*)sender openFiles:(NSArray<NSString*>*)filenames
 {
+	// If Scintilla isn't ready yet, queue files for after init completes
+	if (!_finishedLaunching)
+	{
+		if (!_pendingFiles)
+			_pendingFiles = [NSMutableArray array];
+		for (NSString* path in filenames)
+		{
+			BOOL isDir = NO;
+			if ([[NSFileManager defaultManager] fileExistsAtPath:path isDirectory:&isDir] && !isDir)
+				[_pendingFiles addObject:[path copy]];
+		}
+		[sender replyToOpenOrPrint:NSApplicationDelegateReplySuccess];
+		return;
+	}
+
 	BOOL anyOpened = NO;
 	for (NSString* path in filenames)
 	{

--- a/macos/platform/app_delegate.mm
+++ b/macos/platform/app_delegate.mm
@@ -106,6 +106,8 @@ static void setDockIconFromLogo()
 	ctx().fontSize = s.fontSize;
 	ctx().tabWidth = s.tabWidth;
 	ctx().showLineNumbers = s.showLineNumbers;
+	ctx().zoomLevel = s.zoomLevel;
+	ctx().showCaretLine = s.showCaretLine;
 	setDockIconFromLogo();
 
 	ctx().recentFiles.clear();
@@ -483,6 +485,8 @@ static void setDockIconFromLogo()
 	s.fontSize = ctx().fontSize;
 	s.tabWidth = ctx().tabWidth;
 	s.showLineNumbers = ctx().showLineNumbers;
+	s.zoomLevel = ctx().zoomLevel;
+	s.showCaretLine = ctx().showCaretLine;
 	s.wordWrap = ctx().scintillaView ?
 		(ScintillaBridge_sendMessage(ctx().scintillaView, SCI_GETWRAPMODE, 0, 0) != 0) : false;
 

--- a/macos/platform/app_state.h
+++ b/macos/platform/app_state.h
@@ -51,6 +51,8 @@ struct AppContext
 	int tabWidth = 4;
 	std::string fontName = "Menlo";
 	bool showLineNumbers = true;
+	int zoomLevel = 0;
+	bool showCaretLine = true;
 
 	// Split view state
 	void* scintillaView2 = nullptr;

--- a/macos/platform/appearance.mm
+++ b/macos/platform/appearance.mm
@@ -48,6 +48,7 @@ void applyAppearanceToView(void* sci, int langIdx, bool isDark)
 	}
 
 	ScintillaBridge_sendMessage(sci, SCI_SETCARETFORE, isDark ? 0xAEAFAD : 0x000000, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEVISIBLE, ctx().showCaretLine ? 1 : 0, 0);
 	ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEBACK, isDark ? 0x2A2A2A : 0xF0F0F0, 0);
 
 	ScintillaBridge_sendMessage(sci, SCI_STYLESETFORE, 33, isDark ? 0x858585 : 0x808080);

--- a/macos/platform/appearance.mm
+++ b/macos/platform/appearance.mm
@@ -49,7 +49,8 @@ void applyAppearanceToView(void* sci, int langIdx, bool isDark)
 
 	ScintillaBridge_sendMessage(sci, SCI_SETCARETFORE, isDark ? 0xAEAFAD : 0x000000, 0);
 	ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEVISIBLE, ctx().showCaretLine ? 1 : 0, 0);
-	ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEBACK, isDark ? 0x2A2A2A : 0xF0F0F0, 0);
+	if (ctx().showCaretLine)
+		ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEBACK, isDark ? 0x2A2A2A : 0xF0F0F0, 0);
 
 	ScintillaBridge_sendMessage(sci, SCI_STYLESETFORE, 33, isDark ? 0x858585 : 0x808080);
 	ScintillaBridge_sendMessage(sci, SCI_STYLESETBACK, 33, isDark ? 0x1E1E1E : 0xF0F0F0);

--- a/macos/platform/keyboard_shortcuts.h
+++ b/macos/platform/keyboard_shortcuts.h
@@ -1,0 +1,8 @@
+// keyboard_shortcuts.h — Native macOS keyboard shortcut configuration
+// Part of the Notepad++ macOS port modular refactor.
+
+#pragma once
+
+// Configure native macOS keyboard shortcuts on a Scintilla view.
+// Must be called after each ScintillaView is created.
+void configureKeyboardShortcuts(void* sci);

--- a/macos/platform/keyboard_shortcuts.mm
+++ b/macos/platform/keyboard_shortcuts.mm
@@ -1,0 +1,70 @@
+// keyboard_shortcuts.mm — Native macOS keyboard shortcut configuration
+// Part of the Notepad++ macOS port modular refactor.
+//
+// Remaps Scintilla key bindings to match macOS Human Interface Guidelines:
+//   Home/End        → line start/end (not document)
+//   Cmd+Up/Down     → document start/end
+//   Cmd+Left/Right  → line start/end
+//   Opt+Left/Right  → word navigation
+//   Opt+Backspace   → delete word backward
+//   Opt+Delete      → delete word forward
+//   Cmd+Backspace   → delete to line start
+
+#include "keyboard_shortcuts.h"
+#include "npp_constants.h"
+#include "scintilla_bridge.h"
+
+// Pack key + modifiers into wParam for SCI_ASSIGNCMDKEY / SCI_CLEARCMDKEY
+static inline int keyMod(int key, int mod) { return key | (mod << 16); }
+
+// Clear then assign a key binding (avoids conflicts with Scintilla defaults)
+static void reassign(void* sci, int key, int mod, int sciCmd)
+{
+	ScintillaBridge_sendMessage(sci, SCI_CLEARCMDKEY, keyMod(key, mod), 0);
+	ScintillaBridge_sendMessage(sci, SCI_ASSIGNCMDKEY, keyMod(key, mod), sciCmd);
+}
+
+// Bind a Cmd shortcut to both SCMOD_SUPER and SCMOD_META variants.
+// Cocoa Scintilla may map the Command key to either modifier depending on build.
+static void reassignCmd(void* sci, int key, int extraMod, int sciCmd)
+{
+	reassign(sci, key, SCMOD_SUPER | extraMod, sciCmd);
+	reassign(sci, key, SCMOD_META | extraMod, sciCmd);
+}
+
+void configureKeyboardShortcuts(void* sci)
+{
+	if (!sci) return;
+
+	// --- Home/End: line start/end (not document) ---
+	// VCHOME goes to first non-whitespace char (smarter), matching most macOS editors
+	reassign(sci, SCK_HOME, 0,           SCI_VCHOME);
+	reassign(sci, SCK_HOME, SCMOD_SHIFT, SCI_VCHOMEEXTEND);
+	reassign(sci, SCK_END,  0,           SCI_LINEEND);
+	reassign(sci, SCK_END,  SCMOD_SHIFT, SCI_LINEENDEXTEND);
+
+	// --- Cmd+Up/Down: document start/end ---
+	reassignCmd(sci, SCK_UP,   0,           SCI_DOCUMENTSTART);
+	reassignCmd(sci, SCK_UP,   SCMOD_SHIFT, SCI_DOCUMENTSTARTEXTEND);
+	reassignCmd(sci, SCK_DOWN, 0,           SCI_DOCUMENTEND);
+	reassignCmd(sci, SCK_DOWN, SCMOD_SHIFT, SCI_DOCUMENTENDEXTEND);
+
+	// --- Cmd+Left/Right: line start/end ---
+	reassignCmd(sci, SCK_LEFT,  0,           SCI_VCHOME);
+	reassignCmd(sci, SCK_LEFT,  SCMOD_SHIFT, SCI_VCHOMEEXTEND);
+	reassignCmd(sci, SCK_RIGHT, 0,           SCI_LINEEND);
+	reassignCmd(sci, SCK_RIGHT, SCMOD_SHIFT, SCI_LINEENDEXTEND);
+
+	// --- Opt+Left/Right: word navigation ---
+	reassign(sci, SCK_LEFT,  SCMOD_ALT,                SCI_WORDLEFT);
+	reassign(sci, SCK_LEFT,  SCMOD_ALT | SCMOD_SHIFT,  SCI_WORDLEFTEXTEND);
+	reassign(sci, SCK_RIGHT, SCMOD_ALT,                SCI_WORDRIGHT);
+	reassign(sci, SCK_RIGHT, SCMOD_ALT | SCMOD_SHIFT,  SCI_WORDRIGHTEXTEND);
+
+	// --- Opt+Backspace/Delete: delete word ---
+	reassign(sci, SCK_BACK,   SCMOD_ALT, SCI_DELWORDLEFT);
+	reassign(sci, SCK_DELETE, SCMOD_ALT, SCI_DELWORDRIGHT);
+
+	// --- Cmd+Backspace: delete to line start ---
+	reassignCmd(sci, SCK_BACK, 0, SCI_DELLINELEFT);
+}

--- a/macos/platform/menu_builder.mm
+++ b/macos/platform/menu_builder.mm
@@ -97,6 +97,10 @@ HMENU buildMenuBar()
 	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_MOVETOOTHER, L"&Move to Other View");
 	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_CLONETOOTHER, L"&Clone to Other View");
 	AppendMenuW(hViewMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_ZOOMIN, L"Zoom &In\tCtrl+=");
+	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_ZOOMOUT, L"Zoom &Out\tCtrl+-");
+	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_ZOOMRESTORE, L"&Reset Zoom\tCtrl+0");
+	AppendMenuW(hViewMenu, MF_SEPARATOR, 0, nullptr);
 	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_PREFERENCES, L"&Preferences...\tCtrl+,");
 	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hViewMenu), L"&View");
 

--- a/macos/platform/npp_constants.h
+++ b/macos/platform/npp_constants.h
@@ -60,6 +60,11 @@
 #define IDM_VIEW_MOVETOOTHER         42072
 #define IDM_VIEW_CLONETOOTHER        42073
 
+// Zoom commands
+#define IDM_VIEW_ZOOMIN              42074
+#define IDM_VIEW_ZOOMOUT             42075
+#define IDM_VIEW_ZOOMRESTORE         42076
+
 // Help menu commands
 #define IDM_HELP_ABOUT           46001
 
@@ -214,7 +219,53 @@ enum {
 	SCI_SETEOLMODE = 2031,
 	SCI_GETEOLMODE = 2030,
 	SCI_CONVERTEOLS = 2029,
+
+	// Zoom
+	SCI_ZOOMIN = 2333,
+	SCI_ZOOMOUT = 2334,
+	SCI_SETZOOM = 2373,
+	SCI_GETZOOM = 2374,
+
+	// Key binding support
+	SCI_ASSIGNCMDKEY = 2070,
+	SCI_CLEARCMDKEY = 2071,
+
+	// Movement commands
+	SCI_DOCUMENTSTART = 2316,
+	SCI_DOCUMENTSTARTEXTEND = 2317,
+	SCI_DOCUMENTEND = 2318,
+	SCI_DOCUMENTENDEXTEND = 2319,
+	SCI_HOME = 2312,
+	SCI_HOMEEXTEND = 2313,
+	SCI_VCHOME = 2331,
+	SCI_VCHOMEEXTEND = 2332,
+	SCI_LINEEND = 2314,
+	SCI_LINEENDEXTEND = 2315,
+	SCI_WORDLEFT = 2308,
+	SCI_WORDLEFTEXTEND = 2309,
+	SCI_WORDRIGHT = 2310,
+	SCI_WORDRIGHTEXTEND = 2311,
+	SCI_DELWORDLEFT = 2335,
+	SCI_DELWORDRIGHT = 2336,
+	SCI_DELLINELEFT = 2395,
 };
+
+// Scintilla key constants
+#define SCK_DOWN    300
+#define SCK_UP      301
+#define SCK_LEFT    302
+#define SCK_RIGHT   303
+#define SCK_HOME    304
+#define SCK_END     305
+#define SCK_DELETE  308
+#define SCK_BACK    8
+
+// Scintilla modifier masks
+#define SCMOD_SHIFT 1
+#define SCMOD_CTRL  2
+#define SCMOD_ALT   4
+#define SCMOD_SUPER 8
+#define SCMOD_META  16
 
 // Scintilla search flags
 #define SCFIND_MATCHCASE  4

--- a/macos/platform/preferences_dialog.mm
+++ b/macos/platform/preferences_dialog.mm
@@ -13,7 +13,7 @@
 void showPreferencesDlg()
 {
 	@autoreleasepool {
-		NSPanel* panel = [[NSPanel alloc] initWithContentRect:NSMakeRect(0, 0, 380, 240)
+		NSPanel* panel = [[NSPanel alloc] initWithContentRect:NSMakeRect(0, 0, 380, 270)
 		                                    styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable
 		                                    backing:NSBackingStoreBuffered
 		                                    defer:NO];
@@ -22,7 +22,7 @@ void showPreferencesDlg()
 
 		NSView* content = panel.contentView;
 
-		NSTextField* fontLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 195, 100, 20)];
+		NSTextField* fontLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 225, 100, 20)];
 		fontLabel.stringValue = @"Font:";
 		fontLabel.bezeled = NO;
 		fontLabel.drawsBackground = NO;
@@ -30,7 +30,7 @@ void showPreferencesDlg()
 		fontLabel.selectable = NO;
 		[content addSubview:fontLabel];
 
-		NSPopUpButton* fontPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(130, 192, 200, 26) pullsDown:NO];
+		NSPopUpButton* fontPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(130, 222, 200, 26) pullsDown:NO];
 		NSArray* fonts = @[@"Menlo", @"Monaco", @"SF Mono", @"Courier New", @"Consolas",
 		                   @"Fira Code", @"JetBrains Mono", @"Source Code Pro"];
 		for (NSString* f in fonts)
@@ -41,7 +41,7 @@ void showPreferencesDlg()
 			[fontPopup selectItemAtIndex:0];
 		[content addSubview:fontPopup];
 
-		NSTextField* sizeLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 160, 100, 20)];
+		NSTextField* sizeLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 190, 100, 20)];
 		sizeLabel.stringValue = @"Font Size:";
 		sizeLabel.bezeled = NO;
 		sizeLabel.drawsBackground = NO;
@@ -49,7 +49,7 @@ void showPreferencesDlg()
 		sizeLabel.selectable = NO;
 		[content addSubview:sizeLabel];
 
-		NSPopUpButton* sizePopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(130, 157, 80, 26) pullsDown:NO];
+		NSPopUpButton* sizePopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(130, 187, 80, 26) pullsDown:NO];
 		NSArray* sizes = @[@"9", @"10", @"11", @"12", @"13", @"14", @"16", @"18", @"20", @"24"];
 		for (NSString* s in sizes)
 			[sizePopup addItemWithTitle:s];
@@ -58,7 +58,7 @@ void showPreferencesDlg()
 			[sizePopup selectItemAtIndex:4];
 		[content addSubview:sizePopup];
 
-		NSTextField* tabLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 125, 100, 20)];
+		NSTextField* tabLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 155, 100, 20)];
 		tabLabel.stringValue = @"Tab Width:";
 		tabLabel.bezeled = NO;
 		tabLabel.drawsBackground = NO;
@@ -66,7 +66,7 @@ void showPreferencesDlg()
 		tabLabel.selectable = NO;
 		[content addSubview:tabLabel];
 
-		NSPopUpButton* tabPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(130, 122, 80, 26) pullsDown:NO];
+		NSPopUpButton* tabPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(130, 152, 80, 26) pullsDown:NO];
 		NSArray* tabSizes = @[@"2", @"3", @"4", @"5", @"6", @"7", @"8"];
 		for (NSString* t in tabSizes)
 			[tabPopup addItemWithTitle:t];
@@ -75,7 +75,13 @@ void showPreferencesDlg()
 			[tabPopup selectItemAtIndex:2];
 		[content addSubview:tabPopup];
 
-		NSTextField* darkLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 85, 340, 20)];
+		NSButton* caretLineCheck = [[NSButton alloc] initWithFrame:NSMakeRect(20, 90, 300, 20)];
+		caretLineCheck.title = @"Highlight current line";
+		[caretLineCheck setButtonType:NSButtonTypeSwitch];
+		caretLineCheck.state = ctx().showCaretLine ? NSControlStateValueOn : NSControlStateValueOff;
+		[content addSubview:caretLineCheck];
+
+		NSTextField* darkLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 65, 340, 20)];
 		darkLabel.stringValue = @"Dark mode follows system preferences.";
 		darkLabel.bezeled = NO;
 		darkLabel.drawsBackground = NO;
@@ -111,6 +117,7 @@ void showPreferencesDlg()
 			ctx().fontName = [selFont UTF8String];
 			ctx().fontSize = sizePopup.titleOfSelectedItem.intValue;
 			ctx().tabWidth = tabPopup.titleOfSelectedItem.intValue;
+			ctx().showCaretLine = (caretLineCheck.state == NSControlStateValueOn);
 
 			void* views[] = { ctx().scintillaView, ctx().scintillaView2 };
 			for (void* sci : views)
@@ -134,6 +141,7 @@ void showPreferencesDlg()
 			ss.fontName = ctx().fontName;
 			ss.fontSize = ctx().fontSize;
 			ss.tabWidth = ctx().tabWidth;
+			ss.showCaretLine = ctx().showCaretLine;
 			SettingsManager::instance().save();
 		}
 

--- a/macos/platform/scintilla_config.mm
+++ b/macos/platform/scintilla_config.mm
@@ -45,7 +45,8 @@ void configureScintilla(void* sci)
 	ScintillaBridge_sendMessage(sci, SCI_SETAUTOMATICFOLD, SC_AUTOMATICFOLD_CLICK, 0);
 
 	ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEVISIBLE, ctx().showCaretLine ? 1 : 0, 0);
-	ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEBACK, 0xF0F0F0, 0);
+	if (ctx().showCaretLine)
+		ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEBACK, 0xF0F0F0, 0);
 
 	if (ctx().zoomLevel != 0)
 		ScintillaBridge_sendMessage(sci, SCI_SETZOOM, ctx().zoomLevel, 0);

--- a/macos/platform/scintilla_config.mm
+++ b/macos/platform/scintilla_config.mm
@@ -5,6 +5,7 @@
 #include "npp_constants.h"
 #include "app_state.h"
 #include "scintilla_bridge.h"
+#include "keyboard_shortcuts.h"
 
 void configureScintilla(void* sci)
 {
@@ -43,6 +44,11 @@ void configureScintilla(void* sci)
 	ScintillaBridge_sendMessage(sci, SCI_SETFOLDFLAGS, 16, 0);
 	ScintillaBridge_sendMessage(sci, SCI_SETAUTOMATICFOLD, SC_AUTOMATICFOLD_CLICK, 0);
 
-	ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEVISIBLE, 1, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEVISIBLE, ctx().showCaretLine ? 1 : 0, 0);
 	ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEBACK, 0xF0F0F0, 0);
+
+	if (ctx().zoomLevel != 0)
+		ScintillaBridge_sendMessage(sci, SCI_SETZOOM, ctx().zoomLevel, 0);
+
+	configureKeyboardShortcuts(sci);
 }

--- a/macos/platform/settings_manager.h
+++ b/macos/platform/settings_manager.h
@@ -21,6 +21,8 @@ struct AppSettings
 	// View state
 	bool wordWrap = false;
 	bool showLineNumbers = true;
+	int zoomLevel = 0;
+	bool showCaretLine = true;
 
 	// Recent files
 	std::vector<std::string> recentFiles;

--- a/macos/platform/settings_manager.mm
+++ b/macos/platform/settings_manager.mm
@@ -73,6 +73,8 @@ bool SettingsManager::load()
 	// View state
 	if ([json[@"wordWrap"] isKindOfClass:[NSNumber class]])        settings.wordWrap = [json[@"wordWrap"] boolValue];
 	if ([json[@"showLineNumbers"] isKindOfClass:[NSNumber class]]) settings.showLineNumbers = [json[@"showLineNumbers"] boolValue];
+	if ([json[@"zoomLevel"] isKindOfClass:[NSNumber class]])       settings.zoomLevel = [json[@"zoomLevel"] intValue];
+	if ([json[@"showCaretLine"] isKindOfClass:[NSNumber class]])   settings.showCaretLine = [json[@"showCaretLine"] boolValue];
 
 	// Recent files
 	settings.recentFiles.clear();
@@ -130,6 +132,8 @@ bool SettingsManager::save()
 		@"tabWidth":     @(settings.tabWidth),
 		@"wordWrap":     @(settings.wordWrap),
 		@"showLineNumbers": @(settings.showLineNumbers),
+		@"zoomLevel":    @(settings.zoomLevel),
+		@"showCaretLine": @(settings.showCaretLine),
 		@"recentFiles":  recentArr
 	};
 

--- a/macos/platform/wndproc.mm
+++ b/macos/platform/wndproc.mm
@@ -271,6 +271,36 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 					doJoinLines();
 					return 0;
 
+				case IDM_VIEW_ZOOMIN:
+				{
+					if (ctx().scintillaView)
+						ScintillaBridge_sendMessage(ctx().scintillaView, SCI_ZOOMIN, 0, 0);
+					if (ctx().isSplit && ctx().scintillaView2)
+						ScintillaBridge_sendMessage(ctx().scintillaView2, SCI_ZOOMIN, 0, 0);
+					if (ctx().scintillaView)
+						ctx().zoomLevel = static_cast<int>(ScintillaBridge_sendMessage(ctx().scintillaView, SCI_GETZOOM, 0, 0));
+					return 0;
+				}
+				case IDM_VIEW_ZOOMOUT:
+				{
+					if (ctx().scintillaView)
+						ScintillaBridge_sendMessage(ctx().scintillaView, SCI_ZOOMOUT, 0, 0);
+					if (ctx().isSplit && ctx().scintillaView2)
+						ScintillaBridge_sendMessage(ctx().scintillaView2, SCI_ZOOMOUT, 0, 0);
+					if (ctx().scintillaView)
+						ctx().zoomLevel = static_cast<int>(ScintillaBridge_sendMessage(ctx().scintillaView, SCI_GETZOOM, 0, 0));
+					return 0;
+				}
+				case IDM_VIEW_ZOOMRESTORE:
+				{
+					ctx().zoomLevel = 0;
+					if (ctx().scintillaView)
+						ScintillaBridge_sendMessage(ctx().scintillaView, SCI_SETZOOM, 0, 0);
+					if (ctx().isSplit && ctx().scintillaView2)
+						ScintillaBridge_sendMessage(ctx().scintillaView2, SCI_SETZOOM, 0, 0);
+					return 0;
+				}
+
 				case IDM_VIEW_SPLIT:
 					doSplit();
 					return 0;


### PR DESCRIPTION
## Summary
- **#18 (P0-04):** Add 19 language-specific `CFBundleDocumentTypes` with `LSHandlerRank=Alternate` for .py, .js, .ts, .html, .css, .md, .rs, .go, .swift, .sql, .java, .rb, .php, .yaml, .toml, .ini/.cfg, .log; uses `CFBundleTypeExtensions` for types without stable UTIs
- **#19 (P0-05):** Zoom in/out/restore (Cmd+=/-/0) via Scintilla API with split-view sync, settings persistence, and `SCI_GETZOOM` read-back to avoid drift at clamp limits
- **#20 (P0-06):** New `keyboard_shortcuts` module remapping keys to macOS HIG conventions (Home/End→line, Cmd+arrows→doc/line, Opt+arrows→word, Opt+Backspace→delete word, Cmd+Backspace→delete to line start); binds both `SCMOD_SUPER` and `SCMOD_META` for Cmd portability
- **#21 (P0-07):** Centralize caret-line setup with persisted on/off toggle in Preferences; theme-aware via `appearance.mm`; applied to both split views

### Bug fixes
- Fix Finder "Open With" race condition: files arriving before Scintilla init are queued and opened after startup completes
- Fix caret line toggle: `SCI_SETCARETLINEBACK` implicitly re-enables the element in Scintilla 5.x; skip setting back color when disabled

## Test plan
- [ ] Build: `cmake -G Xcode .. && cmake --build . --target MacOSNotePP_package`
- [ ] Validate plist: `plutil -lint MacNote++.app/Contents/Info.plist`
- [ ] Right-click `.py`, `.rs`, `.go`, `.toml` in Finder → "Open With" shows MacNote++
- [ ] Right-click a file → "Open With → MacNote++" when app is NOT running → file opens in new tab
- [ ] Cmd+= zooms in, Cmd+- zooms out, Cmd+0 resets; both split views sync
- [ ] Quit and relaunch → zoom level restored
- [ ] Home/End moves to line start/end (not document)
- [ ] Cmd+Up/Down moves to document start/end
- [ ] Opt+Left/Right navigates by word; Opt+Backspace deletes word backward
- [ ] Cmd+Backspace deletes to line start
- [ ] All above work in both split view panes
- [ ] Preferences → uncheck "Highlight current line" → caret line disappears immediately
- [ ] Move cursor around → no gray highlight visible
- [ ] Re-check "Highlight current line" → caret line reappears
- [ ] Caret line preference persists across restart
- [ ] Theme change (light↔dark) updates caret line color immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)