### PR TITLE
fix: resolve dangling reference in Find in Files search

### DIFF
--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -343,6 +343,9 @@ add_executable(MacOSNotePP
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/tab_bar_view.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/tab_context_menu.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/smart_highlight.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/incremental_search.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/find_in_files.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/search_results_panel.mm"
 )
 target_include_directories(MacOSNotePP PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/platform"

--- a/macos/platform/app_state.h
+++ b/macos/platform/app_state.h
@@ -74,6 +74,12 @@ struct AppContext
 	// Notification suppression (prevents false dirty indicators during tab switches)
 	bool suppressSavePointNotifications = false;
 
+	// Incremental search bar state
+	NSView* incrementalSearchBar = nil;
+	bool incrSearchVisible = false;
+	int incrSearchCurrentMatch = -1;
+	int incrSearchTotalMatches = 0;
+
 	// Accessor helpers for split view
 	void*& activeScintillaView() { return activeView == 0 ? scintillaView : scintillaView2; }
 	std::vector<DocumentData>& activeDocuments() { return activeView == 0 ? documents : documents2; }

--- a/macos/platform/appearance.mm
+++ b/macos/platform/appearance.mm
@@ -63,6 +63,10 @@ void applyAppearanceToView(void* sci, int langIdx, bool isDark)
 	applyFoldMarkerColorsToView(sci, isDark);
 	configureBraceStyles(sci, isDark);
 	configureSmartHighlightIndicator(sci, isDark);
+
+	// Incremental search indicator colors
+	ScintillaBridge_sendMessage(sci, SCI_INDICSETFORE, INDIC_INCREMENTAL_SEARCH,
+		isDark ? 0x50C8FF : 0xFF8000);
 }
 
 void applyAppearance()

--- a/macos/platform/document_manager.mm
+++ b/macos/platform/document_manager.mm
@@ -8,6 +8,7 @@
 #include "lexer_styles.h"
 #include "scintilla_bridge.h"
 #include "smart_highlight.h"
+#include "incremental_search.h"
 #include "windows.h"
 #include "commctrl.h"
 #include "handle_registry.h"
@@ -95,12 +96,23 @@ void switchToTabInView(int viewIndex, int tabIndex)
 	if (!sci) return;
 
 	clearSmartHighlight(sci);
+	// Clear incremental search highlights
+	{
+		intptr_t docLen = ScintillaBridge_sendMessage(sci, SCI_GETLENGTH, 0, 0);
+		if (docLen > 0) {
+			ScintillaBridge_sendMessage(sci, SCI_SETINDICATORCURRENT, INDIC_INCREMENTAL_SEARCH, 0);
+			ScintillaBridge_sendMessage(sci, SCI_INDICATORCLEARRANGE, 0, docLen);
+		}
+	}
 	saveViewState(sci, docs, activeTab);
 	activeTab = tabIndex;
 	if (tabHwnd)
 		SendMessageW(tabHwnd, TCM_SETCURSEL, tabIndex, 0);
 	restoreViewToScintilla(sci, docs, tabIndex);
 	applyLanguageToView(sci, docs[tabIndex].languageIndex);
+
+	if (isIncrementalSearchVisible())
+		updateIncrementalSearchTarget();
 
 	const auto& doc = docs[tabIndex];
 	NSString* title = WideToNSString(doc.title.c_str());

--- a/macos/platform/find_in_files.h
+++ b/macos/platform/find_in_files.h
@@ -1,2 +1,4 @@
 // find_in_files.h — Find in Files dialog for MacNote++
 #pragma once
+
+void showFindInFilesDlg();

--- a/macos/platform/find_in_files.h
+++ b/macos/platform/find_in_files.h
@@ -1,4 +1,38 @@
-// find_in_files.h — Find in Files dialog for MacNote++
+// find_in_files.h — Find in Files dialog and search engine
 #pragma once
+#import <Foundation/Foundation.h>
+#include <string>
+#include <vector>
+#include <atomic>
+#include <functional>
 
+struct FIFMatch {
+	int lineNumber;       // 1-based
+	int column;           // 0-based byte offset within line
+	int matchLength;      // bytes
+	std::string lineText; // trimmed line content (max 500 chars)
+};
+
+struct FIFFileResult {
+	std::string filePath;
+	std::vector<FIFMatch> matches;
+};
+
+struct FIFSearchResult {
+	std::string searchTerm;
+	std::string directory;
+	std::string filters;
+	int filesSearched = 0;
+	int filesWithMatches = 0;
+	int totalMatches = 0;
+	std::vector<FIFFileResult> fileResults;
+};
+
+// Show the Find in Files dialog
 void showFindInFilesDlg();
+
+// Check if a search is currently running
+bool isFIFSearchRunning();
+
+// Cancel any running search
+void cancelFIFSearch();

--- a/macos/platform/find_in_files.h
+++ b/macos/platform/find_in_files.h
@@ -1,0 +1,2 @@
+// find_in_files.h — Find in Files dialog for MacNote++
+#pragma once

--- a/macos/platform/find_in_files.mm
+++ b/macos/platform/find_in_files.mm
@@ -1,10 +1,41 @@
-// find_in_files.mm — Find in Files dialog implementation
+// find_in_files.mm — Find in Files dialog and search engine implementation
 #include "find_in_files.h"
+#include "file_operations.h"
 #import <Cocoa/Cocoa.h>
 #include <fnmatch.h>
 #include <string>
 #include <vector>
 #include <sstream>
+#include <regex>
+#include <cstring>
+#include <atomic>
+#include <dispatch/dispatch.h>
+
+// ---------------------------------------------------------------------------
+// Search state
+// ---------------------------------------------------------------------------
+static std::atomic<bool> sFIFRunning{false};
+static std::atomic<bool> sFIFCancel{false};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+static constexpr int kMaxMatches = 10000;
+static constexpr int kBatchSize = 20;
+static constexpr size_t kMaxLineTextLength = 500;
+
+// ---------------------------------------------------------------------------
+// Callback type
+// ---------------------------------------------------------------------------
+using FIFCallback = std::function<void(const FIFSearchResult&, bool complete)>;
+
+// ---------------------------------------------------------------------------
+// isWordChar — helper for whole-word boundary checking
+// ---------------------------------------------------------------------------
+static bool isWordChar(char c)
+{
+	return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
+}
 
 // ---------------------------------------------------------------------------
 // enumerateFiles — collect file paths matching glob filters under a directory
@@ -141,7 +172,309 @@ static bool isBinaryFile(NSString* path)
 }
 
 // ---------------------------------------------------------------------------
