### PR TITLE
macOS: Sprint 5 — editor text polish (6 features)

### DIFF
--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -338,6 +338,7 @@ add_executable(MacOSNotePP
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/keyboard_shortcuts.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/brace_match.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/auto_indent.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/file_path_ops.mm"
 )
 target_include_directories(MacOSNotePP PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/platform"

--- a/macos/platform/app_delegate.mm
+++ b/macos/platform/app_delegate.mm
@@ -111,6 +111,10 @@ static void setDockIconFromLogo()
 	ctx().zoomLevel = s.zoomLevel;
 	ctx().showCaretLine = s.showCaretLine;
 	ctx().autoIndent = s.autoIndent;
+	ctx().useTabs = s.useTabs;
+	ctx().showWhitespace = s.showWhitespace;
+	ctx().showEol = s.showEol;
+	ctx().showIndentGuides = s.showIndentGuides;
 	setDockIconFromLogo();
 
 	ctx().recentFiles.clear();
@@ -149,6 +153,7 @@ static void setDockIconFromLogo()
 		ctx().mainWindow = (__bridge NSWindow*)mainInfo->nativeWindow;
 		ctx().mainWindow.delegate = self;
 		[ctx().mainWindow setMinSize:NSMakeSize(500, 400)];
+		ctx().mainWindow.collectionBehavior |= NSWindowCollectionBehaviorFullScreenPrimary;
 
 		if (s.windowX != 100 || s.windowY != 100)
 		{
@@ -300,7 +305,12 @@ static void setDockIconFromLogo()
 				else if (scn->nmhdr.code == SCN_CHARADDED)
 				{
 					if (ctx().autoIndent)
-						performAutoIndent(ctx().scintillaView, scn->ch);
+					{
+						int langIdx = -1;
+						if (ctx().activeTab >= 0 && ctx().activeTab < static_cast<int>(ctx().documents.size()))
+							langIdx = ctx().documents[ctx().activeTab].languageIndex;
+						performAutoIndent(ctx().scintillaView, scn->ch, langIdx);
+					}
 				}
 			}
 		});
@@ -531,6 +541,10 @@ static void setDockIconFromLogo()
 	s.zoomLevel = ctx().zoomLevel;
 	s.showCaretLine = ctx().showCaretLine;
 	s.autoIndent = ctx().autoIndent;
+	s.useTabs = ctx().useTabs;
+	s.showWhitespace = ctx().showWhitespace;
+	s.showEol = ctx().showEol;
+	s.showIndentGuides = ctx().showIndentGuides;
 	s.wordWrap = ctx().scintillaView ?
 		(ScintillaBridge_sendMessage(ctx().scintillaView, SCI_GETWRAPMODE, 0, 0) != 0) : false;
 

--- a/macos/platform/app_state.h
+++ b/macos/platform/app_state.h
@@ -54,6 +54,10 @@ struct AppContext
 	int zoomLevel = 0;
 	bool showCaretLine = true;
 	bool autoIndent = true;
+	bool useTabs = false;
+	bool showWhitespace = false;
+	bool showEol = false;
+	bool showIndentGuides = false;
 
 	// Split view state
 	void* scintillaView2 = nullptr;

--- a/macos/platform/auto_indent.h
+++ b/macos/platform/auto_indent.h
@@ -2,4 +2,5 @@
 
 // Perform auto-indentation after a newline character is added.
 // Call this from SCN_CHARADDED with the character that was added.
-void performAutoIndent(void* sci, int charAdded);
+// languageIndex is used to gate brace-aware indentation to C-style languages.
+void performAutoIndent(void* sci, int charAdded, int languageIndex = -1);

