### PR TITLE
macos: add auto-indent preference toggle

### DIFF
--- a/macos/platform/app_delegate.mm
+++ b/macos/platform/app_delegate.mm
@@ -110,6 +110,7 @@ static void setDockIconFromLogo()
 	ctx().showLineNumbers = s.showLineNumbers;
 	ctx().zoomLevel = s.zoomLevel;
 	ctx().showCaretLine = s.showCaretLine;
+	ctx().autoIndent = s.autoIndent;
 	setDockIconFromLogo();
 
 	ctx().recentFiles.clear();
@@ -298,7 +299,8 @@ static void setDockIconFromLogo()
 				}
 				else if (scn->nmhdr.code == SCN_CHARADDED)
 				{
-					performAutoIndent(ctx().scintillaView, scn->ch);
+					if (ctx().autoIndent)
+						performAutoIndent(ctx().scintillaView, scn->ch);
 				}
 			}
 		});
@@ -528,6 +530,7 @@ static void setDockIconFromLogo()
 	s.showLineNumbers = ctx().showLineNumbers;
 	s.zoomLevel = ctx().zoomLevel;
 	s.showCaretLine = ctx().showCaretLine;
+	s.autoIndent = ctx().autoIndent;
 	s.wordWrap = ctx().scintillaView ?
 		(ScintillaBridge_sendMessage(ctx().scintillaView, SCI_GETWRAPMODE, 0, 0) != 0) : false;
 

--- a/macos/platform/app_state.h
+++ b/macos/platform/app_state.h
@@ -53,6 +53,7 @@ struct AppContext
 	bool showLineNumbers = true;
 	int zoomLevel = 0;
 	bool showCaretLine = true;
+	bool autoIndent = true;
 
 	// Split view state
 	void* scintillaView2 = nullptr;

--- a/macos/platform/preferences_dialog.mm
+++ b/macos/platform/preferences_dialog.mm
@@ -13,7 +13,7 @@
 void showPreferencesDlg()
 {
 	@autoreleasepool {
-		NSPanel* panel = [[NSPanel alloc] initWithContentRect:NSMakeRect(0, 0, 380, 270)
+		NSPanel* panel = [[NSPanel alloc] initWithContentRect:NSMakeRect(0, 0, 380, 300)
 		                                    styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable
 		                                    backing:NSBackingStoreBuffered
 		                                    defer:NO];
@@ -81,7 +81,13 @@ void showPreferencesDlg()
 		caretLineCheck.state = ctx().showCaretLine ? NSControlStateValueOn : NSControlStateValueOff;
 		[content addSubview:caretLineCheck];
 
-		NSTextField* darkLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 65, 340, 20)];
+		NSButton* autoIndentCheck = [[NSButton alloc] initWithFrame:NSMakeRect(20, 65, 300, 20)];
+		autoIndentCheck.title = @"Auto-indent on Enter";
+		[autoIndentCheck setButtonType:NSButtonTypeSwitch];
+		autoIndentCheck.state = ctx().autoIndent ? NSControlStateValueOn : NSControlStateValueOff;
+		[content addSubview:autoIndentCheck];
+
+		NSTextField* darkLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 40, 340, 20)];
 		darkLabel.stringValue = @"Dark mode follows system preferences.";
 		darkLabel.bezeled = NO;
 		darkLabel.drawsBackground = NO;
@@ -118,6 +124,7 @@ void showPreferencesDlg()
 			ctx().fontSize = sizePopup.titleOfSelectedItem.intValue;
 			ctx().tabWidth = tabPopup.titleOfSelectedItem.intValue;
 			ctx().showCaretLine = (caretLineCheck.state == NSControlStateValueOn);
+			ctx().autoIndent = (autoIndentCheck.state == NSControlStateValueOn);
 
 			void* views[] = { ctx().scintillaView, ctx().scintillaView2 };
 			for (void* sci : views)
@@ -142,6 +149,7 @@ void showPreferencesDlg()
 			ss.fontSize = ctx().fontSize;
 			ss.tabWidth = ctx().tabWidth;
 			ss.showCaretLine = ctx().showCaretLine;
+			ss.autoIndent = ctx().autoIndent;
 			SettingsManager::instance().save();
 		}
 

--- a/macos/platform/settings_manager.h
+++ b/macos/platform/settings_manager.h
@@ -23,6 +23,7 @@ struct AppSettings
 	bool showLineNumbers = true;
 	int zoomLevel = 0;
 	bool showCaretLine = true;
+	bool autoIndent = true;
 
 	// Recent files
 	std::vector<std::string> recentFiles;

--- a/macos/platform/settings_manager.mm
+++ b/macos/platform/settings_manager.mm
@@ -75,6 +75,7 @@ bool SettingsManager::load()
 	if ([json[@"showLineNumbers"] isKindOfClass:[NSNumber class]]) settings.showLineNumbers = [json[@"showLineNumbers"] boolValue];
 	if ([json[@"zoomLevel"] isKindOfClass:[NSNumber class]])       settings.zoomLevel = [json[@"zoomLevel"] intValue];
 	if ([json[@"showCaretLine"] isKindOfClass:[NSNumber class]])   settings.showCaretLine = [json[@"showCaretLine"] boolValue];
+	if ([json[@"autoIndent"] isKindOfClass:[NSNumber class]])      settings.autoIndent = [json[@"autoIndent"] boolValue];
 
 	// Recent files
 	settings.recentFiles.clear();
@@ -134,6 +135,7 @@ bool SettingsManager::save()
 		@"showLineNumbers": @(settings.showLineNumbers),
 		@"zoomLevel":    @(settings.zoomLevel),
 		@"showCaretLine": @(settings.showCaretLine),
+		@"autoIndent":   @(settings.autoIndent),
 		@"recentFiles":  recentArr
 	};
 

--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -153,7 +153,8 @@ void doSplit()
 					}
 					else if (scn->nmhdr.code == SCN_CHARADDED)
 					{
-						performAutoIndent(ctx().scintillaView2, scn->ch);
+						if (ctx().autoIndent)
+							performAutoIndent(ctx().scintillaView2, scn->ch);
 					}
 				}
 			});


### PR DESCRIPTION
## Summary
- add an "Auto-indent on Enter" checkbox to the macOS Preferences dialog
- persist autoIndent in settings load/save JSON
- apply the setting in both primary and split editors by gating SCN_CHARADDED auto-indent handling

## Validation
- cmake --build macos/build --target npp_macos_compile_test --config Debug