-// Public API stubs
+// searchLinePlainText — search a single line for plain text matches
+// ---------------------------------------------------------------------------
+static void searchLinePlainText(const std::string& line,
+                                const std::string& searchTerm,
+                                const std::string& searchTermLower,
+                                bool matchCase,
+                                bool wholeWord,
+                                int lineNumber,
+                                FIFFileResult& fileResult,
+                                int& totalMatches)
+{
+	const char* linePtr = line.c_str();
+	size_t lineLen = line.size();
+	size_t termLen = searchTerm.size();
+	size_t pos = 0;
+
+	while (pos + termLen <= lineLen && totalMatches < kMaxMatches)
+	{
+		const char* found = nullptr;
+
+		if (matchCase)
+		{
+			found = strstr(linePtr + pos, searchTerm.c_str());
+		}
+		else
+		{
+			found = strcasestr(linePtr + pos, searchTerm.c_str());
+		}
+
+		if (!found)
+		{
+			break;
+		}
+
+		size_t matchPos = static_cast<size_t>(found - linePtr);
+
+		// Whole-word boundary check
+		if (wholeWord)
+		{
+			bool leftBoundary = (matchPos == 0) || !isWordChar(linePtr[matchPos - 1]);
+			bool rightBoundary = (matchPos + termLen >= lineLen) ||
+			                     !isWordChar(linePtr[matchPos + termLen]);
+			if (!leftBoundary || !rightBoundary)
+			{
+				pos = matchPos + 1;
+				continue;
+			}
+		}
+
+		// Trim line text
+		std::string lineText = line;
+		if (lineText.size() > kMaxLineTextLength)
+		{
+			lineText = lineText.substr(0, kMaxLineTextLength);
+		}
+
+		FIFMatch match;
+		match.lineNumber = lineNumber;
+		match.column = static_cast<int>(matchPos);
+		match.matchLength = static_cast<int>(termLen);
+		match.lineText = lineText;
+		fileResult.matches.push_back(std::move(match));
+		++totalMatches;
+
+		pos = matchPos + termLen;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// searchLineRegex — search a single line for regex matches
+// ---------------------------------------------------------------------------
+static void searchLineRegex(const std::string& line,
+                            const std::regex& pattern,
+                            bool wholeWord,
+                            int lineNumber,
+                            FIFFileResult& fileResult,
+                            int& totalMatches)
+{
+	std::sregex_iterator it(line.begin(), line.end(), pattern);
+	std::sregex_iterator end;
+
+	for (; it != end && totalMatches < kMaxMatches; ++it)
+	{
+		const std::smatch& m = *it;
+		size_t matchPos = static_cast<size_t>(m.position());
+		size_t matchLen = static_cast<size_t>(m.length());
+
+		// Whole-word boundary check
+		if (wholeWord)
+		{
+			bool leftBoundary = (matchPos == 0) ||
+			                    !isWordChar(line[matchPos - 1]);
+			bool rightBoundary = (matchPos + matchLen >= line.size()) ||
+			                     !isWordChar(line[matchPos + matchLen]);
+			if (!leftBoundary || !rightBoundary)
+			{
+				continue;
+			}
+		}
+
+		// Trim line text
+		std::string lineText = line;
+		if (lineText.size() > kMaxLineTextLength)
+		{
+			lineText = lineText.substr(0, kMaxLineTextLength);
+		}
+
+		FIFMatch match;
+		match.lineNumber = lineNumber;
+		match.column = static_cast<int>(matchPos);
+		match.matchLength = static_cast<int>(matchLen);
+		match.lineText = lineText;
+		fileResult.matches.push_back(std::move(match));
+		++totalMatches;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// doFindInFiles — background search engine
+// ---------------------------------------------------------------------------
+static void doFindInFiles(const std::string& searchTerm,
+                          const std::string& directory,
+                          const std::string& filters,
+                          bool matchCase,
+                          bool wholeWord,
+                          bool useRegex,
+                          bool recursive,
+                          bool includeHidden,
+                          FIFCallback callback)
+{
+	// Prevent concurrent searches
+	if (sFIFRunning.load())
+	{
+		return;
+	}
+
+	sFIFRunning.store(true);
+	sFIFCancel.store(false);
+
+	// Enumerate files on the calling thread (fast enough, avoids threading issues)
+	NSString* dirNS = [NSString stringWithUTF8String:directory.c_str()];
+	std::vector<std::string> files = enumerateFiles(dirNS, filters, recursive, includeHidden);
+
+	// Capture everything needed by the block
+	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+		@autoreleasepool
+		{
+			FIFSearchResult result;
+			result.searchTerm = searchTerm;
+			result.directory = directory;
+			result.filters = filters;
+			int totalMatches = 0;
+
+			// Prepare regex if needed
+			std::regex regexPattern;
+			bool regexValid = true;
+			if (useRegex)
+			{
+				try
+				{
+					auto flags = std::regex_constants::ECMAScript;
+					if (!matchCase)
+					{
+						flags |= std::regex_constants::icase;
+					}
+					regexPattern = std::regex(searchTerm, flags);
+				}
+				catch (const std::regex_error&)
+				{
+					regexValid = false;
+				}
+			}
+
+			// Prepare lowercase search term for case-insensitive plain text search
+			std::string searchTermLower;
+			if (!useRegex && !matchCase)
+			{
+				searchTermLower.resize(searchTerm.size());
+				for (size_t i = 0; i < searchTerm.size(); ++i)
+				{
+					searchTermLower[i] = static_cast<char>(
+						std::tolower(static_cast<unsigned char>(searchTerm[i])));
+				}
+			}
+
+			int filesProcessed = 0;
+
+			for (const auto& filePath : files)
+			{
+				// Check cancel flag
+				if (sFIFCancel.load())
+				{
+					break;
+				}
+
+				// Check match cap
+				if (totalMatches >= kMaxMatches)
+				{
+					break;
+				}
+
+				@autoreleasepool
+				{
+					NSString* pathNS = [NSString stringWithUTF8String:filePath.c_str()];
+
+					// Skip binary files
+					if (isBinaryFile(pathNS))
+					{
+						++filesProcessed;
+						++result.filesSearched;
+						continue;
+					}
+
+					// Read file data
+					NSData* data = [NSData dataWithContentsOfFile:pathNS];
+					if (!data || [data length] == 0)
+					{
+						++filesProcessed;
+						++result.filesSearched;
+						continue;
+					}
+
+					// Detect encoding and decode to UTF-8
+					int encoding = detectEncoding(data);
+					std::string utf8Text = decodeFileData(data, encoding);
+
+					if (utf8Text.empty())
+					{
+						++filesProcessed;
+						++result.filesSearched;
+						continue;
+					}
+
+					// Search line-by-line
+					FIFFileResult fileResult;
+					fileResult.filePath = filePath;
+
+					std::istringstream textStream(utf8Text);
+					std::string line;
+					int lineNumber = 0;
+
+					while (std::getline(textStream, line) && totalMatches < kMaxMatches)
+					{
+						++lineNumber;
+
+						// Remove trailing \r if present (for \r\n line endings)
+						if (!line.empty() && line.back() == '\r')
+						{
+							line.pop_back();
+						}
+
+						if (useRegex)
+						{
+							if (regexValid)
+							{
+								searchLineRegex(line, regexPattern, wholeWord,
+								                lineNumber, fileResult, totalMatches);
+							}
+						}
+						else
+						{
+							searchLinePlainText(line, searchTerm, searchTermLower,
+							                    matchCase, wholeWord,
+							                    lineNumber, fileResult, totalMatches);
+						}
+					}
+
+					++result.filesSearched;
+
+					if (!fileResult.matches.empty())
+					{
+						++result.filesWithMatches;
+						result.totalMatches += static_cast<int>(fileResult.matches.size());
+						result.fileResults.push_back(std::move(fileResult));
+					}
+
+					++filesProcessed;
+
+					// Post batch update to main thread every kBatchSize files
+					if (filesProcessed % kBatchSize == 0)
+					{
+						FIFSearchResult batchResult = result;
+						FIFCallback cb = callback;
+						dispatch_async(dispatch_get_main_queue(), ^{
+							cb(batchResult, false);
+						});
+					}
+				}
+			}
+
+			// Post final result on main thread
+			FIFSearchResult finalResult = std::move(result);
+			FIFCallback cb = callback;
+			dispatch_async(dispatch_get_main_queue(), ^{
+				sFIFRunning.store(false);
+				cb(finalResult, true);
+			});
+		}
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Public API
 // ---------------------------------------------------------------------------
 
 void showFindInFilesDlg()
@@ -151,14 +484,10 @@ void showFindInFilesDlg()
 
 bool isFIFSearchRunning()
 {
-	return false;
+	return sFIFRunning.load();
 }
 
 void cancelFIFSearch()
 {
-	// No-op — will be implemented when search engine is added
+	sFIFCancel.store(true);
 }
-
-// Suppress unused-function warnings for static helpers used in later tasks
-__attribute__((used)) static auto _fifRef1 = &enumerateFiles;
-__attribute__((used)) static auto _fifRef2 = &isBinaryFile;

--- a/macos/platform/find_in_files.mm
+++ b/macos/platform/find_in_files.mm
@@ -795,7 +795,7 @@ void showFindInFilesDlg()
 						result.totalMatches, result.filesWithMatches, result.filesSearched];
 					sFIFStatusLabel.stringValue = status;
 
-					// Show results panel (stub for now, Task 9 implements it)
+					// Show search results panel
 					showSearchResultsPanel(result);
 				}
 			});

--- a/macos/platform/find_in_files.mm
+++ b/macos/platform/find_in_files.mm
@@ -186,6 +186,11 @@ static void searchLinePlainText(const std::string& line,
                                 FIFFileResult& fileResult,
                                 int& totalMatches)
 {
+	if (searchTerm.empty())
+	{
+		return;
+	}
+
 	const char* linePtr = line.c_str();
 	size_t lineLen = line.size();
 	size_t termLen = searchTerm.size();
@@ -295,9 +300,9 @@ static void searchLineRegex(const std::string& line,
 // ---------------------------------------------------------------------------
 // doFindInFiles — background search engine
 // ---------------------------------------------------------------------------
-static void doFindInFiles(const std::string& searchTerm,
-                          const std::string& directory,
-                          const std::string& filters,
+static void doFindInFiles(std::string searchTerm,
+                          std::string directory,
+                          std::string filters,
                           bool matchCase,
                           bool wholeWord,
                           bool useRegex,
@@ -305,6 +310,12 @@ static void doFindInFiles(const std::string& searchTerm,
                           bool includeHidden,
                           FIFCallback callback)
 {
+	// Reject empty search term
+	if (searchTerm.empty())
+	{
+		return;
+	}
+
 	// Prevent concurrent searches
 	if (sFIFRunning.load())
 	{

--- a/macos/platform/find_in_files.mm
+++ b/macos/platform/find_in_files.mm
@@ -1,7 +1,11 @@
 // find_in_files.mm — Find in Files dialog and search engine implementation
 #include "find_in_files.h"
 #include "file_operations.h"
+#include "search_results_panel.h"
+#include "app_state.h"
+#include "string_utils.h"
 #import <Cocoa/Cocoa.h>
+#import <objc/runtime.h>
 #include <fnmatch.h>
 #include <string>
 #include <vector>
@@ -474,12 +478,357 @@ static void doFindInFiles(const std::string& searchTerm,
 }
 
 // ---------------------------------------------------------------------------
+// Dialog state (file-static, reused across calls)
+// ---------------------------------------------------------------------------
+static NSPanel* sFIFPanel = nil;
+static NSTextField* sFIFSearchField = nil;
+static NSTextField* sFIFDirField = nil;
+static NSTextField* sFIFFilterField = nil;
+static NSButton* sFIFMatchCaseCheck = nil;
+static NSButton* sFIFWholeWordCheck = nil;
+static NSButton* sFIFRegexCheck = nil;
+static NSButton* sFIFRecursiveCheck = nil;
+static NSButton* sFIFHiddenCheck = nil;
+static NSButton* sFIFFindAllBtn = nil;
+static NSButton* sFIFCancelBtn = nil;
+static NSTextField* sFIFStatusLabel = nil;
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 void showFindInFilesDlg()
 {
-	// Stub — will be implemented in Task 8
+	// Reuse existing panel if already created
+	if (sFIFPanel)
+	{
+		// Update search field from ctx() in case it changed
+		if (!ctx().findText.empty())
+		{
+			sFIFSearchField.stringValue = WideToNSString(ctx().findText.c_str());
+		}
+
+		[sFIFPanel makeKeyAndOrderFront:nil];
+		[sFIFPanel makeFirstResponder:sFIFSearchField];
+		return;
+	}
+
+	// -----------------------------------------------------------------------
+	// Create the floating panel
+	// -----------------------------------------------------------------------
+	CGFloat panelW = 480;
+	CGFloat panelH = 320;
+
+	NSRect panelRect = NSMakeRect(0, 0, panelW, panelH);
+	sFIFPanel = [[NSPanel alloc]
+		initWithContentRect:panelRect
+		          styleMask:(NSWindowStyleMaskTitled |
+		                     NSWindowStyleMaskClosable |
+		                     NSWindowStyleMaskUtilityWindow)
+		            backing:NSBackingStoreBuffered
+		              defer:NO];
+	[sFIFPanel setTitle:@"Find in Files"];
+	[sFIFPanel setReleasedWhenClosed:NO];
+	[sFIFPanel setFloatingPanel:YES];
+	[sFIFPanel setBecomesKeyOnlyIfNeeded:NO];
+
+	// Center relative to main window
+	if (ctx().mainWindow)
+	{
+		NSRect mainFrame = [ctx().mainWindow frame];
+		CGFloat x = NSMidX(mainFrame) - panelW / 2;
+		CGFloat y = NSMidY(mainFrame) - panelH / 2;
+		[sFIFPanel setFrameOrigin:NSMakePoint(x, y)];
+	}
+	else
+	{
+		[sFIFPanel center];
+	}
+
+	NSView* content = [sFIFPanel contentView];
+
+	// -----------------------------------------------------------------------
+	// Layout constants
+	// -----------------------------------------------------------------------
+	CGFloat leftMargin = 16;
+	CGFloat rightMargin = 16;
+	CGFloat labelW = 72;
+	CGFloat fieldH = 24;
+	CGFloat rowSpacing = 8;
+	CGFloat fieldX = leftMargin + labelW + 4;
+	CGFloat fieldW = panelW - fieldX - rightMargin;
+	CGFloat browseW = 70;
+	CGFloat dirFieldW = fieldW - browseW - 8;
+
+	// Start from top of content area (flipped-style: compute from top)
+	CGFloat topY = panelH - 16;
+
+	// -----------------------------------------------------------------------
+	// Row 1: Find label + field
+	// -----------------------------------------------------------------------
+	topY -= fieldH;
+	NSTextField* findLabel = [NSTextField labelWithString:@"Find:"];
+	findLabel.frame = NSMakeRect(leftMargin, topY, labelW, fieldH);
+	findLabel.alignment = NSTextAlignmentRight;
+	[content addSubview:findLabel];
+
+	sFIFSearchField = [[NSTextField alloc] initWithFrame:NSMakeRect(fieldX, topY, fieldW, fieldH)];
+	sFIFSearchField.placeholderString = @"Search term";
+	if (!ctx().findText.empty())
+	{
+		sFIFSearchField.stringValue = WideToNSString(ctx().findText.c_str());
+	}
+	[content addSubview:sFIFSearchField];
+
+	// -----------------------------------------------------------------------
+	// Row 2: Directory label + field + Browse button
+	// -----------------------------------------------------------------------
+	topY -= (fieldH + rowSpacing);
+	NSTextField* dirLabel = [NSTextField labelWithString:@"Directory:"];
+	dirLabel.frame = NSMakeRect(leftMargin, topY, labelW, fieldH);
+	dirLabel.alignment = NSTextAlignmentRight;
+	[content addSubview:dirLabel];
+
+	sFIFDirField = [[NSTextField alloc] initWithFrame:NSMakeRect(fieldX, topY, dirFieldW, fieldH)];
+	sFIFDirField.placeholderString = @"/path/to/search";
+
+	// Pre-fill directory from current file or home
+	NSString* dirDefault = NSHomeDirectory();
+	auto& docs = ctx().activeDocuments();
+	int tabIdx = ctx().activeTabIndex();
+	if (tabIdx >= 0 && tabIdx < static_cast<int>(docs.size()) && !docs[tabIdx].filePath.empty())
+	{
+		NSString* path = WideToNSString(docs[tabIdx].filePath.c_str());
+		dirDefault = [path stringByDeletingLastPathComponent];
+	}
+	sFIFDirField.stringValue = dirDefault;
+	[content addSubview:sFIFDirField];
+
+	NSButton* browseBtn = [NSButton buttonWithTitle:@"Browse..."
+	                                         target:nil
+	                                         action:nil];
+	browseBtn.frame = NSMakeRect(fieldX + dirFieldW + 8, topY, browseW, fieldH);
+	[content addSubview:browseBtn];
+
+	// -----------------------------------------------------------------------
+	// Row 3: Filters label + field
+	// -----------------------------------------------------------------------
+	topY -= (fieldH + rowSpacing);
+	NSTextField* filterLabel = [NSTextField labelWithString:@"Filters:"];
+	filterLabel.frame = NSMakeRect(leftMargin, topY, labelW, fieldH);
+	filterLabel.alignment = NSTextAlignmentRight;
+	[content addSubview:filterLabel];
+
+	sFIFFilterField = [[NSTextField alloc] initWithFrame:NSMakeRect(fieldX, topY, fieldW, fieldH)];
+	sFIFFilterField.stringValue = @"*.*";
+	sFIFFilterField.placeholderString = @"*.cpp;*.h;*.mm";
+	[content addSubview:sFIFFilterField];
+
+	// -----------------------------------------------------------------------
+	// Row 4: Checkboxes — Match case, Whole word, Regex
+	// -----------------------------------------------------------------------
+	topY -= (fieldH + rowSpacing + 4);
+	CGFloat checkW = 110;
+	CGFloat checkX = fieldX;
+
+	sFIFMatchCaseCheck = [NSButton checkboxWithTitle:@"Match case" target:nil action:nil];
+	sFIFMatchCaseCheck.frame = NSMakeRect(checkX, topY, checkW, fieldH);
+	sFIFMatchCaseCheck.state = ctx().matchCase ? NSControlStateValueOn : NSControlStateValueOff;
+	[content addSubview:sFIFMatchCaseCheck];
+
+	checkX += checkW + 8;
+	sFIFWholeWordCheck = [NSButton checkboxWithTitle:@"Whole word" target:nil action:nil];
+	sFIFWholeWordCheck.frame = NSMakeRect(checkX, topY, checkW, fieldH);
+	sFIFWholeWordCheck.state = ctx().wholeWord ? NSControlStateValueOn : NSControlStateValueOff;
+	[content addSubview:sFIFWholeWordCheck];
+
+	checkX += checkW + 8;
+	sFIFRegexCheck = [NSButton checkboxWithTitle:@"Regex" target:nil action:nil];
+	sFIFRegexCheck.frame = NSMakeRect(checkX, topY, 80, fieldH);
+	sFIFRegexCheck.state = ctx().useRegex ? NSControlStateValueOn : NSControlStateValueOff;
+	[content addSubview:sFIFRegexCheck];
+
+	// -----------------------------------------------------------------------
+	// Row 5: Checkboxes — Recursive, Hidden
+	// -----------------------------------------------------------------------
+	topY -= (fieldH + rowSpacing);
+	checkX = fieldX;
+
+	sFIFRecursiveCheck = [NSButton checkboxWithTitle:@"In sub-folders" target:nil action:nil];
+	sFIFRecursiveCheck.frame = NSMakeRect(checkX, topY, 130, fieldH);
+	sFIFRecursiveCheck.state = NSControlStateValueOn;
+	[content addSubview:sFIFRecursiveCheck];
+
+	checkX += 130 + 8;
+	sFIFHiddenCheck = [NSButton checkboxWithTitle:@"In hidden folders" target:nil action:nil];
+	sFIFHiddenCheck.frame = NSMakeRect(checkX, topY, 140, fieldH);
+	sFIFHiddenCheck.state = NSControlStateValueOff;
+	[content addSubview:sFIFHiddenCheck];
+
+	// -----------------------------------------------------------------------
+	// Row 6: Buttons — Find All, Cancel, Close
+	// -----------------------------------------------------------------------
+	topY -= (fieldH + rowSpacing + 8);
+	CGFloat btnW = 80;
+	CGFloat btnH = 32;
+	CGFloat btnX = leftMargin;
+
+	sFIFFindAllBtn = [NSButton buttonWithTitle:@"Find All" target:nil action:nil];
+	sFIFFindAllBtn.frame = NSMakeRect(btnX, topY, btnW, btnH);
+	sFIFFindAllBtn.bezelStyle = NSBezelStyleRounded;
+	sFIFFindAllBtn.keyEquivalent = @"\r"; // Enter key
+	[content addSubview:sFIFFindAllBtn];
+
+	btnX += btnW + 12;
+	sFIFCancelBtn = [NSButton buttonWithTitle:@"Cancel" target:nil action:nil];
+	sFIFCancelBtn.frame = NSMakeRect(btnX, topY, btnW, btnH);
+	sFIFCancelBtn.bezelStyle = NSBezelStyleRounded;
+	sFIFCancelBtn.enabled = NO;
+	[content addSubview:sFIFCancelBtn];
+
+	NSButton* closeBtn = [NSButton buttonWithTitle:@"Close" target:nil action:nil];
+	closeBtn.frame = NSMakeRect(panelW - rightMargin - btnW, topY, btnW, btnH);
+	closeBtn.bezelStyle = NSBezelStyleRounded;
+	closeBtn.keyEquivalent = @"\033"; // Escape key
+	[content addSubview:closeBtn];
+
+	// -----------------------------------------------------------------------
+	// Row 7: Status label
+	// -----------------------------------------------------------------------
+	topY -= (btnH + rowSpacing);
+	sFIFStatusLabel = [NSTextField labelWithString:@"Status: Ready"];
+	sFIFStatusLabel.frame = NSMakeRect(leftMargin, topY, panelW - leftMargin - rightMargin, fieldH);
+	sFIFStatusLabel.textColor = [NSColor secondaryLabelColor];
+	[content addSubview:sFIFStatusLabel];
+
+	// -----------------------------------------------------------------------
+	// FIFActionHandler — lightweight ObjC class for button actions
+	// Defined once via the runtime and reused across calls.
+	// -----------------------------------------------------------------------
+	static dispatch_once_t onceToken;
+	static Class fifHandlerClass = nil;
+	dispatch_once(&onceToken, ^{
+		fifHandlerClass = objc_allocateClassPair([NSObject class], "FIFActionHandler", 0);
+
+		// Browse action
+		class_addMethod(fifHandlerClass, @selector(browseAction:), imp_implementationWithBlock(^(id self, id sender) {
+			NSOpenPanel* panel = [NSOpenPanel openPanel];
+			panel.canChooseDirectories = YES;
+			panel.canChooseFiles = NO;
+			panel.allowsMultipleSelection = NO;
+			panel.prompt = @"Select";
+			[panel beginSheetModalForWindow:sFIFPanel completionHandler:^(NSModalResponse result) {
+				if (result == NSModalResponseOK)
+				{
+					sFIFDirField.stringValue = panel.URL.path;
+				}
+			}];
+		}), "v@:@");
+
+		// Find All action
+		class_addMethod(fifHandlerClass, @selector(findAllAction:), imp_implementationWithBlock(^(id self, id sender) {
+			NSString* searchText = sFIFSearchField.stringValue;
+			if (searchText.length == 0)
+			{
+				sFIFStatusLabel.stringValue = @"Status: Enter a search term";
+				return;
+			}
+
+			NSString* directory = sFIFDirField.stringValue;
+			if (directory.length == 0)
+			{
+				sFIFStatusLabel.stringValue = @"Status: Enter a directory";
+				return;
+			}
+
+			NSString* filters = sFIFFilterField.stringValue;
+			if (filters.length == 0)
+			{
+				filters = @"*.*";
+			}
+
+			bool matchCase = (sFIFMatchCaseCheck.state == NSControlStateValueOn);
+			bool wholeWord = (sFIFWholeWordCheck.state == NSControlStateValueOn);
+			bool useRegex = (sFIFRegexCheck.state == NSControlStateValueOn);
+			bool recursive = (sFIFRecursiveCheck.state == NSControlStateValueOn);
+			bool hidden = (sFIFHiddenCheck.state == NSControlStateValueOn);
+
+			// Sync search options back to ctx()
+			ctx().findText = NSStringToWide(searchText);
+			ctx().matchCase = matchCase;
+			ctx().wholeWord = wholeWord;
+			ctx().useRegex = useRegex;
+
+			// Update UI state
+			sFIFStatusLabel.stringValue = @"Status: Searching...";
+			sFIFFindAllBtn.enabled = NO;
+			sFIFCancelBtn.enabled = YES;
+
+			std::string searchTermStr = [searchText UTF8String];
+			std::string dirStr = [directory UTF8String];
+			std::string filterStr = [filters UTF8String];
+
+			doFindInFiles(searchTermStr, dirStr, filterStr,
+			              matchCase, wholeWord, useRegex, recursive, hidden,
+			              [](const FIFSearchResult& result, bool complete) {
+				if (!complete)
+				{
+					// Progress update
+					NSString* status = [NSString stringWithFormat:
+						@"Status: Searching... %d files, %d matches",
+						result.filesSearched, result.totalMatches];
+					sFIFStatusLabel.stringValue = status;
+				}
+				else
+				{
+					// Search complete
+					sFIFFindAllBtn.enabled = YES;
+					sFIFCancelBtn.enabled = NO;
+
+					NSString* status = [NSString stringWithFormat:
+						@"Status: Done: %d matches in %d files of %d searched",
+						result.totalMatches, result.filesWithMatches, result.filesSearched];
+					sFIFStatusLabel.stringValue = status;
+
+					// Show results panel (stub for now, Task 9 implements it)
+					showSearchResultsPanel(result);
+				}
+			});
+		}), "v@:@");
+
+		// Cancel action
+		class_addMethod(fifHandlerClass, @selector(cancelAction:), imp_implementationWithBlock(^(id self, id sender) {
+			cancelFIFSearch();
+			sFIFStatusLabel.stringValue = @"Status: Cancelling...";
+		}), "v@:@");
+
+		// Close action
+		class_addMethod(fifHandlerClass, @selector(closeAction:), imp_implementationWithBlock(^(id self, id sender) {
+			[sFIFPanel orderOut:nil];
+		}), "v@:@");
+
+		objc_registerClassPair(fifHandlerClass);
+	});
+
+	static id fifHandler = [[fifHandlerClass alloc] init];
+
+	browseBtn.target = fifHandler;
+	browseBtn.action = @selector(browseAction:);
+
+	sFIFFindAllBtn.target = fifHandler;
+	sFIFFindAllBtn.action = @selector(findAllAction:);
+
+	sFIFCancelBtn.target = fifHandler;
+	sFIFCancelBtn.action = @selector(cancelAction:);
+
+	closeBtn.target = fifHandler;
+	closeBtn.action = @selector(closeAction:);
+
+	// -----------------------------------------------------------------------
+	// Show the panel
+	// -----------------------------------------------------------------------
+	[sFIFPanel makeKeyAndOrderFront:nil];
+	[sFIFPanel makeFirstResponder:sFIFSearchField];
 }
 
 bool isFIFSearchRunning()

--- a/macos/platform/find_in_files.mm
+++ b/macos/platform/find_in_files.mm
@@ -1,7 +1,164 @@
 // find_in_files.mm — Find in Files dialog implementation
 #include "find_in_files.h"
+#import <Cocoa/Cocoa.h>
+#include <fnmatch.h>
+#include <string>
+#include <vector>
+#include <sstream>
+
+// ---------------------------------------------------------------------------
+// enumerateFiles — collect file paths matching glob filters under a directory
+// ---------------------------------------------------------------------------
+static std::vector<std::string> enumerateFiles(NSString* directory,
+                                                const std::string& filters,
+                                                bool recursive,
+                                                bool includeHidden)
+{
+	static constexpr int kMaxFiles = 100000;
+	std::vector<std::string> result;
+
+	NSFileManager* fm = [NSFileManager defaultManager];
+	NSURL* dirURL = [NSURL fileURLWithPath:directory isDirectory:YES];
+
+	// Build enumeration options
+	NSDirectoryEnumerationOptions options = 0;
+	if (!recursive)
+	{
+		options |= NSDirectoryEnumerationSkipsSubdirectoryDescendants;
+	}
+	if (!includeHidden)
+	{
+		options |= NSDirectoryEnumerationSkipsHiddenFiles;
+	}
+
+	NSArray<NSURLResourceKey>* keys = @[NSURLIsRegularFileKey, NSURLNameKey];
+
+	NSDirectoryEnumerator<NSURL*>* enumerator =
+		[fm enumeratorAtURL:dirURL
+		 includingPropertiesForKeys:keys
+		 options:options
+		 errorHandler:nil];
+
+	// Parse filter patterns by splitting on ";"
+	bool acceptAll = false;
+	std::vector<std::string> patterns;
+
+	if (filters.empty() || filters == "*.*" || filters == "*")
+	{
+		acceptAll = true;
+	}
+	else
+	{
+		std::istringstream stream(filters);
+		std::string token;
+		while (std::getline(stream, token, ';'))
+		{
+			// Trim whitespace
+			size_t start = token.find_first_not_of(" \t");
+			size_t end = token.find_last_not_of(" \t");
+			if (start != std::string::npos)
+			{
+				patterns.push_back(token.substr(start, end - start + 1));
+			}
+		}
+		if (patterns.empty())
+		{
+			acceptAll = true;
+		}
+	}
+
+	for (NSURL* fileURL in enumerator)
+	{
+		if (static_cast<int>(result.size()) >= kMaxFiles)
+		{
+			break;
+		}
+
+		// Skip directories — only include regular files
+		NSNumber* isRegularFile = nil;
+		[fileURL getResourceValue:&isRegularFile forKey:NSURLIsRegularFileKey error:nil];
+		if (![isRegularFile boolValue])
+		{
+			continue;
+		}
+
+		if (!acceptAll)
+		{
+			NSString* fileName = [fileURL lastPathComponent];
+			const char* name = [fileName UTF8String];
+			bool matched = false;
+			for (const auto& pattern : patterns)
+			{
+				if (fnmatch(pattern.c_str(), name, FNM_CASEFOLD) == 0)
+				{
+					matched = true;
+					break;
+				}
+			}
+			if (!matched)
+			{
+				continue;
+			}
+		}
+
+		result.push_back([[fileURL path] UTF8String]);
+	}
+
+	return result;
+}
+
+// ---------------------------------------------------------------------------
+// isBinaryFile — returns true if first 8KB of file contains null bytes
+// ---------------------------------------------------------------------------
+static bool isBinaryFile(NSString* path)
+{
+	NSError* error = nil;
+	NSData* data = [NSData dataWithContentsOfFile:path
+	                                      options:NSDataReadingMappedIfSafe
+	                                        error:&error];
+	if (!data)
+	{
+		return false;
+	}
+
+	static constexpr NSUInteger kCheckSize = 8192;
+	NSUInteger length = [data length];
+	if (length > kCheckSize)
+	{
+		length = kCheckSize;
+	}
+
+	const uint8_t* bytes = static_cast<const uint8_t*>([data bytes]);
+	for (NSUInteger i = 0; i < length; ++i)
+	{
+		if (bytes[i] == 0x00)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+// ---------------------------------------------------------------------------
+// Public API stubs
+// ---------------------------------------------------------------------------
 
 void showFindInFilesDlg()
 {
 	// Stub — will be implemented in Task 8
 }
+
+bool isFIFSearchRunning()
+{
+	return false;
+}
+
+void cancelFIFSearch()
+{
+	// No-op — will be implemented when search engine is added
+}
+
+// Suppress unused-function warnings for static helpers used in later tasks
+__attribute__((used)) static auto _fifRef1 = &enumerateFiles;
+__attribute__((used)) static auto _fifRef2 = &isBinaryFile;

--- a/macos/platform/find_in_files.mm
+++ b/macos/platform/find_in_files.mm
@@ -1,2 +1,7 @@
 // find_in_files.mm — Find in Files dialog implementation
 #include "find_in_files.h"
+
+void showFindInFilesDlg()
+{
+	// Stub — will be implemented in Task 8
+}

--- a/macos/platform/find_in_files.mm
+++ b/macos/platform/find_in_files.mm
@@ -1,0 +1,2 @@
+// find_in_files.mm — Find in Files dialog implementation
+#include "find_in_files.h"

--- a/macos/platform/find_in_files.mm
+++ b/macos/platform/find_in_files.mm
@@ -180,7 +180,6 @@ static bool isBinaryFile(NSString* path)
 // ---------------------------------------------------------------------------
 static void searchLinePlainText(const std::string& line,
                                 const std::string& searchTerm,
-                                const std::string& searchTermLower,
                                 bool matchCase,
                                 bool wholeWord,
                                 int lineNumber,
@@ -349,18 +348,6 @@ static void doFindInFiles(const std::string& searchTerm,
 				}
 			}
 
-			// Prepare lowercase search term for case-insensitive plain text search
-			std::string searchTermLower;
-			if (!useRegex && !matchCase)
-			{
-				searchTermLower.resize(searchTerm.size());
-				for (size_t i = 0; i < searchTerm.size(); ++i)
-				{
-					searchTermLower[i] = static_cast<char>(
-						std::tolower(static_cast<unsigned char>(searchTerm[i])));
-				}
-			}
-
 			int filesProcessed = 0;
 
 			for (const auto& filePath : files)
@@ -431,13 +418,20 @@ static void doFindInFiles(const std::string& searchTerm,
 						{
 							if (regexValid)
 							{
-								searchLineRegex(line, regexPattern, wholeWord,
-								                lineNumber, fileResult, totalMatches);
+								try
+								{
+									searchLineRegex(line, regexPattern, wholeWord,
+									                lineNumber, fileResult, totalMatches);
+								}
+								catch (const std::regex_error&)
+								{
+									// Pathological input can throw during matching; skip this line
+								}
 							}
 						}
 						else
 						{
-							searchLinePlainText(line, searchTerm, searchTermLower,
+							searchLinePlainText(line, searchTerm,
 							                    matchCase, wholeWord,
 							                    lineNumber, fileResult, totalMatches);
 						}

--- a/macos/platform/incremental_search.h
+++ b/macos/platform/incremental_search.h
@@ -1,2 +1,12 @@
-// incremental_search.h — Incremental search bar for MacNote++
+// incremental_search.h — Incremental search bar (Cmd+F)
 #pragma once
+
+void showIncrementalSearch();
+void hideIncrementalSearch();
+bool isIncrementalSearchVisible();
+void clearIncrementalSearchHighlights();
+void updateIncrementalSearchTarget();
+
+// Match navigation (called by wndproc for F3/Shift+F3 when bar is visible)
+void doIncrSearchNext();
+void doIncrSearchPrev();

--- a/macos/platform/incremental_search.h
+++ b/macos/platform/incremental_search.h
@@ -1,0 +1,2 @@
+// incremental_search.h — Incremental search bar for MacNote++
+#pragma once

--- a/macos/platform/incremental_search.mm
+++ b/macos/platform/incremental_search.mm
@@ -7,6 +7,7 @@
 #include "string_utils.h"
 #include "scintilla_bridge.h"
 #include <cstring>
+#include <vector>
 
 // Forward-declare free functions called by IncrSearchTextField and IncrementalSearchBar
 void hideIncrementalSearch();
@@ -195,7 +196,7 @@ static unsigned int sIncrSearchGeneration = 0;
 	unsigned int gen = ++sIncrSearchGeneration;
 	dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 100 * NSEC_PER_MSEC),
 		dispatch_get_main_queue(), ^{
-			if (gen == sIncrSearchGeneration)
+			if (gen == sIncrSearchGeneration && ctx().incrSearchVisible)
 				performIncrementalSearch();
 		});
 }
@@ -457,6 +458,9 @@ void showIncrementalSearch()
 	[bar.searchField selectText:nil];
 
 	ctx().incrSearchVisible = true;
+
+	// Trigger initial search so pre-filled text shows highlights and match count
+	performIncrementalSearch();
 }
 
 void hideIncrementalSearch()

--- a/macos/platform/incremental_search.mm
+++ b/macos/platform/incremental_search.mm
@@ -1,2 +1,352 @@
 // incremental_search.mm — Incremental search bar implementation
+#import <Cocoa/Cocoa.h>
 #include "incremental_search.h"
+#include "npp_constants.h"
+#include "app_state.h"
+#include "string_utils.h"
+#include "scintilla_bridge.h"
+
+// Forward-declare free functions called by IncrSearchTextField
+void hideIncrementalSearch();
+void doIncrSearchNext();
+void doIncrSearchPrev();
+
+// ============================================================
+// IncrSearchTextField — custom NSTextField that intercepts keys
+// ============================================================
+@interface IncrSearchTextField : NSTextField
+@end
+
+@implementation IncrSearchTextField
+- (void)cancelOperation:(id)sender
+{
+	hideIncrementalSearch();
+}
+
+- (BOOL)performKeyEquivalent:(NSEvent*)event
+{
+	if (event.keyCode == 36) // Return
+	{
+		if (event.modifierFlags & NSEventModifierFlagShift)
+			doIncrSearchPrev();
+		else
+			doIncrSearchNext();
+		return YES;
+	}
+	return [super performKeyEquivalent:event];
+}
+@end
+
+// ============================================================
+// IncrementalSearchBar — NSView containing search controls
+// ============================================================
+@interface IncrementalSearchBar : NSView <NSTextFieldDelegate>
+@property (strong) IncrSearchTextField* searchField;
+@property (strong) NSTextField* matchLabel;
+@property (strong) NSButton* prevButton;
+@property (strong) NSButton* nextButton;
+@property (strong) NSButton* caseButton;
+@property (strong) NSButton* wordButton;
+@property (strong) NSButton* regexButton;
+@property (strong) NSButton* closeButton;
+@end
+
+@implementation IncrementalSearchBar
+
+- (instancetype)initWithFrame:(NSRect)frameRect
+{
+	self = [super initWithFrame:frameRect];
+	if (!self) return nil;
+
+	self.wantsLayer = YES;
+	self.layer.backgroundColor = NSColor.windowBackgroundColor.CGColor;
+
+	CGFloat x = 8.0;
+	CGFloat fieldHeight = 22.0;
+	CGFloat yOffset = (frameRect.size.height - fieldHeight) / 2.0;
+
+	// Close button
+	_closeButton = [NSButton buttonWithImage:[NSImage imageNamed:NSImageNameStopProgressFreestandingTemplate]
+	                                  target:self
+	                                  action:@selector(closeClicked:)];
+	_closeButton.bezelStyle = NSBezelStyleInline;
+	_closeButton.bordered = NO;
+	_closeButton.frame = NSMakeRect(x, yOffset, 20, fieldHeight);
+	[_closeButton setToolTip:@"Close search bar (Esc)"];
+	[self addSubview:_closeButton];
+	x += 24;
+
+	// Search field
+	_searchField = [[IncrSearchTextField alloc] initWithFrame:NSMakeRect(x, yOffset, 250, fieldHeight)];
+	_searchField.placeholderString = @"Incremental Search";
+	_searchField.font = [NSFont systemFontOfSize:12];
+	_searchField.bezelStyle = NSTextFieldRoundedBezel;
+	_searchField.delegate = self;
+	[self addSubview:_searchField];
+	x += 256;
+
+	// Previous button
+	_prevButton = [NSButton buttonWithTitle:@"\u25C0"
+	                                 target:self
+	                                 action:@selector(prevClicked:)];
+	_prevButton.bezelStyle = NSBezelStyleInline;
+	_prevButton.frame = NSMakeRect(x, yOffset, 28, fieldHeight);
+	[_prevButton setToolTip:@"Previous match (Shift+Enter)"];
+	[self addSubview:_prevButton];
+	x += 30;
+
+	// Next button
+	_nextButton = [NSButton buttonWithTitle:@"\u25B6"
+	                                 target:self
+	                                 action:@selector(nextClicked:)];
+	_nextButton.bezelStyle = NSBezelStyleInline;
+	_nextButton.frame = NSMakeRect(x, yOffset, 28, fieldHeight);
+	[_nextButton setToolTip:@"Next match (Enter)"];
+	[self addSubview:_nextButton];
+	x += 34;
+
+	// Case-sensitive toggle
+	_caseButton = [NSButton buttonWithTitle:@"Aa"
+	                                 target:self
+	                                 action:@selector(caseToggled:)];
+	_caseButton.bezelStyle = NSBezelStyleRecessed;
+	[_caseButton setButtonType:NSButtonTypeToggle];
+	_caseButton.frame = NSMakeRect(x, yOffset, 32, fieldHeight);
+	[_caseButton setToolTip:@"Match Case"];
+	_caseButton.state = ctx().matchCase ? NSControlStateValueOn : NSControlStateValueOff;
+	[self addSubview:_caseButton];
+	x += 36;
+
+	// Whole word toggle
+	_wordButton = [NSButton buttonWithTitle:@"W"
+	                                 target:self
+	                                 action:@selector(wordToggled:)];
+	_wordButton.bezelStyle = NSBezelStyleRecessed;
+	[_wordButton setButtonType:NSButtonTypeToggle];
+	_wordButton.frame = NSMakeRect(x, yOffset, 28, fieldHeight);
+	[_wordButton setToolTip:@"Whole Word"];
+	_wordButton.state = ctx().wholeWord ? NSControlStateValueOn : NSControlStateValueOff;
+	[self addSubview:_wordButton];
+	x += 32;
+
+	// Regex toggle
+	_regexButton = [NSButton buttonWithTitle:@".*"
+	                                  target:self
+	                                  action:@selector(regexToggled:)];
+	_regexButton.bezelStyle = NSBezelStyleRecessed;
+	[_regexButton setButtonType:NSButtonTypeToggle];
+	_regexButton.frame = NSMakeRect(x, yOffset, 32, fieldHeight);
+	[_regexButton setToolTip:@"Regular Expression"];
+	_regexButton.state = ctx().useRegex ? NSControlStateValueOn : NSControlStateValueOff;
+	[self addSubview:_regexButton];
+	x += 38;
+
+	// Match count label
+	_matchLabel = [NSTextField labelWithString:@""];
+	_matchLabel.font = [NSFont systemFontOfSize:11];
+	_matchLabel.textColor = NSColor.secondaryLabelColor;
+	_matchLabel.frame = NSMakeRect(x, yOffset, 120, fieldHeight);
+	[self addSubview:_matchLabel];
+
+	return self;
+}
+
+- (void)closeClicked:(id)sender
+{
+	hideIncrementalSearch();
+}
+
+- (void)prevClicked:(id)sender
+{
+	doIncrSearchPrev();
+}
+
+- (void)nextClicked:(id)sender
+{
+	doIncrSearchNext();
+}
+
+- (void)caseToggled:(id)sender
+{
+	ctx().matchCase = (_caseButton.state == NSControlStateValueOn);
+}
+
+- (void)wordToggled:(id)sender
+{
+	ctx().wholeWord = (_wordButton.state == NSControlStateValueOn);
+}
+
+- (void)regexToggled:(id)sender
+{
+	ctx().useRegex = (_regexButton.state == NSControlStateValueOn);
+}
+
+@end
+
+// ============================================================
+// Helper: get the search bar as its typed class
+// ============================================================
+static IncrementalSearchBar* getSearchBar()
+{
+	return (IncrementalSearchBar*)ctx().incrementalSearchBar;
+}
+
+// ============================================================
+// Helper: get the active editor container
+// ============================================================
+static NSView* activeEditorContainer()
+{
+	return ctx().activeView == 0 ? ctx().editorContainer : ctx().editorContainer2;
+}
+
+// ============================================================
+// Helper: get the ScintillaView as NSView
+// ============================================================
+static NSView* activeScintillaNSView()
+{
+	void* sciPtr = ctx().activeScintillaView();
+	if (!sciPtr) return nil;
+	return (__bridge NSView*)sciPtr;
+}
+
+// ============================================================
+// Helper: get selected text from Scintilla (up to maxLen chars)
+// ============================================================
+static NSString* getSelectionText(int maxLen)
+{
+	void* sci = ctx().activeScintillaView();
+	if (!sci) return nil;
+
+	intptr_t selStart = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONSTART, 0, 0);
+	intptr_t selEnd = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONEND, 0, 0);
+	intptr_t selLen = selEnd - selStart;
+
+	if (selLen <= 0 || selLen > maxLen)
+		return nil;
+
+	// SCI_GETSELTEXT writes selLen+1 bytes (null-terminated)
+	std::vector<char> buf(selLen + 1, 0);
+	ScintillaBridge_sendMessage(sci, SCI_GETSELTEXT, 0, (intptr_t)buf.data());
+
+	return [NSString stringWithUTF8String:buf.data()];
+}
+
+// ============================================================
+// Public API
+// ============================================================
+
+static const CGFloat kSearchBarHeight = 30.0;
+
+void showIncrementalSearch()
+{
+	NSView* container = activeEditorContainer();
+	if (!container) return;
+
+	// If bar already visible, just focus the field and select all
+	if (ctx().incrSearchVisible)
+	{
+		IncrementalSearchBar* bar = getSearchBar();
+		if (bar)
+		{
+			[bar.window makeFirstResponder:bar.searchField];
+			[bar.searchField selectText:nil];
+		}
+		return;
+	}
+
+	// Create the bar if it doesn't exist yet
+	if (ctx().incrementalSearchBar == nil)
+	{
+		NSRect barFrame = NSMakeRect(0, container.bounds.size.height - kSearchBarHeight,
+		                             container.bounds.size.width, kSearchBarHeight);
+		IncrementalSearchBar* bar = [[IncrementalSearchBar alloc] initWithFrame:barFrame];
+		bar.autoresizingMask = NSViewWidthSizable | NSViewMinYMargin;
+		ctx().incrementalSearchBar = bar;
+	}
+
+	IncrementalSearchBar* bar = getSearchBar();
+
+	// Add bar as subview at the top of the editor container
+	[container addSubview:bar];
+	bar.frame = NSMakeRect(0, container.bounds.size.height - kSearchBarHeight,
+	                       container.bounds.size.width, kSearchBarHeight);
+
+	// Adjust the ScintillaView frame to leave space for the bar
+	NSView* sciView = activeScintillaNSView();
+	if (sciView && sciView.superview == container)
+	{
+		NSRect sciFrame = container.bounds;
+		sciFrame.size.height -= kSearchBarHeight;
+		sciView.frame = sciFrame;
+	}
+
+	// Pre-fill search field from current selection (if < 256 chars) or ctx().findText
+	NSString* selText = getSelectionText(256);
+	if (selText && selText.length > 0)
+	{
+		bar.searchField.stringValue = selText;
+	}
+	else if (!ctx().findText.empty())
+	{
+		bar.searchField.stringValue = WideToNSString(ctx().findText.c_str());
+	}
+
+	// Make search field first responder
+	[bar.window makeFirstResponder:bar.searchField];
+	[bar.searchField selectText:nil];
+
+	ctx().incrSearchVisible = true;
+}
+
+void hideIncrementalSearch()
+{
+	clearIncrementalSearchHighlights();
+
+	IncrementalSearchBar* bar = getSearchBar();
+	if (bar)
+	{
+		NSView* container = bar.superview;
+		[bar removeFromSuperview];
+
+		// Restore ScintillaView to fill the container
+		NSView* sciView = activeScintillaNSView();
+		if (sciView && container && sciView.superview == container)
+		{
+			sciView.frame = container.bounds;
+		}
+	}
+
+	// Return focus to Scintilla
+	NSView* sciView = activeScintillaNSView();
+	if (sciView)
+	{
+		[sciView.window makeFirstResponder:sciView];
+	}
+
+	ctx().incrSearchVisible = false;
+}
+
+bool isIncrementalSearchVisible()
+{
+	return ctx().incrSearchVisible;
+}
+
+void clearIncrementalSearchHighlights()
+{
+	// Will be filled in Task 3
+}
+
+void updateIncrementalSearchTarget()
+{
+	// Will be filled in Task 5
+}
+
+void doIncrSearchNext()
+{
+	// Will be filled in Task 3
+}
+
+void doIncrSearchPrev()
+{
+	// Will be filled in Task 3
+}

--- a/macos/platform/incremental_search.mm
+++ b/macos/platform/incremental_search.mm
@@ -1,0 +1,2 @@
+// incremental_search.mm — Incremental search bar implementation
+#include "incremental_search.h"

--- a/macos/platform/incremental_search.mm
+++ b/macos/platform/incremental_search.mm
@@ -509,7 +509,33 @@ void clearIncrementalSearchHighlights()
 
 void updateIncrementalSearchTarget()
 {
-	// Will be filled in Task 5
+	if (!ctx().incrSearchVisible) return;
+
+	IncrementalSearchBar* bar = getSearchBar();
+	if (!bar) return;
+
+	// Remove bar from current superview
+	[bar removeFromSuperview];
+
+	// Re-add to the active editor container
+	NSView* container = activeEditorContainer();
+	if (!container) return;
+
+	bar.frame = NSMakeRect(0, container.bounds.size.height - kSearchBarHeight,
+	                       container.bounds.size.width, kSearchBarHeight);
+	[container addSubview:bar];
+
+	// Adjust ScintillaView to leave space for bar
+	NSView* sciView = activeScintillaNSView();
+	if (sciView && sciView.superview == container)
+	{
+		NSRect sciFrame = container.bounds;
+		sciFrame.size.height -= kSearchBarHeight;
+		sciView.frame = sciFrame;
+	}
+
+	// Re-run search on the new document
+	performIncrementalSearch();
 }
 
 void doIncrSearchNext()

--- a/macos/platform/incremental_search.mm
+++ b/macos/platform/incremental_search.mm
@@ -1,15 +1,18 @@
 // incremental_search.mm — Incremental search bar implementation
 #import <Cocoa/Cocoa.h>
 #include "incremental_search.h"
+#include "smart_highlight.h"
 #include "npp_constants.h"
 #include "app_state.h"
 #include "string_utils.h"
 #include "scintilla_bridge.h"
+#include <cstring>
 
-// Forward-declare free functions called by IncrSearchTextField
+// Forward-declare free functions called by IncrSearchTextField and IncrementalSearchBar
 void hideIncrementalSearch();
 void doIncrSearchNext();
 void doIncrSearchPrev();
+static void performIncrementalSearch();
 
 // ============================================================
 // IncrSearchTextField — custom NSTextField that intercepts keys
@@ -169,16 +172,32 @@ void doIncrSearchPrev();
 - (void)caseToggled:(id)sender
 {
 	ctx().matchCase = (_caseButton.state == NSControlStateValueOn);
+	performIncrementalSearch();
 }
 
 - (void)wordToggled:(id)sender
 {
 	ctx().wholeWord = (_wordButton.state == NSControlStateValueOn);
+	performIncrementalSearch();
 }
 
 - (void)regexToggled:(id)sender
 {
 	ctx().useRegex = (_regexButton.state == NSControlStateValueOn);
+	performIncrementalSearch();
+}
+
+// Debounced text change handler — re-runs search on every keystroke
+static unsigned int sIncrSearchGeneration = 0;
+
+- (void)controlTextDidChange:(NSNotification*)notification
+{
+	unsigned int gen = ++sIncrSearchGeneration;
+	dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 100 * NSEC_PER_MSEC),
+		dispatch_get_main_queue(), ^{
+			if (gen == sIncrSearchGeneration)
+				performIncrementalSearch();
+		});
 }
 
 @end
@@ -229,6 +248,148 @@ static NSString* getSelectionText(int maxLen)
 	ScintillaBridge_sendMessage(sci, SCI_GETSELTEXT, 0, (intptr_t)buf.data());
 
 	return [NSString stringWithUTF8String:buf.data()];
+}
+
+// ============================================================
+// Core search logic
+// ============================================================
+
+// Build search flags from current toggle button state
+static int buildIncrSearchFlags()
+{
+	int flags = 0;
+	if (ctx().matchCase) flags |= SCFIND_MATCHCASE;
+	if (ctx().wholeWord) flags |= SCFIND_WHOLEWORD;
+	if (ctx().useRegex)  flags |= SCFIND_REGEXP | SCFIND_CXX11REGEX;
+	return flags;
+}
+
+// Count which match index the given position corresponds to (1-based).
+// Searches from document start to the given position, counting matches.
+static int countMatchIndex(void* sci, const char* utf8Text, size_t textLen, int flags, intptr_t matchPos)
+{
+	intptr_t docLen = ScintillaBridge_sendMessage(sci, SCI_GETLENGTH, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETSEARCHFLAGS, flags, 0);
+
+	int index = 0;
+	intptr_t searchStart = 0;
+
+	while (searchStart < docLen)
+	{
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, searchStart, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, docLen, 0);
+
+		intptr_t pos = ScintillaBridge_sendMessage(sci, SCI_SEARCHINTARGET,
+		                                           textLen, (intptr_t)utf8Text);
+		if (pos < 0) break;
+
+		++index;
+		if (pos == matchPos)
+			return index;
+
+		intptr_t targetEnd = ScintillaBridge_sendMessage(sci, SCI_GETTARGETEND, 0, 0);
+		if (targetEnd <= searchStart)
+		{
+			++searchStart;
+			continue;
+		}
+		searchStart = targetEnd;
+	}
+
+	return 0; // not found
+}
+
+static void performIncrementalSearch()
+{
+	IncrementalSearchBar* bar = getSearchBar();
+	if (!bar) return;
+
+	NSString* searchText = bar.searchField.stringValue;
+	void* sci = ctx().activeScintillaView();
+	if (!sci) return;
+
+	// If search text is empty, clear highlights and reset label
+	if (!searchText || searchText.length == 0)
+	{
+		intptr_t docLen = ScintillaBridge_sendMessage(sci, SCI_GETLENGTH, 0, 0);
+		if (docLen > 0)
+		{
+			ScintillaBridge_sendMessage(sci, SCI_SETINDICATORCURRENT, INDIC_INCREMENTAL_SEARCH, 0);
+			ScintillaBridge_sendMessage(sci, SCI_INDICATORCLEARRANGE, 0, docLen);
+		}
+		bar.matchLabel.stringValue = @"";
+		ctx().incrSearchCurrentMatch = -1;
+		ctx().incrSearchTotalMatches = 0;
+		return;
+	}
+
+	const char* utf8Find = [searchText UTF8String];
+	size_t textLen = strlen(utf8Find);
+
+	// Sync search text to ctx().findText
+	ctx().findText = NSStringToWide(searchText);
+
+	// Build search flags
+	int flags = buildIncrSearchFlags();
+
+	// Clear previous highlights
+	intptr_t docLen = ScintillaBridge_sendMessage(sci, SCI_GETLENGTH, 0, 0);
+	if (docLen > 0)
+	{
+		ScintillaBridge_sendMessage(sci, SCI_SETINDICATORCURRENT, INDIC_INCREMENTAL_SEARCH, 0);
+		ScintillaBridge_sendMessage(sci, SCI_INDICATORCLEARRANGE, 0, docLen);
+	}
+
+	// Highlight all occurrences
+	int count = highlightAllOccurrences(sci, utf8Find, flags, INDIC_INCREMENTAL_SEARCH, 10000);
+
+	if (count == 0)
+	{
+		bar.matchLabel.stringValue = @"No matches";
+		ctx().incrSearchCurrentMatch = -1;
+		ctx().incrSearchTotalMatches = 0;
+		return;
+	}
+
+	ctx().incrSearchTotalMatches = count;
+
+	// Find the match nearest to (at or after) current cursor position
+	intptr_t cursorPos = ScintillaBridge_sendMessage(sci, SCI_GETCURRENTPOS, 0, 0);
+
+	// Search forward from cursor to end
+	ScintillaBridge_sendMessage(sci, SCI_SETSEARCHFLAGS, flags, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, cursorPos, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, docLen, 0);
+
+	intptr_t foundPos = ScintillaBridge_sendMessage(sci, SCI_SEARCHINTARGET,
+	                                                textLen, (intptr_t)utf8Find);
+
+	if (foundPos < 0)
+	{
+		// Wrap: search from beginning
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, 0, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, docLen, 0);
+		foundPos = ScintillaBridge_sendMessage(sci, SCI_SEARCHINTARGET,
+		                                       textLen, (intptr_t)utf8Find);
+	}
+
+	if (foundPos >= 0)
+	{
+		intptr_t targetEnd = ScintillaBridge_sendMessage(sci, SCI_GETTARGETEND, 0, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETSEL, foundPos, targetEnd);
+		ScintillaBridge_sendMessage(sci, SCI_SCROLLCARET, 0, 0);
+
+		// Count which match this is
+		int matchIndex = countMatchIndex(sci, utf8Find, textLen, flags, foundPos);
+		ctx().incrSearchCurrentMatch = matchIndex;
+
+		bar.matchLabel.stringValue = [NSString stringWithFormat:@"%d of %d", matchIndex, count];
+	}
+	else
+	{
+		bar.matchLabel.stringValue = @"No matches";
+		ctx().incrSearchCurrentMatch = -1;
+	}
 }
 
 // ============================================================