--- a/macos/platform/auto_indent.mm
+++ b/macos/platform/auto_indent.mm
@@ -55,11 +55,25 @@ void performAutoIndent(void* sci, int charAdded, int languageIndex)
 
 			if (isOnlyWhitespaceBefore(buf.data(), prefixLen) && curLine > 0)
 			{
-				intptr_t prevIndent = ScintillaBridge_sendMessage(sci, SCI_GETLINEINDENTATION, curLine - 1, 0);
+				intptr_t prevLine = curLine - 1;
+				intptr_t prevIndent = ScintillaBridge_sendMessage(sci, SCI_GETLINEINDENTATION, prevLine, 0);
 				intptr_t tabWidth = ScintillaBridge_sendMessage(sci, SCI_GETTABWIDTH, 0, 0);
-				// Indent unit is always measured in columns
-				intptr_t newIndent = prevIndent - tabWidth;
-				if (newIndent < 0) newIndent = 0;
+
+				// Check if previous line ends with '{' (empty block case).
+				// If so, align '}' with the '{' line rather than outdenting further.
+				intptr_t prevLineLen = ScintillaBridge_sendMessage(sci, SCI_LINELENGTH, prevLine, 0);
+				std::vector<char> prevBuf(prevLineLen + 1, 0);
+				ScintillaBridge_sendMessage(sci, SCI_GETLINE, prevLine, (intptr_t)prevBuf.data());
+				char lastCh = lastNonWS(prevBuf.data(), prevLineLen);
+
+				intptr_t newIndent;
+				if (lastCh == '{')
+					newIndent = prevIndent;
+				else
+				{
+					newIndent = prevIndent - tabWidth;
+					if (newIndent < 0) newIndent = 0;
+				}
 
 				ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
 				ScintillaBridge_sendMessage(sci, SCI_SETLINEINDENTATION, curLine, newIndent);

--- a/macos/platform/auto_indent.mm
+++ b/macos/platform/auto_indent.mm
@@ -8,17 +8,106 @@
 #include <string>
 #include <vector>
 
-// Find the last non-whitespace character on a line (excluding EOL chars).
-static char lastNonWS(const char* buf, intptr_t len)
+// Find the last significant character on a C-style source line.
+// Trailing comments and quoted content are ignored.
+static char lastSignificantCStyleChar(const char* buf, intptr_t len)
 {
-	for (intptr_t i = len - 1; i >= 0; --i)
+	char last = '\0';
+	bool inLineComment = false;
+	bool inBlockComment = false;
+	bool inString = false;
+	bool inChar = false;
+	bool escaped = false;
+
+	for (intptr_t i = 0; i < len; ++i)
 	{
 		char c = buf[i];
+
+		if (inLineComment)
+		{
+			if (c == '\r' || c == '\n')
+				inLineComment = false;
+			continue;
+		}
+
+		if (inBlockComment)
+		{
+			if (c == '*' && (i + 1) < len && buf[i + 1] == '/')
+			{
+				inBlockComment = false;
+				++i;
+			}
+			continue;
+		}
+
+		if (inString)
+		{
+			if (escaped)
+			{
+				escaped = false;
+				continue;
+			}
+			if (c == '\\')
+			{
+				escaped = true;
+				continue;
+			}
+			if (c == '"')
+				inString = false;
+			continue;
+		}
+
+		if (inChar)
+		{
+			if (escaped)
+			{
+				escaped = false;
+				continue;
+			}
+			if (c == '\\')
+			{
+				escaped = true;
+				continue;
+			}
+			if (c == '\'')
+				inChar = false;
+			continue;
+		}
+
+		if (c == '/' && (i + 1) < len)
+		{
+			if (buf[i + 1] == '/')
+			{
+				inLineComment = true;
+				++i;
+				continue;
+			}
+			if (buf[i + 1] == '*')
+			{
+				inBlockComment = true;
+				++i;
+				continue;
+			}
+		}
+
+		if (c == '"')
+		{
+			inString = true;
+			continue;
+		}
+		if (c == '\'')
+		{
+			inChar = true;
+			continue;
+		}
+
 		if (c == '\r' || c == '\n' || c == ' ' || c == '\t')
 			continue;
-		return c;
+
+		last = c;
 	}
-	return '\0';
+
+	return last;
 }
 
 // Check if a line contains only whitespace before the given position.
@@ -64,10 +153,10 @@ void performAutoIndent(void* sci, int charAdded, int languageIndex)
 				intptr_t prevLineLen = ScintillaBridge_sendMessage(sci, SCI_LINELENGTH, prevLine, 0);
 				std::vector<char> prevBuf(prevLineLen + 1, 0);
 				ScintillaBridge_sendMessage(sci, SCI_GETLINE, prevLine, (intptr_t)prevBuf.data());
-				char lastCh = lastNonWS(prevBuf.data(), prevLineLen);
+				char prevSigChar = lastSignificantCStyleChar(prevBuf.data(), prevLineLen);
 
 				intptr_t newIndent;
-				if (lastCh == '{')
+				if (prevSigChar == '{')
 					newIndent = prevIndent;
 				else
 				{
@@ -131,8 +220,8 @@ void performAutoIndent(void* sci, int charAdded, int languageIndex)
 	bool addIndent = false;
 	if (isCStyle)
 	{
-		char last = lastNonWS(lineBuf.data(), prevLineLen);
-		if (last == '{')
+		char prevSigChar = lastSignificantCStyleChar(lineBuf.data(), prevLineLen);
+		if (prevSigChar == '{')
 			addIndent = true;
 	}
 

--- a/macos/platform/auto_indent.mm
+++ b/macos/platform/auto_indent.mm
@@ -1,15 +1,78 @@
-// auto_indent.mm — Auto-indentation on Enter
+// auto_indent.mm — Auto-indentation on Enter + smart brace indentation
 // Part of the Notepad++ macOS port modular refactor.
 
 #include "auto_indent.h"
 #include "npp_constants.h"
+#include "language_defs.h"
 #include "scintilla_bridge.h"
 #include <string>
 #include <vector>
 
-void performAutoIndent(void* sci, int charAdded)
+// Find the last non-whitespace character on a line (excluding EOL chars).
+static char lastNonWS(const char* buf, intptr_t len)
+{
+	for (intptr_t i = len - 1; i >= 0; --i)
+	{
+		char c = buf[i];
+		if (c == '\r' || c == '\n' || c == ' ' || c == '\t')
+			continue;
+		return c;
+	}
+	return '\0';
+}
+
+// Check if a line contains only whitespace before the given position.
+static bool isOnlyWhitespaceBefore(const char* buf, intptr_t len)
+{
+	for (intptr_t i = 0; i < len; ++i)
+	{
+		if (buf[i] != ' ' && buf[i] != '\t')
+			return false;
+	}
+	return true;
+}
+
+void performAutoIndent(void* sci, int charAdded, int languageIndex)
 {
 	if (!sci) return;
+
+	bool isCStyle = isCStyleLanguage(languageIndex);
+
+	// --- Handle '}' outdent for C-style languages ---
+	if (isCStyle && charAdded == '}')
+	{
+		intptr_t curPos = ScintillaBridge_sendMessage(sci, SCI_GETCURRENTPOS, 0, 0);
+		intptr_t curLine = ScintillaBridge_sendMessage(sci, SCI_LINEFROMPOSITION, curPos, 0);
+
+		// Get current line content up to cursor
+		intptr_t lineStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, curLine, 0);
+		intptr_t prefixLen = curPos - lineStart - 1; // -1 for the '}' just typed
+		if (prefixLen >= 0)
+		{
+			std::vector<char> buf(prefixLen + 1, 0);
+			for (intptr_t i = 0; i < prefixLen; ++i)
+				buf[i] = static_cast<char>(ScintillaBridge_sendMessage(sci, SCI_GETCHARAT, lineStart + i, 0));
+
+			if (isOnlyWhitespaceBefore(buf.data(), prefixLen) && curLine > 0)
+			{
+				intptr_t prevIndent = ScintillaBridge_sendMessage(sci, SCI_GETLINEINDENTATION, curLine - 1, 0);
+				intptr_t tabWidth = ScintillaBridge_sendMessage(sci, SCI_GETTABWIDTH, 0, 0);
+				// Indent unit is always measured in columns
+				intptr_t newIndent = prevIndent - tabWidth;
+				if (newIndent < 0) newIndent = 0;
+
+				ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
+				ScintillaBridge_sendMessage(sci, SCI_SETLINEINDENTATION, curLine, newIndent);
+				// Position cursor after the indentation + the '}'
+				intptr_t newLineEnd = ScintillaBridge_sendMessage(sci, SCI_GETLINEENDPOSITION, curLine, 0);
+				ScintillaBridge_sendMessage(sci, SCI_GOTOPOS, newLineEnd, 0);
+				ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
+			}
+		}
+		return;
+	}
+
+	// --- Handle newline auto-indent ---
 
 	// CRLF guard: when EOL mode is CRLF, Scintilla fires SCN_CHARADDED for both
 	// '\r' and '\n'. Skip '\r' unless the EOL mode is CR-only.
@@ -33,11 +96,6 @@ void performAutoIndent(void* sci, int charAdded)
 
 	intptr_t prevLine = curLine - 1;
 
-	// Quick check: if previous line has no indentation, nothing to do
-	intptr_t indent = ScintillaBridge_sendMessage(sci, SCI_GETLINEINDENTATION, prevLine, 0);
-	if (indent <= 0)
-		return;
-
 	// Get previous line content and extract its leading whitespace
 	intptr_t prevLineLen = ScintillaBridge_sendMessage(sci, SCI_LINELENGTH, prevLine, 0);
 	if (prevLineLen <= 0)
@@ -55,11 +113,32 @@ void performAutoIndent(void* sci, int charAdded)
 			break;
 	}
 
-	if (leadingWS.empty())
+	// Check if previous line ends with '{' for C-style smart indent
+	bool addIndent = false;
+	if (isCStyle)
+	{
+		char last = lastNonWS(lineBuf.data(), prevLineLen);
+		if (last == '{')
+			addIndent = true;
+	}
+
+	if (leadingWS.empty() && !addIndent)
 		return;
+
+	std::string indent = leadingWS;
+	if (addIndent)
+	{
+		// Add one indent unit using the current tab/space setting
+		intptr_t useTabs = ScintillaBridge_sendMessage(sci, SCI_GETUSETABS, 0, 0);
+		intptr_t tabWidth = ScintillaBridge_sendMessage(sci, SCI_GETTABWIDTH, 0, 0);
+		if (useTabs)
+			indent += '\t';
+		else
+			indent.append(tabWidth, ' ');
+	}
 
 	// Insert the indentation on the new line as a single undoable action
 	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
-	ScintillaBridge_sendMessage(sci, SCI_REPLACESEL, 0, (intptr_t)leadingWS.c_str());
+	ScintillaBridge_sendMessage(sci, SCI_REPLACESEL, 0, (intptr_t)indent.c_str());
 	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
 }

