### PR TITLE
fix: correct closing brace indentation when pressing Enter between {}

### DIFF
--- a/macos/platform/auto_indent.mm
+++ b/macos/platform/auto_indent.mm
@@ -240,8 +240,32 @@ void performAutoIndent(void* sci, int charAdded, int languageIndex)
 			indent.append(tabWidth, ' ');
 	}
 
+	// Check if the cursor sits immediately before a closing brace.
+	// If so, split the brace onto its own line with base indentation.
+	bool splitBrace = false;
+	if (addIndent)
+	{
+		char nextCh = static_cast<char>(ScintillaBridge_sendMessage(sci, SCI_GETCHARAT, curPos, 0));
+		splitBrace = (nextCh == '}');
+	}
+
+	std::string toInsert = indent;
+	if (splitBrace)
+	{
+		intptr_t eolMode = ScintillaBridge_sendMessage(sci, SCI_GETEOLMODE, 0, 0);
+		const char* eolStr = (eolMode == SC_EOL_CR) ? "\r" : (eolMode == SC_EOL_CRLF) ? "\r\n" : "\n";
+		toInsert += eolStr;
+		toInsert += leadingWS;
+	}
+
 	// Insert the indentation on the new line as a single undoable action
 	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
-	ScintillaBridge_sendMessage(sci, SCI_REPLACESEL, 0, (intptr_t)indent.c_str());
+	ScintillaBridge_sendMessage(sci, SCI_REPLACESEL, 0, (intptr_t)toInsert.c_str());
+	if (splitBrace)
+	{
+		// Position cursor on the middle line (after indent, before the closing brace line)
+		intptr_t newPos = curPos + static_cast<intptr_t>(indent.size());
+		ScintillaBridge_sendMessage(sci, SCI_GOTOPOS, newPos, 0);
+	}
 	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
 }


### PR DESCRIPTION
## Summary

- When pressing Enter between auto-closed braces `{}`, the closing `}` was indented one tab stop too far forward
- The auto-indent handler now detects when the cursor sits before a `}` during smart indent, splits the brace onto its own line with base indentation, and positions the cursor on an indented middle line
- Matches standard editor behavior (VS Code, IntelliJ, etc.)

## Test plan

- [ ] Type `{` in a C-style file → auto-close inserts `}` → press Enter → closing brace should align with opening brace, cursor on indented middle line
- [ ] Test with nested braces (e.g., inside a function body)
- [ ] Test pressing Enter when `}` is NOT the next character (normal indent unchanged)
- [ ] Test with both tabs and spaces indentation settings
- [ ] Verify undo reverts the entire operation in one step

🤖 Generated with [Claude Code](https://claude.com/claude-code)