@@ -333,7 +494,17 @@ bool isIncrementalSearchVisible()
 
 void clearIncrementalSearchHighlights()
 {
-	// Will be filled in Task 3
+	void* views[] = { ctx().scintillaView, ctx().scintillaView2 };
+	for (void* sci : views)
+	{
+		if (!sci) continue;
+		intptr_t docLen = ScintillaBridge_sendMessage(sci, SCI_GETLENGTH, 0, 0);
+		if (docLen <= 0) continue;
+		ScintillaBridge_sendMessage(sci, SCI_SETINDICATORCURRENT, INDIC_INCREMENTAL_SEARCH, 0);
+		ScintillaBridge_sendMessage(sci, SCI_INDICATORCLEARRANGE, 0, docLen);
+	}
+	ctx().incrSearchCurrentMatch = -1;
+	ctx().incrSearchTotalMatches = 0;
 }
 
 void updateIncrementalSearchTarget()
@@ -343,10 +514,102 @@ void updateIncrementalSearchTarget()
 
 void doIncrSearchNext()
 {
-	// Will be filled in Task 3
+	if (ctx().findText.empty()) return;
+
+	void* sci = ctx().activeScintillaView();
+	if (!sci) return;
+
+	NSString* nsFind = WideToNSString(ctx().findText.c_str());
+	const char* utf8Find = [nsFind UTF8String];
+	size_t textLen = strlen(utf8Find);
+	int flags = buildIncrSearchFlags();
+	intptr_t docLen = ScintillaBridge_sendMessage(sci, SCI_GETLENGTH, 0, 0);
+
+	// Search forward from selection end
+	intptr_t selEnd = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONEND, 0, 0);
+
+	ScintillaBridge_sendMessage(sci, SCI_SETSEARCHFLAGS, flags, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, selEnd, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, docLen, 0);
+
+	intptr_t foundPos = ScintillaBridge_sendMessage(sci, SCI_SEARCHINTARGET,
+	                                                textLen, (intptr_t)utf8Find);
+
+	if (foundPos < 0)
+	{
+		// Wrap: search from beginning to selection end
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, 0, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, selEnd, 0);
+		foundPos = ScintillaBridge_sendMessage(sci, SCI_SEARCHINTARGET,
+		                                       textLen, (intptr_t)utf8Find);
+	}
+
+	if (foundPos >= 0)
+	{
+		intptr_t targetEnd = ScintillaBridge_sendMessage(sci, SCI_GETTARGETEND, 0, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETSEL, foundPos, targetEnd);
+		ScintillaBridge_sendMessage(sci, SCI_SCROLLCARET, 0, 0);
+
+		// Update match index label
+		int matchIndex = countMatchIndex(sci, utf8Find, textLen, flags, foundPos);
+		ctx().incrSearchCurrentMatch = matchIndex;
+
+		IncrementalSearchBar* bar = getSearchBar();
+		if (bar)
+		{
+			bar.matchLabel.stringValue = [NSString stringWithFormat:@"%d of %d",
+			                              matchIndex, ctx().incrSearchTotalMatches];
+		}
+	}
 }
 
 void doIncrSearchPrev()
 {
-	// Will be filled in Task 3
+	if (ctx().findText.empty()) return;
+
+	void* sci = ctx().activeScintillaView();
+	if (!sci) return;
+
+	NSString* nsFind = WideToNSString(ctx().findText.c_str());
+	const char* utf8Find = [nsFind UTF8String];
+	size_t textLen = strlen(utf8Find);
+	int flags = buildIncrSearchFlags();
+	intptr_t docLen = ScintillaBridge_sendMessage(sci, SCI_GETLENGTH, 0, 0);
+
+	// Search backward from selection start to document start
+	intptr_t selStart = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONSTART, 0, 0);
+
+	ScintillaBridge_sendMessage(sci, SCI_SETSEARCHFLAGS, flags, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, selStart, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, 0, 0);
+
+	intptr_t foundPos = ScintillaBridge_sendMessage(sci, SCI_SEARCHINTARGET,
+	                                                textLen, (intptr_t)utf8Find);
+
+	if (foundPos < 0)
+	{
+		// Wrap: search backward from document end to selection start
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, docLen, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, selStart, 0);
+		foundPos = ScintillaBridge_sendMessage(sci, SCI_SEARCHINTARGET,
+		                                       textLen, (intptr_t)utf8Find);
+	}
+
+	if (foundPos >= 0)
+	{
+		intptr_t targetEnd = ScintillaBridge_sendMessage(sci, SCI_GETTARGETEND, 0, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETSEL, foundPos, targetEnd);
+		ScintillaBridge_sendMessage(sci, SCI_SCROLLCARET, 0, 0);
+
+		// Update match index label
+		int matchIndex = countMatchIndex(sci, utf8Find, textLen, flags, foundPos);
+		ctx().incrSearchCurrentMatch = matchIndex;
+
+		IncrementalSearchBar* bar = getSearchBar();
+		if (bar)
+		{
+			bar.matchLabel.stringValue = [NSString stringWithFormat:@"%d of %d",
+			                              matchIndex, ctx().incrSearchTotalMatches];
+		}
+	}
 }

