### PR TITLE
feat: add code signing and notarization support

### DIFF
--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -116,10 +116,23 @@ jobs:
         id: check_secrets
         env:
           HAS_CERT: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          HAS_CERT_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          HAS_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
+          HAS_APPLE_ID: ${{ secrets.APPLE_ID }}
+          HAS_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          HAS_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
         run: |
-          if [ -z "$HAS_CERT" ]; then
+          missing=()
+          [ -z "$HAS_CERT" ] && missing+=("APPLE_CERTIFICATE_P12")
+          [ -z "$HAS_CERT_PASSWORD" ] && missing+=("APPLE_CERTIFICATE_PASSWORD")
+          [ -z "$HAS_IDENTITY" ] && missing+=("APPLE_CODESIGN_IDENTITY")
+          [ -z "$HAS_APPLE_ID" ] && missing+=("APPLE_ID")
+          [ -z "$HAS_TEAM_ID" ] && missing+=("APPLE_TEAM_ID")
+          [ -z "$HAS_APP_PASSWORD" ] && missing+=("APPLE_APP_PASSWORD")
+
+          if [ ${#missing[@]} -ne 0 ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::Signing secrets not configured. Skipping signing and notarization."
+            echo "::warning::Signing/notarization secrets not fully configured. Missing: ${missing[*]}. Skipping."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
@@ -133,7 +146,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: MacNote++.app-macos-15-arm64
-          path: macos/dist/MacNote++.app
+          path: macos/dist
 
       - name: Restore executable permission
         if: steps.check_secrets.outputs.skip != 'true'

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -104,3 +104,116 @@ jobs:
           name: MacOSNotePP-Release-${{ matrix.runner }}-${{ matrix.arch }}
           path: macos/build/Release/MacOSNotePP
           retention-days: 14
+
+  sign_and_notarize:
+    name: Sign & Notarize (ARM64)
+    needs: build_macos
+    runs-on: macos-15
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Check signing secrets
+        id: check_secrets
+        env:
+          HAS_CERT: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+        run: |
+          if [ -z "$HAS_CERT" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Signing secrets not configured. Skipping signing and notarization."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout repo
+        if: steps.check_secrets.outputs.skip != 'true'
+        uses: actions/checkout@v4
+
+      - name: Download app bundle artifact
+        if: steps.check_secrets.outputs.skip != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: MacNote++.app-macos-15-arm64
+          path: macos/dist/MacNote++.app
+
+      - name: Restore executable permission
+        if: steps.check_secrets.outputs.skip != 'true'
+        run: chmod +x macos/dist/MacNote++.app/Contents/MacOS/MacOSNotePP
+
+      - name: Import code signing certificate
+        if: steps.check_secrets.outputs.skip != 'true'
+        env:
+          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+          echo "$APPLE_CERTIFICATE_P12" | base64 --decode > "$CERT_PATH"
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+
+          security set-key-partition-list -S apple-tool:,apple: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+          rm -f "$CERT_PATH"
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+
+      - name: Build unsigned DMG
+        if: steps.check_secrets.outputs.skip != 'true'
+        run: |
+          mkdir -p macos/dist/dmg-root
+          rm -rf macos/dist/dmg-root/MacNote++.app
+          cp -R macos/dist/MacNote++.app macos/dist/dmg-root/MacNote++.app
+          rm -f macos/dist/dmg-root/Applications
+          ln -s /Applications macos/dist/dmg-root/Applications
+          rm -f macos/dist/MacNote++-unsigned.dmg
+          hdiutil create \
+            -volname "MacNote++" \
+            -srcfolder macos/dist/dmg-root \
+            -format UDZO \
+            -ov \
+            macos/dist/MacNote++-unsigned.dmg
+
+      - name: Sign and notarize
+        if: steps.check_secrets.outputs.skip != 'true'
+        env:
+          CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+        run: |
+          chmod +x macos/scripts/sign-and-notarize.sh
+          macos/scripts/sign-and-notarize.sh --verbose
+
+      - name: Upload signed DMG
+        if: steps.check_secrets.outputs.skip != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: MacNote++.dmg-signed-arm64
+          path: macos/dist/MacNote++.dmg
+          retention-days: 30
+
+      - name: Upload signed app bundle
+        if: steps.check_secrets.outputs.skip != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: MacNote++.app-signed-arm64
+          path: macos/dist/MacNote++.app
+          retention-days: 30
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          if [ -n "${KEYCHAIN_PATH:-}" ] && [ -f "$KEYCHAIN_PATH" ]; then
+            security delete-keychain "$KEYCHAIN_PATH" || true
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,8 @@ PowerEditor/bin/SourceCodePro-Regular.ttf
 # macOS port
 macos/build/
 macos/dist/
+*.p12
+*.keychain-db
 
 #-------------------------------------------------------------------------------
 # MinGW-w64 GCC

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,18 @@ cmake --build . --target MacOSNotePP_package
 # Build unsigned DMG for distribution
 cmake --build . --target MacOSNotePP_dmg
 
+# Build with code signing (opt-in, requires Developer ID certificate)
+cmake -G Xcode .. -DCODESIGN_ENABLED=ON -DCODESIGN_IDENTITY="Developer ID Application"
+cmake --build . --target MacOSNotePP_sign     # Sign .app bundle
+cmake --build . --target MacOSNotePP_dmg      # Build + sign DMG
+
+# Full sign + notarize workflow (after building unsigned DMG)
+export CODESIGN_IDENTITY="Developer ID Application"
+export APPLE_ID="your@email.com"
+export APPLE_TEAM_ID="TEAMID"
+export APPLE_APP_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+macos/scripts/sign-and-notarize.sh
+
 # Run the app (development build)
 ./Debug/MacOSNotePP
 

--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -448,12 +448,17 @@ add_custom_target(MacOSNotePP_package
 )
 
 if(CODESIGN_ENABLED)
-    # Sign and build DMG in /tmp to avoid iCloud/FileProvider xattr interference.
-    # iCloud-synced directories (e.g., ~/Desktop) re-add xattrs that invalidate
-    # code signatures, so all signing and DMG creation happens outside the sync zone.
+    # Sign and build DMG in a temp directory to avoid iCloud/FileProvider xattr
+    # interference. iCloud-synced directories re-add xattrs that invalidate code
+    # signatures, so all signing and DMG creation happens outside the sync zone.
     # NOTE: --deep is acceptable while the bundle has no nested frameworks/helpers.
     # Replace with explicit per-component signing if nested bundles are added.
-    set(NPP_SIGN_STAGE "/tmp/MacNotePP-sign-stage")
+    if(DEFINED ENV{TMPDIR} AND NOT "$ENV{TMPDIR}" STREQUAL "")
+        set(NPP_SIGN_STAGE_ROOT "$ENV{TMPDIR}")
+    else()
+        set(NPP_SIGN_STAGE_ROOT "/tmp")
+    endif()
+    set(NPP_SIGN_STAGE "${NPP_SIGN_STAGE_ROOT}/MacNotePP-sign-stage")
     set(NPP_SIGN_STAGE_APP "${NPP_SIGN_STAGE}/MacNote++.app")
     set(NPP_SIGN_STAGE_DMG_ROOT "${NPP_SIGN_STAGE}/dmg-root")
 
@@ -473,6 +478,10 @@ if(CODESIGN_ENABLED)
             "${NPP_SIGN_STAGE_APP}"
         COMMAND codesign --verify --deep --strict --verbose=2
             "${NPP_SIGN_STAGE_APP}"
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${NPP_MACOS_APP_BUNDLE}"
+        COMMAND ditto "${NPP_SIGN_STAGE_APP}" "${NPP_MACOS_APP_BUNDLE}"
+        COMMAND ${CMAKE_COMMAND} -E echo
+            "Signed app bundle: ${NPP_MACOS_APP_BUNDLE}"
         COMMENT "Code signing MacNote++.app with '${CODESIGN_IDENTITY}'"
     )
 

--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -9,6 +9,26 @@ set(CMAKE_OBJCXX_STANDARD 20)
 set(NPP_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/..")
 
 # ============================================================
+# Code Signing Configuration (opt-in)
+# ============================================================
+option(CODESIGN_ENABLED "Enable code signing for the app bundle and DMG" OFF)
+set(CODESIGN_IDENTITY "Developer ID Application" CACHE STRING
+    "Code signing identity (e.g., 'Developer ID Application: Your Name (TEAMID)')")
+set(CODESIGN_ENTITLEMENTS "${CMAKE_CURRENT_SOURCE_DIR}/platform/MacNote.entitlements" CACHE FILEPATH
+    "Path to entitlements plist for hardened runtime")
+
+if(CODESIGN_ENABLED)
+    message(STATUS "Code signing: ENABLED")
+    message(STATUS "  Identity: ${CODESIGN_IDENTITY}")
+    message(STATUS "  Entitlements: ${CODESIGN_ENTITLEMENTS}")
+    if(NOT EXISTS "${CODESIGN_ENTITLEMENTS}")
+        message(FATAL_ERROR "Entitlements file not found: ${CODESIGN_ENTITLEMENTS}")
+    endif()
+else()
+    message(STATUS "Code signing: DISABLED (pass -DCODESIGN_ENABLED=ON to enable)")
+endif()
+
+# ============================================================
 # Win32 Shim Library
 # ============================================================
 # The shim include directory MUST come first so that
@@ -386,7 +406,7 @@ add_custom_command(TARGET MacOSNotePP POST_BUILD
 )
 
 # ============================================================
-# Packaging: App bundle + unsigned DMG
+# Packaging: App bundle, code signing, and DMG
 # ============================================================
 set(NPP_MACOS_DIST_DIR "${CMAKE_CURRENT_SOURCE_DIR}/dist")
 set(NPP_MACOS_APP_BUNDLE "${NPP_MACOS_DIST_DIR}/MacNote++.app")
@@ -412,10 +432,10 @@ add_custom_target(MacOSNotePP_package
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "$<TARGET_FILE:MacOSNotePP>"
         "${NPP_MACOS_APP_MACOS}/MacOSNotePP"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    COMMAND ditto --norsrc
         "${NPP_ROOT}/logo.png"
         "${NPP_MACOS_APP_MACOS}/logo.png"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    COMMAND ditto --norsrc
         "${NPP_ROOT}/logo.png"
         "${NPP_MACOS_APP_RESOURCES}/logo.png"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
@@ -427,32 +447,100 @@ add_custom_target(MacOSNotePP_package
     COMMENT "Packaging MacNote++.app"
 )
 
-add_custom_target(MacOSNotePP_dmg
-    DEPENDS MacOSNotePP_package
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${NPP_MACOS_DMG_ROOT}"
-    COMMAND ${CMAKE_COMMAND} -E rm -rf "${NPP_MACOS_DMG_APP_BUNDLE}"
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        "${NPP_MACOS_APP_BUNDLE}"
-        "${NPP_MACOS_DMG_APP_BUNDLE}"
-    COMMAND ${CMAKE_COMMAND} -E rm -rf "${NPP_MACOS_DMG_ROOT}/Applications"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink
-        "/Applications"
-        "${NPP_MACOS_DMG_ROOT}/Applications"
-    COMMAND ${CMAKE_COMMAND} -E rm -f "${NPP_MACOS_UNSIGNED_DMG}"
-    COMMAND hdiutil create
-        -volname "MacNote++"
-        -srcfolder "${NPP_MACOS_DMG_ROOT}"
-        -format UDZO
-        -ov
-        "${NPP_MACOS_UNSIGNED_DMG}"
-    COMMENT "Building MacNote++-unsigned.dmg"
-)
+if(CODESIGN_ENABLED)
+    # Sign and build DMG in /tmp to avoid iCloud/FileProvider xattr interference.
+    # iCloud-synced directories (e.g., ~/Desktop) re-add xattrs that invalidate
+    # code signatures, so all signing and DMG creation happens outside the sync zone.
+    # NOTE: --deep is acceptable while the bundle has no nested frameworks/helpers.
+    # Replace with explicit per-component signing if nested bundles are added.
+    set(NPP_SIGN_STAGE "/tmp/MacNotePP-sign-stage")
+    set(NPP_SIGN_STAGE_APP "${NPP_SIGN_STAGE}/MacNote++.app")
+    set(NPP_SIGN_STAGE_DMG_ROOT "${NPP_SIGN_STAGE}/dmg-root")
+
+    add_custom_target(MacOSNotePP_sign
+        DEPENDS MacOSNotePP_package
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${NPP_SIGN_STAGE}"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${NPP_SIGN_STAGE}"
+        COMMAND ditto --norsrc
+            "${NPP_MACOS_APP_BUNDLE}"
+            "${NPP_SIGN_STAGE_APP}"
+        COMMAND xattr -cr "${NPP_SIGN_STAGE_APP}"
+        COMMAND codesign --force --options runtime
+            --sign "${CODESIGN_IDENTITY}"
+            --entitlements "${CODESIGN_ENTITLEMENTS}"
+            --timestamp
+            --deep
+            "${NPP_SIGN_STAGE_APP}"
+        COMMAND codesign --verify --deep --strict --verbose=2
+            "${NPP_SIGN_STAGE_APP}"
+        COMMENT "Code signing MacNote++.app with '${CODESIGN_IDENTITY}'"
+    )
+
+    add_custom_target(MacOSNotePP_dmg
+        DEPENDS MacOSNotePP_sign
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${NPP_SIGN_STAGE_DMG_ROOT}"
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${NPP_SIGN_STAGE_DMG_ROOT}/MacNote++.app"
+        COMMAND ditto "${NPP_SIGN_STAGE_APP}" "${NPP_SIGN_STAGE_DMG_ROOT}/MacNote++.app"
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${NPP_SIGN_STAGE_DMG_ROOT}/Applications"
+        COMMAND ${CMAKE_COMMAND} -E create_symlink
+            "/Applications"
+            "${NPP_SIGN_STAGE_DMG_ROOT}/Applications"
+        COMMAND ${CMAKE_COMMAND} -E rm -f "${NPP_SIGN_STAGE}/MacNote++.dmg"
+        COMMAND hdiutil create
+            -volname "MacNote++"
+            -srcfolder "${NPP_SIGN_STAGE_DMG_ROOT}"
+            -format UDZO
+            -ov
+            "${NPP_SIGN_STAGE}/MacNote++.dmg"
+        COMMAND codesign --force --sign "${CODESIGN_IDENTITY}"
+            --timestamp "${NPP_SIGN_STAGE}/MacNote++.dmg"
+        COMMAND codesign --verify --verbose=2 "${NPP_SIGN_STAGE}/MacNote++.dmg"
+        COMMAND ${CMAKE_COMMAND} -E copy
+            "${NPP_SIGN_STAGE}/MacNote++.dmg"
+            "${NPP_MACOS_DIST_DIR}/MacNote++.dmg"
+        COMMAND ${CMAKE_COMMAND} -E echo
+            "Signed DMG: ${NPP_MACOS_DIST_DIR}/MacNote++.dmg"
+        COMMAND ${CMAKE_COMMAND} -E echo
+            "NOTE: If your project directory is iCloud-synced, signature verification"
+        COMMAND ${CMAKE_COMMAND} -E echo
+            "may fail locally due to Finder xattrs. The DMG is valid for distribution."
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${NPP_SIGN_STAGE}"
+        COMMENT "Building and signing MacNote++.dmg"
+    )
+else()
+    add_custom_target(MacOSNotePP_sign
+        DEPENDS MacOSNotePP_package
+        COMMENT "Code signing SKIPPED (CODESIGN_ENABLED=OFF)"
+    )
+
+    add_custom_target(MacOSNotePP_dmg
+        DEPENDS MacOSNotePP_sign
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${NPP_MACOS_DMG_ROOT}"
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${NPP_MACOS_DMG_APP_BUNDLE}"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${NPP_MACOS_APP_BUNDLE}"
+            "${NPP_MACOS_DMG_APP_BUNDLE}"
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${NPP_MACOS_DMG_ROOT}/Applications"
+        COMMAND ${CMAKE_COMMAND} -E create_symlink
+            "/Applications"
+            "${NPP_MACOS_DMG_ROOT}/Applications"
+        COMMAND ${CMAKE_COMMAND} -E rm -f "${NPP_MACOS_UNSIGNED_DMG}"
+        COMMAND hdiutil create
+            -volname "MacNote++"
+            -srcfolder "${NPP_MACOS_DMG_ROOT}"
+            -format UDZO
+            -ov
+            "${NPP_MACOS_UNSIGNED_DMG}"
+        COMMENT "Building MacNote++-unsigned.dmg"
+    )
+endif()
 
 message(STATUS "=== Notepad++ macOS Port ===")
 message(STATUS "Compatibility compile target: npp_macos_compile_test")
 message(STATUS "App target: MacOSNotePP")
 message(STATUS "Packaging target: MacOSNotePP_package")
-message(STATUS "Unsigned DMG target: MacOSNotePP_dmg")
+message(STATUS "Signing target: MacOSNotePP_sign")
+message(STATUS "DMG target: MacOSNotePP_dmg")
 message(STATUS "Shim headers: ${SHIM_INCLUDE_DIR}")
 message(STATUS "Scintilla: ${SCINTILLA_DIR}")
 message(STATUS "Lexilla: ${LEXILLA_DIR}")

--- a/macos/platform/MacNote.entitlements
+++ b/macos/platform/MacNote.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/macos/platform/MacNote.entitlements
+++ b/macos/platform/MacNote.entitlements
@@ -2,9 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-	<true/>
-	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
 </dict>
 </plist>

--- a/macos/scripts/sign-and-notarize.sh
+++ b/macos/scripts/sign-and-notarize.sh
@@ -35,12 +35,19 @@ SKIP_NOTARIZE=false
 SKIP_DMG=false
 VERBOSE=false
 
+# Helper: require a value argument for an option
+require_arg() {
+	if [[ $# -lt 2 || "$2" == --* ]]; then
+		echo "ERROR: $1 requires a value" >&2; exit 1
+	fi
+}
+
 # Parse arguments
 while [[ $# -gt 0 ]]; do
 	case "$1" in
-		--app-path)      APP_PATH="$2"; shift 2 ;;
-		--dmg-path)      DMG_PATH="$2"; shift 2 ;;
-		--entitlements)  ENTITLEMENTS="$2"; shift 2 ;;
+		--app-path)      require_arg "$1" "${2:-}"; APP_PATH="$2"; shift 2 ;;
+		--dmg-path)      require_arg "$1" "${2:-}"; DMG_PATH="$2"; shift 2 ;;
+		--entitlements)  require_arg "$1" "${2:-}"; ENTITLEMENTS="$2"; shift 2 ;;
 		--skip-notarize) SKIP_NOTARIZE=true; shift ;;
 		--skip-dmg)      SKIP_DMG=true; shift ;;
 		--verbose)       VERBOSE=true; shift ;;