--- a/macos/platform/context_menu.mm
+++ b/macos/platform/context_menu.mm
@@ -4,6 +4,7 @@
 #include "context_menu.h"
 #include "npp_constants.h"
 #include "app_state.h"
+#include "file_path_ops.h"
 
 void showContextMenu(NSPoint screenPoint)
 {
@@ -40,6 +41,19 @@ void showContextMenu(NSPoint screenPoint)
 	[contextMenu addItem:selectAllItem];
 	[contextMenu addItem:[NSMenuItem separatorItem]];
 	[contextMenu addItem:bookmarkItem];
+
+	if (hasActiveFilePath())
+	{
+		[contextMenu addItem:[NSMenuItem separatorItem]];
+
+		NSMenuItem* revealItem = [[NSMenuItem alloc] initWithTitle:@"Reveal in Finder" action:@selector(performContextAction:) keyEquivalent:@""];
+		revealItem.tag = IDM_FILE_REVEAL_FINDER;
+		[contextMenu addItem:revealItem];
+
+		NSMenuItem* copyPathItem = [[NSMenuItem alloc] initWithTitle:@"Copy Full Path" action:@selector(performContextAction:) keyEquivalent:@""];
+		copyPathItem.tag = IDM_FILE_COPY_FULL_PATH;
+		[contextMenu addItem:copyPathItem];
+	}
 
 	[NSMenu popUpContextMenu:contextMenu withEvent:[NSApp currentEvent] forView:ctx().mainWindow.contentView];
 }

--- a/macos/platform/edit_commands.h
+++ b/macos/platform/edit_commands.h
@@ -9,3 +9,5 @@ void doRemoveEmptyLines();
 void doToggleLineComment();
 void doSortLines(bool ascending);
 void doJoinLines();
+void doTabsToSpaces();
+void doSpacesToTabs();

--- a/macos/platform/edit_commands.mm
+++ b/macos/platform/edit_commands.mm
@@ -248,3 +248,106 @@ void doJoinLines()
 	ScintillaBridge_sendMessage(sci, SCI_SETSEL, selStart, selStart + (intptr_t)result.size());
 	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
 }