--- a/macos/platform/menu_builder.mm
+++ b/macos/platform/menu_builder.mm
@@ -80,8 +80,9 @@ HMENU buildMenuBar()
 
 	// Search menu
 	HMENU hSearchMenu = CreatePopupMenu();
-	AppendMenuW(hSearchMenu, MF_STRING, IDM_SEARCH_FIND, L"&Find...\tCtrl+F");
-	AppendMenuW(hSearchMenu, MF_STRING, IDM_SEARCH_REPLACE, L"&Replace...\tCtrl+H");
+	AppendMenuW(hSearchMenu, MF_STRING, IDM_SEARCH_FIND, L"&Find\tCtrl+F");
+	AppendMenuW(hSearchMenu, MF_STRING, IDM_SEARCH_REPLACE, L"Find and &Replace...\tCtrl+H");
+	AppendMenuW(hSearchMenu, MF_STRING, IDM_SEARCH_FINDINFILES, L"Find in F&iles...\tCtrl+Shift+F");
 	AppendMenuW(hSearchMenu, MF_SEPARATOR, 0, nullptr);
 	AppendMenuW(hSearchMenu, MF_STRING, IDM_SEARCH_FINDNEXT, L"Find &Next\tF3");
 	AppendMenuW(hSearchMenu, MF_STRING, IDM_SEARCH_FINDPREV, L"Find &Previous\tShift+F3");