--- a/macos/scripts/sign-and-notarize.sh
+++ b/macos/scripts/sign-and-notarize.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# sign-and-notarize.sh -- Sign and notarize MacNote++.app and its DMG
+#
+# Usage:
+#   ./sign-and-notarize.sh [options]
+#
+# Required environment variables:
+#   CODESIGN_IDENTITY    - Signing identity (e.g., "Developer ID Application: Name (TEAMID)")
+#
+# For notarization (skip with --skip-notarize):
+#   Password auth:  APPLE_ID + APPLE_TEAM_ID + APPLE_APP_PASSWORD
+#   API key auth:   APPLE_API_KEY + APPLE_API_ISSUER (+ optional APPLE_API_KEY_PATH)
+#
+# Options:
+#   --app-path PATH      Path to .app bundle (default: macos/dist/MacNote++.app)
+#   --dmg-path PATH      Path to .dmg file (auto-detected from dist/)
+#   --entitlements PATH  Path to entitlements (default: macos/platform/MacNote.entitlements)
+#   --skip-notarize      Only sign, do not notarize
+#   --skip-dmg           Only sign/notarize the app, not the DMG
+#   --verbose            Enable verbose output
+#   --help               Show this help
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MACOS_DIR="$REPO_ROOT/macos"
+
+# Defaults
+APP_PATH="${MACOS_DIR}/dist/MacNote++.app"
+DMG_PATH=""
+ENTITLEMENTS="${MACOS_DIR}/platform/MacNote.entitlements"
+SKIP_NOTARIZE=false
+SKIP_DMG=false
+VERBOSE=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--app-path)      APP_PATH="$2"; shift 2 ;;
+		--dmg-path)      DMG_PATH="$2"; shift 2 ;;
+		--entitlements)  ENTITLEMENTS="$2"; shift 2 ;;
+		--skip-notarize) SKIP_NOTARIZE=true; shift ;;
+		--skip-dmg)      SKIP_DMG=true; shift ;;
+		--verbose)       VERBOSE=true; shift ;;
+		--help)          head -24 "$0" | tail -22; exit 0 ;;
+		*)               echo "Unknown option: $1" >&2; exit 1 ;;
+	esac
+done
+
+# Logging
+log()     { echo "==> $*"; }
+warn()    { echo "WARNING: $*" >&2; }
+die()     { echo "ERROR: $*" >&2; exit 1; }
+verbose() { $VERBOSE && echo "    $*" || true; }
+
+# --- Validation --------------------------------------------------------
+
+[[ -z "${CODESIGN_IDENTITY:-}" ]] && die "CODESIGN_IDENTITY is not set"
+[[ -d "$APP_PATH" ]] || die "App bundle not found: $APP_PATH"
+[[ -f "$ENTITLEMENTS" ]] || die "Entitlements not found: $ENTITLEMENTS"
+
+AUTH_MODE=""
+if ! $SKIP_NOTARIZE; then
+	if [[ -n "${APPLE_API_KEY:-}" ]]; then
+		[[ -n "${APPLE_API_ISSUER:-}" ]] || die "APPLE_API_ISSUER required with APPLE_API_KEY"
+		AUTH_MODE="apikey"
+	elif [[ -n "${APPLE_ID:-}" ]]; then
+		[[ -n "${APPLE_TEAM_ID:-}" ]]    || die "APPLE_TEAM_ID required with APPLE_ID"
+		[[ -n "${APPLE_APP_PASSWORD:-}" ]] || die "APPLE_APP_PASSWORD required with APPLE_ID"
+		AUTH_MODE="password"
+	else
+		die "Set APPLE_API_KEY+APPLE_API_ISSUER or APPLE_ID+APPLE_TEAM_ID+APPLE_APP_PASSWORD for notarization"
+	fi
+fi
+
+# Auto-detect DMG path
+if [[ -z "$DMG_PATH" ]] && ! $SKIP_DMG; then
+	if [[ -f "${MACOS_DIR}/dist/MacNote++.dmg" ]]; then
+		DMG_PATH="${MACOS_DIR}/dist/MacNote++.dmg"
+	elif [[ -f "${MACOS_DIR}/dist/MacNote++-unsigned.dmg" ]]; then
+		DMG_PATH="${MACOS_DIR}/dist/MacNote++-unsigned.dmg"
+	else
+		warn "No DMG found in dist/. Use --dmg-path or --skip-dmg."
+		SKIP_DMG=true
+	fi
+fi
+
+# --- Build notarytool auth flags as array (avoids word-splitting issues) ---
+
+NOTARY_AUTH_FLAGS=()
+if ! $SKIP_NOTARIZE; then
+	if [[ "$AUTH_MODE" == "apikey" ]]; then
+		key_path="${APPLE_API_KEY_PATH:-$HOME/.private_keys/AuthKey_${APPLE_API_KEY}.p8}"
+		NOTARY_AUTH_FLAGS=(--key "$key_path" --key-id "$APPLE_API_KEY" --issuer "$APPLE_API_ISSUER")
+	else
+		NOTARY_AUTH_FLAGS=(--apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_PASSWORD")
+	fi
+fi
+
+# --- Step 1: Sign the .app bundle --------------------------------------
+
+log "Signing app bundle: $APP_PATH"
+verbose "Identity: $CODESIGN_IDENTITY"
+verbose "Entitlements: $ENTITLEMENTS"
+
+# Strip extended attributes (resource forks, Finder info) that block codesign
+xattr -cr "$APP_PATH"
+
+# NOTE: --deep is acceptable while the bundle has no nested frameworks/helpers.
+# Replace with explicit per-component signing if nested bundles are added.
+codesign --force --options runtime \
+	--sign "$CODESIGN_IDENTITY" \
+	--entitlements "$ENTITLEMENTS" \
+	--timestamp \
+	--deep \
+	"$APP_PATH"
+
+log "Verifying app signature..."
+codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+
+log "Checking Gatekeeper acceptance..."
+if spctl --assess --type execute --verbose=2 "$APP_PATH" 2>&1; then
+	log "App passes Gatekeeper assessment"
+else
+	warn "App does not yet pass Gatekeeper (expected before notarization)"
+fi
+
+# --- Step 2: Sign the DMG ----------------------------------------------
+
+if ! $SKIP_DMG; then
+	log "Signing DMG: $DMG_PATH"
+	codesign --force --sign "$CODESIGN_IDENTITY" --timestamp "$DMG_PATH"
+	codesign --verify --verbose=2 "$DMG_PATH"
+fi
+
+# --- Step 3: Notarize --------------------------------------------------
+
+if ! $SKIP_NOTARIZE; then
+	if ! $SKIP_DMG && [[ -f "$DMG_PATH" ]]; then
+		NOTARIZE_TARGET="$DMG_PATH"
+	else
+		# Create a temporary zip for notarization
+		NOTARIZE_TARGET="${APP_PATH%.app}.zip"
+		log "Creating zip for notarization: $NOTARIZE_TARGET"
+		ditto -c -k --keepParent "$APP_PATH" "$NOTARIZE_TARGET"
+	fi
+
+	log "Submitting for notarization: $NOTARIZE_TARGET"
+	verbose "This may take several minutes..."
+
+	xcrun notarytool submit "$NOTARIZE_TARGET" \
+		"${NOTARY_AUTH_FLAGS[@]}" \
+		--wait \
+		--timeout 30m
+
+	# --- Step 4: Staple ------------------------------------------------
+
+	if ! $SKIP_DMG && [[ -f "$DMG_PATH" ]]; then
+		log "Stapling notarization ticket to DMG: $DMG_PATH"
+		xcrun stapler staple "$DMG_PATH"
+
+		# Rename unsigned DMG to signed name
+		if [[ "$DMG_PATH" == *"-unsigned.dmg" ]]; then
+			SIGNED_DMG="${DMG_PATH%-unsigned.dmg}.dmg"
+			mv "$DMG_PATH" "$SIGNED_DMG"
+			log "Renamed to: $SIGNED_DMG"
+			DMG_PATH="$SIGNED_DMG"
+		fi
+	fi
+
+	log "Stapling notarization ticket to app: $APP_PATH"
+	xcrun stapler staple "$APP_PATH"
+
+	# Clean up temp zip
+	if [[ "${NOTARIZE_TARGET:-}" == *.zip ]]; then
+		rm -f "$NOTARIZE_TARGET"
+	fi
+fi
+
+# --- Final verification -------------------------------------------------
+
+log "Final verification..."
+codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+
+if ! $SKIP_NOTARIZE; then
+	spctl --assess --type execute --verbose=2 "$APP_PATH" || true
+	if ! $SKIP_DMG && [[ -f "$DMG_PATH" ]]; then
+		spctl --assess --type open --context context:primary-signature --verbose=2 "$DMG_PATH" || true
+	fi
+fi
+
+log "Done. Artifacts:"
+log "  App: $APP_PATH"
+if ! $SKIP_DMG && [[ -n "$DMG_PATH" ]]; then
+	log "  DMG: $DMG_PATH"
+fi


### PR DESCRIPTION
## Summary
- Add opt-in code signing to CMake build (`-DCODESIGN_ENABLED=ON`) with Developer ID signing, hardened runtime, and entitlements
- Add `sign-and-notarize.sh` script for full Apple notarization workflow (sign, notarize, staple)
- Add CI job for automated sign & notarize using GitHub secrets
- Add `MacNote.entitlements` for hardened runtime permissions
- Update `.gitignore` to exclude signing artifacts (`.p12`, `.keychain-db`)
- Update `CLAUDE.md` with code signing build instructions

## Test plan
- [x] Clean build with `-DCODESIGN_ENABLED=ON` succeeds
- [x] `MacOSNotePP_sign` target signs `.app` with Developer ID
- [x] `MacOSNotePP_dmg` target produces signed DMG
- [x] `sign-and-notarize.sh` completes notarization and stapling
- [x] `codesign --verify` passes for both `.app` and `.dmg`
- [x] `spctl --assess` reports `Notarized Developer ID`
- [x] Signed artifacts uploaded to v1.0.0 pre-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