+
+void doTabsToSpaces()
+{
+	void* sci = ctx().activeScintillaView();
+	if (!sci) return;
+
+	intptr_t tabWidth = ScintillaBridge_sendMessage(sci, SCI_GETTABWIDTH, 0, 0);
+	if (tabWidth <= 0) tabWidth = 4;
+	std::string spaces(tabWidth, ' ');
+
+	intptr_t lineCount = ScintillaBridge_sendMessage(sci, SCI_GETLINECOUNT, 0, 0);
+
+	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
+	for (intptr_t line = lineCount - 1; line >= 0; --line)
+	{
+		intptr_t lineStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, line, 0);
+		intptr_t lineLen = ScintillaBridge_sendMessage(sci, SCI_LINELENGTH, line, 0);
+		if (lineLen <= 0) continue;
+
+		std::vector<char> buf(lineLen + 1, 0);
+		ScintillaBridge_sendMessage(sci, SCI_GETLINE, line, (intptr_t)buf.data());
+
+		std::string newLeading;
+		intptr_t wsEnd = 0;
+		for (intptr_t i = 0; i < lineLen; ++i)
+		{
+			if (buf[i] == '\t')
+				newLeading += spaces;
+			else if (buf[i] == ' ')
+				newLeading += ' ';
+			else
+			{
+				wsEnd = i;
+				break;
+			}
+			wsEnd = i + 1;
+		}
+
+		if (wsEnd == 0) continue;
+
+		std::string oldLeading(buf.data(), wsEnd);
+		if (oldLeading == newLeading) continue;
+
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, lineStart, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, lineStart + wsEnd, 0);
+		ScintillaBridge_sendMessage(sci, SCI_REPLACETARGET, newLeading.size(), (intptr_t)newLeading.c_str());
+	}
+	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
+}
+
+void doSpacesToTabs()
+{
+	void* sci = ctx().activeScintillaView();
+	if (!sci) return;
+
+	intptr_t tabWidth = ScintillaBridge_sendMessage(sci, SCI_GETTABWIDTH, 0, 0);
+	if (tabWidth <= 0) tabWidth = 4;
+
+	intptr_t lineCount = ScintillaBridge_sendMessage(sci, SCI_GETLINECOUNT, 0, 0);
+
+	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
+	for (intptr_t line = lineCount - 1; line >= 0; --line)
+	{
+		intptr_t lineStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, line, 0);
+		intptr_t lineLen = ScintillaBridge_sendMessage(sci, SCI_LINELENGTH, line, 0);
+		if (lineLen <= 0) continue;
+
+		std::vector<char> buf(lineLen + 1, 0);
+		ScintillaBridge_sendMessage(sci, SCI_GETLINE, line, (intptr_t)buf.data());
+
+		// Count leading spaces
+		intptr_t spaceCount = 0;
+		intptr_t wsEnd = 0;
+		for (intptr_t i = 0; i < lineLen; ++i)
+		{
+			if (buf[i] == ' ')
+				++spaceCount;
+			else if (buf[i] == '\t')
+				spaceCount += tabWidth;
+			else
+			{
+				wsEnd = i;
+				break;
+			}
+			wsEnd = i + 1;
+		}
+
+		if (wsEnd == 0 || spaceCount == 0) continue;
+
+		intptr_t numTabs = spaceCount / tabWidth;
+		intptr_t extraSpaces = spaceCount % tabWidth;
+		std::string newLeading(numTabs, '\t');
+		newLeading.append(extraSpaces, ' ');
+
+		std::string oldLeading(buf.data(), wsEnd);
+		if (oldLeading == newLeading) continue;
+
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, lineStart, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, lineStart + wsEnd, 0);
+		ScintillaBridge_sendMessage(sci, SCI_REPLACETARGET, newLeading.size(), (intptr_t)newLeading.c_str());
+	}
+	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
+}

--- a/macos/platform/file_path_ops.h
+++ b/macos/platform/file_path_ops.h
@@ -1,0 +1,21 @@
+// file_path_ops.h — Reveal in Finder and copy-path commands
+// Part of the Notepad++ macOS port modular refactor.
+
+#pragma once
+
+#ifdef __OBJC__
+@class NSString;
+// Returns the active document's file path as an NSString, or nil if untitled.
+NSString* activeDocumentPath();
+#endif
+
+// Returns true if the active document has a saved file path.
+bool hasActiveFilePath();
+
+void doRevealInFinder();
+void doCopyFullPath();
+void doCopyFilename();
+void doCopyDirPath();
+
+// Enable/disable file-path menu items based on active document state.
+void updateFilePathMenuState();

--- a/macos/platform/file_path_ops.mm
+++ b/macos/platform/file_path_ops.mm
@@ -1,0 +1,77 @@
+// file_path_ops.mm — Reveal in Finder and copy-path commands
+// Part of the Notepad++ macOS port modular refactor.
+
+#import <Cocoa/Cocoa.h>
+#include "file_path_ops.h"
+#include "npp_constants.h"
+#include "app_state.h"
+#include "string_utils.h"
+#include "windows.h"
+
+NSString* activeDocumentPath()
+{
+	auto& docs = ctx().activeDocuments();
+	int idx = ctx().activeTabIndex();
+	if (idx < 0 || idx >= static_cast<int>(docs.size()))
+		return nil;
+	const std::wstring& fp = docs[idx].filePath;
+	if (fp.empty())
+		return nil;
+	return WideToNSString(fp.c_str());
+}
+
+bool hasActiveFilePath()
+{
+	auto& docs = ctx().activeDocuments();
+	int idx = ctx().activeTabIndex();
+	if (idx < 0 || idx >= static_cast<int>(docs.size()))
+		return false;
+	return !docs[idx].filePath.empty();
+}
+
+static void copyStringToClipboard(NSString* s)
+{
+	NSPasteboard* pb = [NSPasteboard generalPasteboard];
+	[pb clearContents];
+	[pb setString:s forType:NSPasteboardTypeString];
+}
+
+void doRevealInFinder()
+{
+	NSString* path = activeDocumentPath();
+	if (!path) return;
+	[[NSWorkspace sharedWorkspace] selectFile:path inFileViewerRootedAtPath:@""];
+}
+
+void doCopyFullPath()
+{
+	NSString* path = activeDocumentPath();
+	if (!path) return;
+	copyStringToClipboard(path);
+}
+
+void doCopyFilename()
+{
+	NSString* path = activeDocumentPath();
+	if (!path) return;
+	copyStringToClipboard([path lastPathComponent]);
+}
+
+void doCopyDirPath()
+{
+	NSString* path = activeDocumentPath();
+	if (!path) return;
+	copyStringToClipboard([path stringByDeletingLastPathComponent]);
+}
+
+void updateFilePathMenuState()
+{
+	HMENU hMenu = GetMenu(ctx().mainHwnd);
+	if (!hMenu) return;
+
+	UINT flag = hasActiveFilePath() ? MF_ENABLED : MF_GRAYED;
+	EnableMenuItem(hMenu, IDM_FILE_REVEAL_FINDER,  MF_BYCOMMAND | flag);
+	EnableMenuItem(hMenu, IDM_FILE_COPY_FULL_PATH, MF_BYCOMMAND | flag);
+	EnableMenuItem(hMenu, IDM_FILE_COPY_FILENAME,  MF_BYCOMMAND | flag);
+	EnableMenuItem(hMenu, IDM_FILE_COPY_DIR_PATH,  MF_BYCOMMAND | flag);
+}