--- a/macos/platform/npp_constants.h
+++ b/macos/platform/npp_constants.h
@@ -31,6 +31,10 @@
 #define IDM_SEARCH_BOOKMARK_NEXT     43011
 #define IDM_SEARCH_BOOKMARK_PREV     43012
 #define IDM_SEARCH_BOOKMARK_CLEARALL 43013
+
+// Power Search command IDs (Sprint 5)
+#define IDM_SEARCH_FINDINFILES   43020  // Find in Files dialog (Cmd+Shift+F)
+
 #define IDM_EDIT_AUTOCOMPLETE        42030
 #define IDM_FILE_RECENT_BASE         41100  // 41100..41109 for 10 recent files
 #define IDM_FILE_RECENT_CLEAR        41110

--- a/macos/platform/scintilla_config.mm
+++ b/macos/platform/scintilla_config.mm
@@ -67,7 +67,7 @@ void configureScintilla(void* sci)
 
 	// Incremental search match highlighting (orange rounded box)
 	ScintillaBridge_sendMessage(sci, SCI_INDICSETSTYLE, INDIC_INCREMENTAL_SEARCH, INDIC_ROUNDBOX);
-	ScintillaBridge_sendMessage(sci, SCI_INDICSETFORE, INDIC_INCREMENTAL_SEARCH, 0xFF8000); // orange (BGR)
+	ScintillaBridge_sendMessage(sci, SCI_INDICSETFORE, INDIC_INCREMENTAL_SEARCH, 0xFF8000); // orange
 	ScintillaBridge_sendMessage(sci, SCI_INDICSETALPHA, INDIC_INCREMENTAL_SEARCH, 80);
 	ScintillaBridge_sendMessage(sci, SCI_INDICSETOUTLINEALPHA, INDIC_INCREMENTAL_SEARCH, 200);
 	ScintillaBridge_sendMessage(sci, SCI_INDICSETUNDER, INDIC_INCREMENTAL_SEARCH, 1);

--- a/macos/platform/scintilla_config.mm
+++ b/macos/platform/scintilla_config.mm
@@ -65,5 +65,12 @@ void configureScintilla(void* sci)
 
 	configureSmartHighlightIndicator(sci, false);
 
+	// Incremental search match highlighting (orange rounded box)
+	ScintillaBridge_sendMessage(sci, SCI_INDICSETSTYLE, INDIC_INCREMENTAL_SEARCH, INDIC_ROUNDBOX);
+	ScintillaBridge_sendMessage(sci, SCI_INDICSETFORE, INDIC_INCREMENTAL_SEARCH, 0xFF8000); // orange (BGR)
+	ScintillaBridge_sendMessage(sci, SCI_INDICSETALPHA, INDIC_INCREMENTAL_SEARCH, 80);
+	ScintillaBridge_sendMessage(sci, SCI_INDICSETOUTLINEALPHA, INDIC_INCREMENTAL_SEARCH, 200);
+	ScintillaBridge_sendMessage(sci, SCI_INDICSETUNDER, INDIC_INCREMENTAL_SEARCH, 1);
+
 	configureKeyboardShortcuts(sci);
 }

--- a/macos/platform/search_results_panel.h
+++ b/macos/platform/search_results_panel.h
@@ -1,2 +1,8 @@
 // search_results_panel.h — Search results panel for MacNote++
 #pragma once
+
+#include "find_in_files.h"
+
+// Show the search results panel with results from a Find in Files search.
+// Currently a stub — will be fully implemented in Task 9.
+void showSearchResultsPanel(const FIFSearchResult& result);

--- a/macos/platform/search_results_panel.h
+++ b/macos/platform/search_results_panel.h
@@ -1,0 +1,2 @@
+// search_results_panel.h — Search results panel for MacNote++
+#pragma once

--- a/macos/platform/search_results_panel.h
+++ b/macos/platform/search_results_panel.h
@@ -1,8 +1,9 @@
-// search_results_panel.h — Search results panel for MacNote++
+// search_results_panel.h — Search results panel
 #pragma once
 
 #include "find_in_files.h"
 
-// Show the search results panel with results from a Find in Files search.
-// Currently a stub — will be fully implemented in Task 9.
 void showSearchResultsPanel(const FIFSearchResult& result);
+void clearSearchResults();
+void hideSearchResultsPanel();
+bool isSearchResultsPanelVisible();

--- a/macos/platform/search_results_panel.mm
+++ b/macos/platform/search_results_panel.mm
@@ -1,2 +1,7 @@
 // search_results_panel.mm — Search results panel implementation
 #include "search_results_panel.h"
+
+void showSearchResultsPanel(const FIFSearchResult& /*result*/)
+{
+	// Stub — will be implemented in Task 9
+}

--- a/macos/platform/search_results_panel.mm
+++ b/macos/platform/search_results_panel.mm
@@ -1,7 +1,440 @@
 // search_results_panel.mm — Search results panel implementation
+#import <Cocoa/Cocoa.h>
 #include "search_results_panel.h"
+#include "find_in_files.h"
 