--- a/macos/platform/file_path_ops.mm
+++ b/macos/platform/file_path_ops.mm
@@ -66,6 +66,7 @@ void doCopyDirPath()
 
 void updateFilePathMenuState()
 {
+	// Menu APIs come from the Win32 shim layer and are intentionally used here.
 	HMENU hMenu = GetMenu(ctx().mainHwnd);
 	if (!hMenu) return;
 

--- a/macos/platform/language_defs.h
+++ b/macos/platform/language_defs.h
@@ -18,3 +18,6 @@ extern const LangDef g_languages[];
 extern const int g_numLanguages;
 
 int guessLanguage(const std::wstring& filePath);
+
+// Returns true if the language uses C-style { } block indentation.
+bool isCStyleLanguage(int languageIndex);

--- a/macos/platform/language_defs.mm
+++ b/macos/platform/language_defs.mm
@@ -180,3 +180,22 @@ int guessLanguage(const std::wstring& filePath)
 
 	return 0;
 }
+
+bool isCStyleLanguage(int languageIndex)
+{
+	switch (languageIndex)
+	{
+		case 1:  // C
+		case 2:  // C++
+		case 3:  // Java
+		case 5:  // JavaScript
+		case 7:  // CSS
+		case 13: // Rust
+		case 14: // Go
+		case 15: // Objective-C
+		case 16: // Swift
+			return true;
+		default:
+			return false;
+	}
+}

--- a/macos/platform/menu_builder.mm
+++ b/macos/platform/menu_builder.mm
@@ -26,6 +26,11 @@ HMENU buildMenuBar()
 	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_SAVE, L"&Save\tCtrl+S");
 	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_SAVEAS, L"Save &As...\tCtrl+Shift+S");
 	AppendMenuW(hFileMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_REVEAL_FINDER, L"Reveal in &Finder");
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_COPY_FULL_PATH, L"Copy Full &Path");
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_COPY_FILENAME, L"Copy File &Name");
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_COPY_DIR_PATH, L"Copy &Directory Path");
+	AppendMenuW(hFileMenu, MF_SEPARATOR, 0, nullptr);
 	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_CLOSE, L"&Close\tCtrl+W");
 	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_CLOSEALL, L"Close &All");
 	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hFileMenu), L"&File");
@@ -61,6 +66,11 @@ HMENU buildMenuBar()
 	AppendMenuW(hLineMenu, MF_STRING, IDM_EDIT_JOINLINES, L"&Join Lines");
 	AppendMenuW(hEditMenu, MF_POPUP, reinterpret_cast<UINT_PTR>(hLineMenu), L"Line Operations");
 
+	HMENU hTabSpaceMenu = CreatePopupMenu();
+	AppendMenuW(hTabSpaceMenu, MF_STRING, IDM_EDIT_TABS_TO_SPACES, L"&Tabs to Spaces");
+	AppendMenuW(hTabSpaceMenu, MF_STRING, IDM_EDIT_SPACES_TO_TABS, L"&Spaces to Tabs");
+	AppendMenuW(hEditMenu, MF_POPUP, reinterpret_cast<UINT_PTR>(hTabSpaceMenu), L"Tab/Space Conversion");
+
 	AppendMenuW(hEditMenu, MF_SEPARATOR, 0, nullptr);
 	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_TOGGLECOMMENT, L"Toggle &Comment\tCtrl+/");
 	AppendMenuW(hEditMenu, MF_STRING, IDM_EDIT_TRIMTRAILING, L"&Trim Trailing Whitespace");
@@ -88,6 +98,9 @@ HMENU buildMenuBar()
 	HMENU hViewMenu = CreatePopupMenu();
 	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_WORDWRAP, L"&Word Wrap");
 	AppendMenuW(hViewMenu, MF_STRING | (ctx().showLineNumbers ? MF_CHECKED : MF_UNCHECKED), IDM_VIEW_LINENUMBER, L"&Line Numbers");
+	AppendMenuW(hViewMenu, MF_STRING | (ctx().showWhitespace ? MF_CHECKED : MF_UNCHECKED), IDM_VIEW_SHOW_WS, L"Show &Whitespace && TAB");
+	AppendMenuW(hViewMenu, MF_STRING | (ctx().showEol ? MF_CHECKED : MF_UNCHECKED), IDM_VIEW_SHOW_EOL, L"Show &End of Line");
+	AppendMenuW(hViewMenu, MF_STRING | (ctx().showIndentGuides ? MF_CHECKED : MF_UNCHECKED), IDM_VIEW_SHOW_INDENT, L"Show &Indent Guides");
 	AppendMenuW(hViewMenu, MF_SEPARATOR, 0, nullptr);
 	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_FOLDALL, L"&Fold All");
 	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_UNFOLDALL, L"&Unfold All");
@@ -100,6 +113,8 @@ HMENU buildMenuBar()
 	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_ZOOMIN, L"Zoom &In\tCtrl+=");
 	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_ZOOMOUT, L"Zoom &Out\tCtrl+-");
 	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_ZOOMRESTORE, L"&Reset Zoom\tCtrl+0");
+	AppendMenuW(hViewMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_FULLSCREEN, L"Enter Full Screen\tCtrl+Cmd+F");
 	AppendMenuW(hViewMenu, MF_SEPARATOR, 0, nullptr);
 	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_PREFERENCES, L"&Preferences...\tCtrl+,");
 	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hViewMenu), L"&View");