-void showSearchResultsPanel(const FIFSearchResult& /*result*/)
+// ---------------------------------------------------------------------------
+// Data model classes
+// ---------------------------------------------------------------------------
+
+// Match item: one result line
+@interface SearchMatchItem : NSObject
+@property (copy) NSString* filePath;      // full path for navigation
+@property (copy) NSString* displayText;   // "Line 42:   int count = ..."
+@property int lineNumber;                  // 1-based
+@property int column;                      // 0-based byte offset
+@property int matchLength;                 // bytes
+@end
+
+@implementation SearchMatchItem
+@end
+
+// File item: represents results within one file
+@interface SearchFileItem : NSObject
+@property (copy) NSString* filePath;
+@property (copy) NSString* displayName;       // "filename.cpp (3 hits)"
+@property (strong) NSMutableArray* matchItems; // array of SearchMatchItem
+@end
+
+@implementation SearchFileItem
+@end
+
+// Root item: represents one search operation
+@interface SearchRootItem : NSObject
+@property (copy) NSString* summary;           // "Search 'term' (N hits in M files)"
+@property (strong) NSMutableArray* fileItems;  // array of SearchFileItem
+@end
+
+@implementation SearchRootItem
+@end
+
+// ---------------------------------------------------------------------------
+// Outline view data source / delegate
+// ---------------------------------------------------------------------------
+
+@interface SearchResultsController : NSObject <NSOutlineViewDataSource, NSOutlineViewDelegate>
+@property (strong) NSMutableArray* rootItems;  // array of SearchRootItem
+@property (weak) NSOutlineView* outlineView;
+@end
+
+@implementation SearchResultsController
+
+- (instancetype)init
 {
-	// Stub — will be implemented in Task 9
+	self = [super init];
+	if (self)
+	{
+		_rootItems = [[NSMutableArray alloc] init];
+	}
+	return self;
+}
+
+// MARK: NSOutlineViewDataSource
+
+- (NSInteger)outlineView:(NSOutlineView*)outlineView numberOfChildrenOfItem:(id)item
+{
+	if (item == nil)
+	{
+		return static_cast<NSInteger>([_rootItems count]);
+	}
+	if ([item isKindOfClass:[SearchRootItem class]])
+	{
+		return static_cast<NSInteger>([((SearchRootItem*)item).fileItems count]);
+	}
+	if ([item isKindOfClass:[SearchFileItem class]])
+	{
+		return static_cast<NSInteger>([((SearchFileItem*)item).matchItems count]);
+	}
+	return 0;
+}
+
+- (id)outlineView:(NSOutlineView*)outlineView child:(NSInteger)index ofItem:(id)item
+{
+	if (item == nil)
+	{
+		return _rootItems[index];
+	}
+	if ([item isKindOfClass:[SearchRootItem class]])
+	{
+		return ((SearchRootItem*)item).fileItems[index];
+	}
+	if ([item isKindOfClass:[SearchFileItem class]])
+	{
+		return ((SearchFileItem*)item).matchItems[index];
+	}
+	return nil;
+}
+
+- (BOOL)outlineView:(NSOutlineView*)outlineView isItemExpandable:(id)item
+{
+	if ([item isKindOfClass:[SearchRootItem class]])
+	{
+		return [((SearchRootItem*)item).fileItems count] > 0;
+	}
+	if ([item isKindOfClass:[SearchFileItem class]])
+	{
+		return [((SearchFileItem*)item).matchItems count] > 0;
+	}
+	return NO;
+}
+
+// MARK: NSOutlineViewDelegate
+
+- (NSView*)outlineView:(NSOutlineView*)outlineView
+	viewForTableColumn:(NSTableColumn*)tableColumn
+	              item:(id)item
+{
+	NSTableCellView* cellView = [outlineView makeViewWithIdentifier:@"SearchResultCell"
+	                                                         owner:self];
+	if (cellView == nil)
+	{
+		cellView = [[NSTableCellView alloc] initWithFrame:NSMakeRect(0, 0, 400, 20)];
+		NSTextField* textField = [NSTextField labelWithString:@""];
+		textField.translatesAutoresizingMaskIntoConstraints = NO;
+		textField.lineBreakMode = NSLineBreakByTruncatingTail;
+		[cellView addSubview:textField];
+		cellView.textField = textField;
+		cellView.identifier = @"SearchResultCell";
+
+		[NSLayoutConstraint activateConstraints:@[
+			[textField.leadingAnchor constraintEqualToAnchor:cellView.leadingAnchor constant:4],
+			[textField.trailingAnchor constraintEqualToAnchor:cellView.trailingAnchor constant:-4],
+			[textField.centerYAnchor constraintEqualToAnchor:cellView.centerYAnchor]
+		]];
+	}
+
+	NSTextField* textField = cellView.textField;
+
+	if ([item isKindOfClass:[SearchRootItem class]])
+	{
+		SearchRootItem* rootItem = (SearchRootItem*)item;
+		textField.stringValue = rootItem.summary;
+		textField.font = [NSFont boldSystemFontOfSize:[NSFont systemFontSize]];
+	}
+	else if ([item isKindOfClass:[SearchFileItem class]])
+	{
+		SearchFileItem* fileItem = (SearchFileItem*)item;
+		textField.stringValue = fileItem.displayName;
+		textField.font = [NSFont boldSystemFontOfSize:[NSFont systemFontSize]];
+	}
+	else if ([item isKindOfClass:[SearchMatchItem class]])
+	{
+		SearchMatchItem* matchItem = (SearchMatchItem*)item;
+		textField.stringValue = matchItem.displayText;
+		textField.font = [NSFont monospacedSystemFontOfSize:[NSFont smallSystemFontSize]
+		                                            weight:NSFontWeightRegular];
+	}
+
+	return cellView;
+}
+
+@end
+
+// ---------------------------------------------------------------------------
+// File-static state
+// ---------------------------------------------------------------------------
+
+static NSPanel* sSearchResultsPanel = nil;
+static SearchResultsController* sController = nil;
+static NSTextField* sResultCountLabel = nil;
+
+// ---------------------------------------------------------------------------
+// Helper: convert C++ result to Obj-C model
+// ---------------------------------------------------------------------------
+
+static SearchRootItem* convertResult(const FIFSearchResult& result)
+{
+	SearchRootItem* root = [[SearchRootItem alloc] init];
+	root.summary = [NSString stringWithFormat:@"Search '%s' (%d hits in %d files of %d searched)",
+	                result.searchTerm.c_str(),
+	                result.totalMatches,
+	                result.filesWithMatches,
+	                result.filesSearched];
+	root.fileItems = [[NSMutableArray alloc] init];
+
+	for (const auto& fr : result.fileResults)
+	{
+		SearchFileItem* fileItem = [[SearchFileItem alloc] init];
+		fileItem.filePath = [NSString stringWithUTF8String:fr.filePath.c_str()];
+
+		NSString* fullPath = fileItem.filePath;
+		NSString* fileName = [fullPath lastPathComponent];
+		fileItem.displayName = [NSString stringWithFormat:@"%@ (%lu hits)",
+		                        fileName, (unsigned long)fr.matches.size()];
+		fileItem.matchItems = [[NSMutableArray alloc] init];
+
+		for (const auto& m : fr.matches)
+		{
+			SearchMatchItem* matchItem = [[SearchMatchItem alloc] init];
+			matchItem.filePath = fileItem.filePath;
+			matchItem.lineNumber = m.lineNumber;
+			matchItem.column = m.column;
+			matchItem.matchLength = m.matchLength;
+			matchItem.displayText = [NSString stringWithFormat:@"  Line %d:   %s",
+			                         m.lineNumber,
+			                         m.lineText.c_str()];
+			[fileItem.matchItems addObject:matchItem];
+		}
+
+		[root.fileItems addObject:fileItem];
+	}
+
+	return root;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build the panel UI
+// ---------------------------------------------------------------------------
+
+static void createPanelIfNeeded()
+{
+	if (sSearchResultsPanel != nil)
+	{
+		return;
+	}
+
+	// Create the controller
+	sController = [[SearchResultsController alloc] init];
+
+	// Create the floating panel
+	NSRect frame = NSMakeRect(200, 200, 600, 400);
+	NSUInteger styleMask = NSWindowStyleMaskTitled
+	                     | NSWindowStyleMaskClosable
+	                     | NSWindowStyleMaskResizable
+	                     | NSWindowStyleMaskMiniaturizable;
+	sSearchResultsPanel = [[NSPanel alloc] initWithContentRect:frame
+	                                                 styleMask:styleMask
+	                                                   backing:NSBackingStoreBuffered
+	                                                     defer:YES];
+	sSearchResultsPanel.title = @"Search Results";
+	sSearchResultsPanel.floatingPanel = YES;
+	sSearchResultsPanel.becomesKeyOnlyIfNeeded = YES;
+	sSearchResultsPanel.releasedWhenClosed = NO;
+	[sSearchResultsPanel setMinSize:NSMakeSize(300, 200)];
+
+	// Content view
+	NSView* contentView = sSearchResultsPanel.contentView;
+
+	// Toolbar area
+	NSView* toolbar = [[NSView alloc] initWithFrame:NSZeroRect];
+	toolbar.translatesAutoresizingMaskIntoConstraints = NO;
+	[contentView addSubview:toolbar];
+
+	// Clear button
+	NSButton* clearButton = [NSButton buttonWithTitle:@"Clear"
+	                                           target:nil
+	                                           action:@selector(clearSearchResultsAction:)];
+	clearButton.translatesAutoresizingMaskIntoConstraints = NO;
+	[toolbar addSubview:clearButton];
+
+	// Result count label
+	sResultCountLabel = [NSTextField labelWithString:@""];
+	sResultCountLabel.translatesAutoresizingMaskIntoConstraints = NO;
+	sResultCountLabel.alignment = NSTextAlignmentCenter;
+	[sResultCountLabel setContentHuggingPriority:NSLayoutPriorityDefaultLow
+	                              forOrientation:NSLayoutConstraintOrientationHorizontal];
+	[toolbar addSubview:sResultCountLabel];
+
+	// Close button
+	NSButton* closeButton = [NSButton buttonWithTitle:@"Close"
+	                                           target:nil
+	                                           action:@selector(closeSearchResultsAction:)];
+	closeButton.translatesAutoresizingMaskIntoConstraints = NO;
+	[toolbar addSubview:closeButton];
+
+	// Create a helper target for button actions
+	// We use the controller as the target
+	clearButton.target = sController;
+	closeButton.target = sController;
+
+	// Scroll view + outline view
+	NSScrollView* scrollView = [[NSScrollView alloc] initWithFrame:NSZeroRect];
+	scrollView.translatesAutoresizingMaskIntoConstraints = NO;
+	scrollView.hasVerticalScroller = YES;
+	scrollView.hasHorizontalScroller = YES;
+	scrollView.autohidesScrollers = YES;
+	scrollView.borderType = NSBezelBorder;
+
+	NSOutlineView* outlineView = [[NSOutlineView alloc] initWithFrame:NSZeroRect];
+	outlineView.headerView = nil; // no header
+	outlineView.usesAlternatingRowBackgroundColors = YES;
+
+	// Single column that auto-resizes
+	NSTableColumn* column = [[NSTableColumn alloc] initWithIdentifier:@"ResultColumn"];
+	column.resizingMask = NSTableColumnAutoresizingMask;
+	[outlineView addTableColumn:column];
+	outlineView.outlineTableColumn = column;
+
+	outlineView.dataSource = sController;
+	outlineView.delegate = sController;
+	sController.outlineView = outlineView;
+
+	scrollView.documentView = outlineView;
+	[contentView addSubview:scrollView];
+
+	// Layout constraints
+	[NSLayoutConstraint activateConstraints:@[
+		// Toolbar at top
+		[toolbar.topAnchor constraintEqualToAnchor:contentView.topAnchor constant:8],
+		[toolbar.leadingAnchor constraintEqualToAnchor:contentView.leadingAnchor constant:8],
+		[toolbar.trailingAnchor constraintEqualToAnchor:contentView.trailingAnchor constant:-8],
+		[toolbar.heightAnchor constraintEqualToConstant:30],
+
+		// Clear button on left
+		[clearButton.leadingAnchor constraintEqualToAnchor:toolbar.leadingAnchor],
+		[clearButton.centerYAnchor constraintEqualToAnchor:toolbar.centerYAnchor],
+
+		// Close button on right
+		[closeButton.trailingAnchor constraintEqualToAnchor:toolbar.trailingAnchor],
+		[closeButton.centerYAnchor constraintEqualToAnchor:toolbar.centerYAnchor],
+
+		// Result count label in center
+		[sResultCountLabel.leadingAnchor constraintEqualToAnchor:clearButton.trailingAnchor constant:8],
+		[sResultCountLabel.trailingAnchor constraintEqualToAnchor:closeButton.leadingAnchor constant:-8],
+		[sResultCountLabel.centerYAnchor constraintEqualToAnchor:toolbar.centerYAnchor],
+
+		// Scroll view fills remaining space
+		[scrollView.topAnchor constraintEqualToAnchor:toolbar.bottomAnchor constant:8],
+		[scrollView.leadingAnchor constraintEqualToAnchor:contentView.leadingAnchor constant:8],
+		[scrollView.trailingAnchor constraintEqualToAnchor:contentView.trailingAnchor constant:-8],
+		[scrollView.bottomAnchor constraintEqualToAnchor:contentView.bottomAnchor constant:-8]
+	]];
+}
+
+// ---------------------------------------------------------------------------
+// Button action methods on SearchResultsController
+// ---------------------------------------------------------------------------
+
+@interface SearchResultsController (Actions)
+- (void)clearSearchResultsAction:(id)sender;
+- (void)closeSearchResultsAction:(id)sender;
+@end
+
+@implementation SearchResultsController (Actions)
+
+- (void)clearSearchResultsAction:(id)sender
+{
+	clearSearchResults();
+}
+
+- (void)closeSearchResultsAction:(id)sender
+{
+	hideSearchResultsPanel();
+}
+
+@end
+
+// ---------------------------------------------------------------------------
+// Helper: update result count label
+// ---------------------------------------------------------------------------
+
+static void updateResultCountLabel()
+{
+	if (sResultCountLabel == nil || sController == nil)
+	{
+		return;
+	}
+
+	NSInteger totalHits = 0;
+	for (SearchRootItem* root in sController.rootItems)
+	{
+		for (SearchFileItem* file in root.fileItems)
+		{
+			totalHits += static_cast<NSInteger>([file.matchItems count]);
+		}
+	}
+
+	if (totalHits == 0)
+	{
+		sResultCountLabel.stringValue = @"No results";
+	}
+	else
+	{
+		sResultCountLabel.stringValue = [NSString stringWithFormat:@"%ld total matches",
+		                                 (long)totalHits];
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+void showSearchResultsPanel(const FIFSearchResult& result)
+{
+	createPanelIfNeeded();
+
+	// Convert C++ data to Obj-C model and append
+	SearchRootItem* rootItem = convertResult(result);
+	[sController.rootItems addObject:rootItem];
+
+	// Reload and expand the new root item
+	[sController.outlineView reloadData];
+	[sController.outlineView expandItem:rootItem expandChildren:NO];
+
+	updateResultCountLabel();
+
+	// Show the panel
+	[sSearchResultsPanel makeKeyAndOrderFront:nil];
+}
+
+void clearSearchResults()
+{
+	if (sController == nil)
+	{
+		return;
+	}
+
+	[sController.rootItems removeAllObjects];
+	[sController.outlineView reloadData];
+	updateResultCountLabel();
+}
+
+void hideSearchResultsPanel()
+{
+	if (sSearchResultsPanel == nil)
+	{
+		return;
+	}
+
+	[sSearchResultsPanel orderOut:nil];
+}
+
+bool isSearchResultsPanelVisible()
+{
+	if (sSearchResultsPanel == nil)
+	{
+		return false;
+	}
+
+	return [sSearchResultsPanel isVisible] == YES;
 }

--- a/macos/platform/search_results_panel.mm
+++ b/macos/platform/search_results_panel.mm
@@ -1,0 +1,2 @@
+// search_results_panel.mm — Search results panel implementation
+#include "search_results_panel.h"

--- a/macos/platform/search_results_panel.mm
+++ b/macos/platform/search_results_panel.mm
@@ -2,6 +2,11 @@
 #import <Cocoa/Cocoa.h>
 #include "search_results_panel.h"
 #include "find_in_files.h"
+#include "file_operations.h"
+#include "app_state.h"
+#include "string_utils.h"
+#include "scintilla_bridge.h"
+#include "npp_constants.h"
 
 // ---------------------------------------------------------------------------
 // Data model classes
@@ -39,12 +44,42 @@
 @end
 
 // ---------------------------------------------------------------------------
+// Custom NSOutlineView subclass — handles Enter key
+// ---------------------------------------------------------------------------
+
+@interface SearchResultsOutlineView : NSOutlineView
+@end
+
+@implementation SearchResultsOutlineView
+
+- (void)keyDown:(NSEvent*)event
+{
+	if (event.keyCode == 36) // Return key
+	{
+		id target = self.target;
+		SEL action = self.doubleAction;
+		if (target && action)
+		{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+			[target performSelector:action withObject:self];
+#pragma clang diagnostic pop
+			return;
+		}
+	}
+	[super keyDown:event];
+}
+
+@end
+
+// ---------------------------------------------------------------------------
 // Outline view data source / delegate
 // ---------------------------------------------------------------------------
 
 @interface SearchResultsController : NSObject <NSOutlineViewDataSource, NSOutlineViewDelegate>
 @property (strong) NSMutableArray* rootItems;  // array of SearchRootItem
 @property (weak) NSOutlineView* outlineView;
+- (void)resultDoubleClicked:(id)sender;
 @end
 
 @implementation SearchResultsController
@@ -156,6 +191,85 @@
 	}
 
 	return cellView;
+}
+
+// MARK: Double-click / Enter navigation
+
+- (void)resultDoubleClicked:(id)sender
+{
+	NSInteger row = [self.outlineView clickedRow];
+	// When triggered via Enter key, clickedRow returns -1; use selectedRow instead
+	if (row < 0)
+	{
+		row = [self.outlineView selectedRow];
+	}
+	if (row < 0)
+	{
+		return;
+	}
+
+	id item = [self.outlineView itemAtRow:row];
+
+	if ([item isKindOfClass:[SearchMatchItem class]])
+	{
+		SearchMatchItem* matchItem = (SearchMatchItem*)item;
+
+		// Try to switch to the file if it is already open
+		std::wstring wpath = NSStringToWide(matchItem.filePath);
+		bool fileReady = switchToFileIfOpen(wpath);
+
+		// If not already open, open it
+		if (!fileReady)
+		{
+			fileReady = openFileAtPath(matchItem.filePath);
+		}
+
+		if (fileReady)
+		{
+			// Navigate to the match in the active Scintilla view
+			void* sci = ctx().activeScintillaView();
+
+			// Go to the line (0-based)
+			ScintillaBridge_sendMessage(sci, SCI_GOTOLINE,
+				static_cast<uintptr_t>(matchItem.lineNumber - 1), 0);
+
+			// Get byte position of the line start
+			intptr_t lineStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE,
+				static_cast<uintptr_t>(matchItem.lineNumber - 1), 0);
+
+			// Select the match text
+			ScintillaBridge_sendMessage(sci, SCI_SETSEL,
+				static_cast<uintptr_t>(lineStart + matchItem.column),
+				static_cast<intptr_t>(lineStart + matchItem.column + matchItem.matchLength));
+
+			// Scroll to show the caret
+			ScintillaBridge_sendMessage(sci, SCI_SCROLLCARET, 0, 0);
+		}
+	}
+	else if ([item isKindOfClass:[SearchFileItem class]])
+	{
+		// Toggle expand/collapse for file items
+		if ([self.outlineView isItemExpanded:item])
+		{
+			[self.outlineView collapseItem:item];
+		}
+		else
+		{
+			[self.outlineView expandItem:item];
+		}
+	}
+	else if ([item isKindOfClass:[SearchRootItem class]])
+	{
+		// Toggle expand/collapse for root items
+		if ([self.outlineView isItemExpanded:item])
+		{
+			[self.outlineView collapseItem:item];
+		}
+		else
+		{
+			[self.outlineView expandItem:item];
+		}
+	}
 }
 
 @end
@@ -285,7 +399,7 @@ static void createPanelIfNeeded()
 	scrollView.autohidesScrollers = YES;
 	scrollView.borderType = NSBezelBorder;
 
-	NSOutlineView* outlineView = [[NSOutlineView alloc] initWithFrame:NSZeroRect];
+	SearchResultsOutlineView* outlineView = [[SearchResultsOutlineView alloc] initWithFrame:NSZeroRect];
 	outlineView.headerView = nil; // no header
 	outlineView.usesAlternatingRowBackgroundColors = YES;
 
@@ -298,6 +412,10 @@ static void createPanelIfNeeded()
 	outlineView.dataSource = sController;
 	outlineView.delegate = sController;
 	sController.outlineView = outlineView;
+
+	// Wire up double-click to navigate to match
+	[outlineView setDoubleAction:@selector(resultDoubleClicked:)];
+	[outlineView setTarget:sController];
 
 	scrollView.documentView = outlineView;
 	[contentView addSubview:scrollView];

--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -14,6 +14,7 @@
 #include "handle_registry.h"
 #include "brace_match.h"
 #include "smart_highlight.h"
+#include "incremental_search.h"
 #include "auto_indent.h"
 #include "scintilla_notify.h"
 #include "windows.h"
@@ -225,6 +226,14 @@ void doUnsplit()
 	if (ctx().scintillaView2)
 		saveViewState(ctx().scintillaView2, ctx().documents2, ctx().activeTab2);
 
+	// If incremental search bar is in the closing view, remove it first
+	if (isIncrementalSearchVisible() && ctx().incrementalSearchBar) {
+		NSView* bar = ctx().incrementalSearchBar;
+		if ([bar superview] == ctx().editorContainer2 || [bar superview] == ctx().sciContainer2) {
+			[bar removeFromSuperview];
+		}
+	}
+
 	if (ctx().scintillaView2)
 	{
 		cancelPendingSmartHighlight();
@@ -263,6 +272,10 @@ void doUnsplit()
 	ctx().activeTab2 = -1;
 	ctx().activeView = 0;
 	ctx().isSplit = false;
+
+	if (isIncrementalSearchVisible())
+		updateIncrementalSearchTarget();
+
 	layoutSplitTopTabBars();
 }
 

--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -227,9 +227,11 @@ void doUnsplit()
 		saveViewState(ctx().scintillaView2, ctx().documents2, ctx().activeTab2);
 
 	// If incremental search bar is in the closing view, remove it first
-	if (isIncrementalSearchVisible() && ctx().incrementalSearchBar) {
+	if (isIncrementalSearchVisible() && ctx().incrementalSearchBar)
+	{
 		NSView* bar = ctx().incrementalSearchBar;
-		if ([bar superview] == ctx().editorContainer2 || [bar superview] == ctx().sciContainer2) {
+		if ([bar superview] == ctx().editorContainer2 || [bar superview] == ctx().sciContainer2)
+		{
 			[bar removeFromSuperview];
 		}
 	}

--- a/macos/platform/wndproc.mm
+++ b/macos/platform/wndproc.mm
@@ -208,14 +208,18 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 					createFindReplaceDlg(true);
 					return 0;
 				case IDM_SEARCH_FINDNEXT:
-					if (ctx().findText.empty())
-						createFindReplaceDlg(false);
+					if (isIncrementalSearchVisible())
+						doIncrSearchNext();
+					else if (ctx().findText.empty())
+						showIncrementalSearch();
 					else
 						doFindNext(true);
 					return 0;
 				case IDM_SEARCH_FINDPREV:
-					if (ctx().findText.empty())
-						createFindReplaceDlg(false);
+					if (isIncrementalSearchVisible())
+						doIncrSearchPrev();
+					else if (ctx().findText.empty())
+						showIncrementalSearch();
 					else
 						doFindNext(false);
 					return 0;

--- a/macos/platform/wndproc.mm
+++ b/macos/platform/wndproc.mm
@@ -19,6 +19,8 @@
 #include "status_bar.h"
 #include "file_path_ops.h"
 #include "tab_context_menu.h"
+#include "incremental_search.h"
+#include "find_in_files.h"
 #include "lexer_styles.h"
 #include "language_defs.h"
 #include "scintilla_bridge.h"
@@ -200,7 +202,7 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 					return 0;
 
 				case IDM_SEARCH_FIND:
-					createFindReplaceDlg(false);
+					showIncrementalSearch();
 					return 0;
 				case IDM_SEARCH_REPLACE:
 					createFindReplaceDlg(true);
@@ -219,6 +221,9 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 					return 0;
 				case IDM_SEARCH_GOTOLINE:
 					showGoToLineDlg();
+					return 0;
+				case IDM_SEARCH_FINDINFILES:
+					showFindInFilesDlg();
 					return 0;
 
 				case IDM_SEARCH_BOOKMARK_TOGGLE:


### PR DESCRIPTION
## Summary

- **Root cause**: `doFindInFiles()` took string parameters by `const std::string&`, but these references were captured by a `dispatch_async` block. By the time the background block executed, the caller's stack had unwound and the originals were destroyed — the search term became empty/garbage, triggering an infinite loop in `searchLinePlainText` until the 10,000 match cap.
- Changed `doFindInFiles` string params from const ref to pass-by-value so the block captures owned copies
- Added early-return guards against empty search term in both `doFindInFiles` and `searchLinePlainText`

## Test plan

- [ ] Build and run the app
- [ ] Open Find in Files (Cmd+Shift+F), search for "FindMe" in `test_file_search/` directory
- [ ] Verify correct match count, line numbers, and search term displayed in results
- [ ] Test regex mode search
- [ ] Test cancel during search

🤖 Generated with [Claude Code](https://claude.com/claude-code)