--- a/macos/platform/npp_constants.h
+++ b/macos/platform/npp_constants.h
@@ -53,6 +53,8 @@
 #define IDM_EDIT_SORTASC             42041
 #define IDM_EDIT_SORTDESC            42042
 #define IDM_EDIT_JOINLINES           42043
+#define IDM_EDIT_TABS_TO_SPACES      42044
+#define IDM_EDIT_SPACES_TO_TABS      42045
 
 // Phase 7 — View commands
 #define IDM_VIEW_SPLIT               42070
@@ -64,6 +66,20 @@
 #define IDM_VIEW_ZOOMIN              42074
 #define IDM_VIEW_ZOOMOUT             42075
 #define IDM_VIEW_ZOOMRESTORE         42076
+
+// Full screen
+#define IDM_VIEW_FULLSCREEN          42077
+
+// File path operations
+#define IDM_FILE_REVEAL_FINDER       42090
+#define IDM_FILE_COPY_FULL_PATH      42091
+#define IDM_FILE_COPY_FILENAME       42092
+#define IDM_FILE_COPY_DIR_PATH       42093
+
+// Whitespace visibility
+#define IDM_VIEW_SHOW_WS             42080
+#define IDM_VIEW_SHOW_EOL            42081
+#define IDM_VIEW_SHOW_INDENT         42082
 
 // Help menu commands
 #define IDM_HELP_ABOUT           46001
@@ -256,7 +272,22 @@ enum {
 
 	// Indentation queries
 	SCI_GETUSETABS = 2125,
+	SCI_SETLINEINDENTATION = 2126,
 	SCI_GETLINEINDENTATION = 2127,
+
+	// Whitespace / EOL visibility
+	SCI_SETVIEWWS            = 2225,
+	SCI_GETVIEWWS            = 2224,
+	SCI_SETVIEWEOL           = 2280,
+	SCI_GETVIEWEOL           = 2281,
+	SCI_SETINDENTATIONGUIDES = 2132,
+	SCI_GETINDENTATIONGUIDES = 2133,
+
+	// Rectangular / column selection
+	SCI_SETMULTIPLESELECTION         = 2563,
+	SCI_SETADDITIONALSELECTIONTYPING = 2565,
+	SCI_SETVIRTUALSPACEOPTIONS       = 2596,
+	SCI_SETRECTANGULARSELECTIONMODIFIER = 2598,
 };
 
 // Scintilla key constants
@@ -275,6 +306,17 @@ enum {
 #define SCMOD_ALT   4
 #define SCMOD_SUPER 8
 #define SCMOD_META  16
+
+// Whitespace visibility modes
+#define SCWS_INVISIBLE         0
+#define SCWS_VISIBLEALWAYS     1
+
+// Indentation guide modes
+#define SC_IV_NONE             0
+#define SC_IV_LOOKBOTH         3
+
+// Virtual space options
+#define SCVS_RECTANGULARSELECTION  1
 
 // Scintilla search flags
 #define SCFIND_MATCHCASE  4

--- a/macos/platform/preferences_dialog.mm
+++ b/macos/platform/preferences_dialog.mm
@@ -13,7 +13,7 @@
 void showPreferencesDlg()
 {
 	@autoreleasepool {
-		NSPanel* panel = [[NSPanel alloc] initWithContentRect:NSMakeRect(0, 0, 380, 300)
+		NSPanel* panel = [[NSPanel alloc] initWithContentRect:NSMakeRect(0, 0, 380, 330)
 		                                    styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable
 		                                    backing:NSBackingStoreBuffered
 		                                    defer:NO];
@@ -75,6 +75,12 @@ void showPreferencesDlg()
 			[tabPopup selectItemAtIndex:2];
 		[content addSubview:tabPopup];
 
+		NSButton* useTabsCheck = [[NSButton alloc] initWithFrame:NSMakeRect(20, 120, 300, 20)];
+		useTabsCheck.title = @"Use Tabs (instead of Spaces)";
+		[useTabsCheck setButtonType:NSButtonTypeSwitch];
+		useTabsCheck.state = ctx().useTabs ? NSControlStateValueOn : NSControlStateValueOff;
+		[content addSubview:useTabsCheck];
+
 		NSButton* caretLineCheck = [[NSButton alloc] initWithFrame:NSMakeRect(20, 90, 300, 20)];
 		caretLineCheck.title = @"Highlight current line";
 		[caretLineCheck setButtonType:NSButtonTypeSwitch];
@@ -125,6 +131,7 @@ void showPreferencesDlg()
 			ctx().tabWidth = tabPopup.titleOfSelectedItem.intValue;
 			ctx().showCaretLine = (caretLineCheck.state == NSControlStateValueOn);
 			ctx().autoIndent = (autoIndentCheck.state == NSControlStateValueOn);
+			ctx().useTabs = (useTabsCheck.state == NSControlStateValueOn);
 
 			void* views[] = { ctx().scintillaView, ctx().scintillaView2 };
 			for (void* sci : views)
@@ -134,6 +141,7 @@ void showPreferencesDlg()
 				ScintillaBridge_sendMessage(sci, SCI_STYLESETSIZE, 32, ctx().fontSize);
 				ScintillaBridge_sendMessage(sci, SCI_STYLECLEARALL, 0, 0);
 				ScintillaBridge_sendMessage(sci, SCI_SETTABWIDTH, ctx().tabWidth, 0);
+				ScintillaBridge_sendMessage(sci, SCI_SETUSETABS, ctx().useTabs ? 1 : 0, 0);
 			}
 
 			applyAppearance();
@@ -150,6 +158,7 @@ void showPreferencesDlg()
 			ss.tabWidth = ctx().tabWidth;
 			ss.showCaretLine = ctx().showCaretLine;
 			ss.autoIndent = ctx().autoIndent;
+			ss.useTabs = ctx().useTabs;
 			SettingsManager::instance().save();
 		}
 

--- a/macos/platform/scintilla_config.mm
+++ b/macos/platform/scintilla_config.mm
@@ -14,7 +14,7 @@ void configureScintilla(void* sci)
 	ScintillaBridge_sendMessage(sci, SCI_SETCODEPAGE, 65001, 0);
 	ScintillaBridge_sendMessage(sci, SCI_SETWRAPMODE, 0, 0);
 	ScintillaBridge_sendMessage(sci, SCI_SETTABWIDTH, ctx().tabWidth, 0);
-	ScintillaBridge_sendMessage(sci, SCI_SETUSETABS, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETUSETABS, ctx().useTabs ? 1 : 0, 0);
 
 	ScintillaBridge_sendMessage(sci, SCI_SETMARGINTYPEN, 0, 1);
 	ScintillaBridge_sendMessage(sci, SCI_SETMARGINWIDTHN, 0, 50);
@@ -43,6 +43,17 @@ void configureScintilla(void* sci)
 
 	ScintillaBridge_sendMessage(sci, SCI_SETFOLDFLAGS, 16, 0);
 	ScintillaBridge_sendMessage(sci, SCI_SETAUTOMATICFOLD, SC_AUTOMATICFOLD_CLICK, 0);
+
+	// Rectangular / column selection (Opt+drag)
+	ScintillaBridge_sendMessage(sci, SCI_SETRECTANGULARSELECTIONMODIFIER, SCMOD_ALT, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETMULTIPLESELECTION, 1, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETADDITIONALSELECTIONTYPING, 1, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETVIRTUALSPACEOPTIONS, SCVS_RECTANGULARSELECTION, 0);
+
+	// Whitespace / EOL / indent guide visibility
+	ScintillaBridge_sendMessage(sci, SCI_SETVIEWWS, ctx().showWhitespace ? SCWS_VISIBLEALWAYS : SCWS_INVISIBLE, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETVIEWEOL, ctx().showEol ? 1 : 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETINDENTATIONGUIDES, ctx().showIndentGuides ? SC_IV_LOOKBOTH : SC_IV_NONE, 0);
 
 	ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEVISIBLE, ctx().showCaretLine ? 1 : 0, 0);
 	if (ctx().showCaretLine)

--- a/macos/platform/settings_manager.h
+++ b/macos/platform/settings_manager.h
@@ -24,6 +24,10 @@ struct AppSettings
 	int zoomLevel = 0;
 	bool showCaretLine = true;
 	bool autoIndent = true;
+	bool useTabs = false;
+	bool showWhitespace = false;
+	bool showEol = false;
+	bool showIndentGuides = false;
 
 	// Recent files
 	std::vector<std::string> recentFiles;

--- a/macos/platform/settings_manager.mm
+++ b/macos/platform/settings_manager.mm
@@ -76,6 +76,10 @@ bool SettingsManager::load()
 	if ([json[@"zoomLevel"] isKindOfClass:[NSNumber class]])       settings.zoomLevel = [json[@"zoomLevel"] intValue];
 	if ([json[@"showCaretLine"] isKindOfClass:[NSNumber class]])   settings.showCaretLine = [json[@"showCaretLine"] boolValue];
 	if ([json[@"autoIndent"] isKindOfClass:[NSNumber class]])      settings.autoIndent = [json[@"autoIndent"] boolValue];
+	if ([json[@"useTabs"] isKindOfClass:[NSNumber class]])         settings.useTabs = [json[@"useTabs"] boolValue];
+	if ([json[@"showWhitespace"] isKindOfClass:[NSNumber class]])  settings.showWhitespace = [json[@"showWhitespace"] boolValue];
+	if ([json[@"showEol"] isKindOfClass:[NSNumber class]])         settings.showEol = [json[@"showEol"] boolValue];
+	if ([json[@"showIndentGuides"] isKindOfClass:[NSNumber class]])settings.showIndentGuides = [json[@"showIndentGuides"] boolValue];
 
 	// Recent files
 	settings.recentFiles.clear();
@@ -136,6 +140,10 @@ bool SettingsManager::save()
 		@"zoomLevel":    @(settings.zoomLevel),
 		@"showCaretLine": @(settings.showCaretLine),
 		@"autoIndent":   @(settings.autoIndent),
+		@"useTabs":      @(settings.useTabs),
+		@"showWhitespace": @(settings.showWhitespace),
+		@"showEol":      @(settings.showEol),
+		@"showIndentGuides": @(settings.showIndentGuides),
 		@"recentFiles":  recentArr
 	};
 

--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -154,7 +154,12 @@ void doSplit()
 					else if (scn->nmhdr.code == SCN_CHARADDED)
 					{
 						if (ctx().autoIndent)
-							performAutoIndent(ctx().scintillaView2, scn->ch);
+						{
+							int langIdx = -1;
+							if (ctx().activeTab2 >= 0 && ctx().activeTab2 < static_cast<int>(ctx().documents2.size()))
+								langIdx = ctx().documents2[ctx().activeTab2].languageIndex;
+							performAutoIndent(ctx().scintillaView2, scn->ch, langIdx);
+						}
 					}
 				}
 			});

--- a/macos/platform/wndproc.mm
+++ b/macos/platform/wndproc.mm
@@ -16,6 +16,7 @@
 #include "about_dialog.h"
 #include "recent_files.h"
 #include "status_bar.h"
+#include "file_path_ops.h"
 #include "lexer_styles.h"
 #include "language_defs.h"
 #include "scintilla_bridge.h"
@@ -89,6 +90,19 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 				case IDM_FILE_RECENT_CLEAR:
 					ctx().recentFiles.clear();
 					rebuildRecentMenu();
+					return 0;
+
+				case IDM_FILE_REVEAL_FINDER:
+					doRevealInFinder();
+					return 0;
+				case IDM_FILE_COPY_FULL_PATH:
+					doCopyFullPath();
+					return 0;
+				case IDM_FILE_COPY_FILENAME:
+					doCopyFilename();
+					return 0;
+				case IDM_FILE_COPY_DIR_PATH:
+					doCopyDirPath();
 					return 0;
 
 				case IDM_EDIT_UNDO:
@@ -279,6 +293,12 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 				case IDM_EDIT_JOINLINES:
 					doJoinLines();
 					return 0;
+				case IDM_EDIT_TABS_TO_SPACES:
+					doTabsToSpaces();
+					return 0;
+				case IDM_EDIT_SPACES_TO_TABS:
+					doSpacesToTabs();
+					return 0;
 
 				case IDM_VIEW_ZOOMIN:
 				{
@@ -310,7 +330,60 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 					return 0;
 				}
 
-				case IDM_VIEW_SPLIT:
+				case IDM_VIEW_SHOW_WS:
+			{
+				ctx().showWhitespace = !ctx().showWhitespace;
+				void* views[] = { ctx().scintillaView, ctx().scintillaView2 };
+				for (void* v : views)
+				{
+					if (v)
+						ScintillaBridge_sendMessage(v, SCI_SETVIEWWS,
+							ctx().showWhitespace ? SCWS_VISIBLEALWAYS : SCWS_INVISIBLE, 0);
+				}
+				HMENU hMenu = GetMenu(hWnd);
+				if (hMenu)
+					CheckMenuItem(hMenu, IDM_VIEW_SHOW_WS,
+						MF_BYCOMMAND | (ctx().showWhitespace ? MF_CHECKED : MF_UNCHECKED));
+				return 0;
+			}
+			case IDM_VIEW_SHOW_EOL:
+			{
+				ctx().showEol = !ctx().showEol;
+				void* views[] = { ctx().scintillaView, ctx().scintillaView2 };
+				for (void* v : views)
+				{
+					if (v)
+						ScintillaBridge_sendMessage(v, SCI_SETVIEWEOL, ctx().showEol ? 1 : 0, 0);
+				}
+				HMENU hMenu = GetMenu(hWnd);
+				if (hMenu)
+					CheckMenuItem(hMenu, IDM_VIEW_SHOW_EOL,
+						MF_BYCOMMAND | (ctx().showEol ? MF_CHECKED : MF_UNCHECKED));
+				return 0;
+			}
+			case IDM_VIEW_SHOW_INDENT:
+			{
+				ctx().showIndentGuides = !ctx().showIndentGuides;
+				void* views[] = { ctx().scintillaView, ctx().scintillaView2 };
+				for (void* v : views)
+				{
+					if (v)
+						ScintillaBridge_sendMessage(v, SCI_SETINDENTATIONGUIDES,
+							ctx().showIndentGuides ? SC_IV_LOOKBOTH : SC_IV_NONE, 0);
+				}
+				HMENU hMenu = GetMenu(hWnd);
+				if (hMenu)
+					CheckMenuItem(hMenu, IDM_VIEW_SHOW_INDENT,
+						MF_BYCOMMAND | (ctx().showIndentGuides ? MF_CHECKED : MF_UNCHECKED));
+				return 0;
+			}
+
+			case IDM_VIEW_FULLSCREEN:
+				if (ctx().mainWindow)
+					[ctx().mainWindow toggleFullScreen:nil];
+				return 0;
+
+			case IDM_VIEW_SPLIT:
 					doSplit();
 					return 0;
 				case IDM_VIEW_UNSPLIT:
@@ -370,6 +443,10 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 			}
 			break;
 		}
+
+		case WM_INITMENUPOPUP:
+			updateFilePathMenuState();
+			break;
 
 		case WM_NOTIFY:
 		{


### PR DESCRIPTION
## Summary

Sprint 5 implements 6 editor text polish features, building on the editor essentials work from Sprint 4:

- **#47 Full screen mode** — `NSWindowCollectionBehaviorFullScreenPrimary` + `IDM_VIEW_FULLSCREEN` via wndproc dispatch
- **#45 Column/rectangular selection** — Opt+drag via `SCI_SETRECTANGULARSELECTIONMODIFIER`, multi-selection typing, virtual space
- **#44 Show whitespace/tabs, EOL markers, indent guides** — 3 View menu toggles with persistence, centralized apply via `configureScintilla()`
- **#28 Tab/space conversion** — Edit submenu with Tabs↔Spaces commands + Use Tabs preference checkbox
- **#26 Reveal in Finder / Copy path** — New `file_path_ops` module, File menu and context menu entries, `WM_INITMENUPOPUP` enable/disable
- **#73 Smart brace indentation** — Increase indent after `{`, outdent on `}`, language-gated via `isCStyleLanguage()`

20 files changed, 574 insertions, 65 deletions. 2 new files (`file_path_ops.h/.mm`).

## Test plan

- [x] Full screen: View > Enter Full Screen toggles native macOS full screen; green traffic light button works
- [x] Column selection: Opt+drag creates rectangular selection; typing inserts on all rows
- [x] Show Whitespace: View > Show Whitespace & TAB renders dots/arrows; persists across restart
- [x] Show EOL: View > Show End of Line renders CR/LF glyphs; persists
- [x] Show Indent Guides: View > Show Indent Guides renders vertical lines; persists
- [x] Tabs to Spaces: Edit > Tab/Space Conversion > Tabs to Spaces converts leading tabs; single undo
- [x] Spaces to Tabs: Edit > Tab/Space Conversion > Spaces to Tabs converts leading spaces; single undo
- [x] Use Tabs preference: Preferences checkbox toggles tab/space insertion; persists
- [x] Reveal in Finder: File > Reveal in Finder opens Finder with file selected; grayed for untitled
- [x] Copy Full Path: File > Copy Full Path copies to clipboard; grayed for untitled
- [x] Context menu: Reveal in Finder and Copy Full Path appear only for saved files
- [x] Smart indent: Type `{` + Enter in a .cpp file → cursor indented one level deeper
- [x] Smart outdent: Type `}` as first char on a line in a .cpp file → line outdented
- [x] Smart indent gating: Plain text files do not get brace indentation
- [x] Split view: All features apply to both main and split editor panes

🤖 Generated with [Claude Code](https://claude.ai/code)