### PR TITLE
feat: add change history tracking margin (#39)

### DIFF
--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -345,6 +345,7 @@ add_executable(MacOSNotePP
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/wndproc.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/appearance.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/scintilla_config.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/change_history.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/lexer_styles.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/language_defs.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/bookmarks.mm"

--- a/macos/platform/app_delegate.mm
+++ b/macos/platform/app_delegate.mm
@@ -124,6 +124,7 @@ static void setDockIconFromLogo()
 	ctx().showIndentGuides = s.showIndentGuides;
 	ctx().syncScrolling = s.syncScrolling;
 	ctx().documentMapEnabled = s.documentMap;
+	ctx().showChangeHistory = s.showChangeHistory;
 	ctx().documentMapWidth = s.documentMapWidth;
 	setDockIconFromLogo();
 
@@ -571,6 +572,7 @@ static void setDockIconFromLogo()
 	s.showIndentGuides = ctx().showIndentGuides;
 	s.syncScrolling = ctx().syncScrolling;
 	s.documentMap = ctx().documentMapEnabled;
+	s.showChangeHistory = ctx().showChangeHistory;
 	s.documentMapWidth = ctx().documentMapWidth;
 	s.wordWrap = ctx().scintillaView ?
 		(ScintillaBridge_sendMessage(ctx().scintillaView, SCI_GETWRAPMODE, 0, 0) != 0) : false;

--- a/macos/platform/app_state.h
+++ b/macos/platform/app_state.h
@@ -59,6 +59,7 @@ struct AppContext
 	bool showEol = false;
 	bool showIndentGuides = false;
 	bool autoCloseBrackets = true;
+	bool showChangeHistory = true;
 
 	// Split view state
 	void* scintillaView2 = nullptr;

--- a/macos/platform/appearance.mm
+++ b/macos/platform/appearance.mm
@@ -10,6 +10,7 @@
 #include "scintilla_bridge.h"
 #include "brace_match.h"
 #include "smart_highlight.h"
+#include "change_history.h"
 
 void applyFoldMarkerColorsToView(void* sci, bool isDark)
 {
@@ -61,6 +62,7 @@ void applyAppearanceToView(void* sci, int langIdx, bool isDark)
 		isDark ? 0xFFA050 : 0xFF8000);
 
 	applyFoldMarkerColorsToView(sci, isDark);
+	applyChangeHistoryColors(sci, isDark);
 	configureBraceStyles(sci, isDark);
 	configureSmartHighlightIndicator(sci, isDark);
 

--- a/macos/platform/change_history.h
+++ b/macos/platform/change_history.h
@@ -1,0 +1,14 @@
+// change_history.h — Change history margin markers
+// Part of the Notepad++ macOS port modular refactor.
+
+#pragma once
+
+// Configure the change-history margin and enable tracking on a Scintilla view.
+// Must be called before content is loaded.
+void configureChangeHistory(void* sci);
+
+// Apply theme-aware marker colors for change history markers.
+void applyChangeHistoryColors(void* sci, bool isDark);
+
+// Show or hide the change-history margin on a single view.
+void setChangeHistoryMarginVisible(void* sci, bool visible);

--- a/macos/platform/change_history.mm
+++ b/macos/platform/change_history.mm
@@ -8,12 +8,20 @@
 
 static constexpr int kChangeHistoryMarginWidth = 4;
 
+static int changeHistoryMode(bool showMarginMarkers)
+{
+	return showMarginMarkers ?
+		(SC_CHANGE_HISTORY_ENABLED | SC_CHANGE_HISTORY_MARKERS) :
+		SC_CHANGE_HISTORY_ENABLED;
+}
+
 void configureChangeHistory(void* sci)
 {
 	if (!sci) return;
 
-	// Enable change tracking with margin markers
-	ScintillaBridge_sendMessage(sci, SCI_SETCHANGEHISTORY, SC_CHANGE_HISTORY_MARKERS, 0);
+	// Enable change tracking + marker display.
+	// SC_CHANGE_HISTORY_ENABLED is required for Scintilla to actually track edits.
+	ScintillaBridge_sendMessage(sci, SCI_SETCHANGEHISTORY, changeHistoryMode(ctx().showChangeHistory), 0);
 
 	// Set up margin 3 as a narrow symbol margin for change bars
 	ScintillaBridge_sendMessage(sci, SCI_SETMARGINTYPEN, CHANGE_HISTORY_MARGIN, 0);
@@ -61,6 +69,10 @@ void applyChangeHistoryColors(void* sci, bool isDark)
 void setChangeHistoryMarginVisible(void* sci, bool visible)
 {
 	if (!sci) return;
+	// If markers are enabled but not mapped to any visible margin, Scintilla paints
+	// them as line background colours in the text area. Keep tracking on, but only
+	// enable marker rendering when the change-history margin is visible.
+	ScintillaBridge_sendMessage(sci, SCI_SETCHANGEHISTORY, changeHistoryMode(visible), 0);
 	ScintillaBridge_sendMessage(sci, SCI_SETMARGINWIDTHN, CHANGE_HISTORY_MARGIN,
 		visible ? kChangeHistoryMarginWidth : 0);
 }

--- a/macos/platform/change_history.mm
+++ b/macos/platform/change_history.mm
@@ -1,0 +1,66 @@
+// change_history.mm — Change history margin markers
+// Part of the Notepad++ macOS port modular refactor.
+
+#include "change_history.h"
+#include "npp_constants.h"
+#include "app_state.h"
+#include "scintilla_bridge.h"
+
+static constexpr int kChangeHistoryMarginWidth = 4;
+
+void configureChangeHistory(void* sci)
+{
+	if (!sci) return;
+
+	// Enable change tracking with margin markers
+	ScintillaBridge_sendMessage(sci, SCI_SETCHANGEHISTORY, SC_CHANGE_HISTORY_MARKERS, 0);
+
+	// Set up margin 3 as a narrow symbol margin for change bars
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINTYPEN, CHANGE_HISTORY_MARGIN, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINWIDTHN, CHANGE_HISTORY_MARGIN,
+		ctx().showChangeHistory ? kChangeHistoryMarginWidth : 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINMASKN, CHANGE_HISTORY_MARGIN, CHANGE_HISTORY_MASK);
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINSENSITIVEN, CHANGE_HISTORY_MARGIN, 0);
+
+	// Use SC_MARK_FULLRECT for a solid change bar
+	ScintillaBridge_sendMessage(sci, SCI_MARKERDEFINE, SC_MARKNUM_HISTORY_MODIFIED, SC_MARK_FULLRECT);
+	ScintillaBridge_sendMessage(sci, SCI_MARKERDEFINE, SC_MARKNUM_HISTORY_SAVED, SC_MARK_FULLRECT);
+	ScintillaBridge_sendMessage(sci, SCI_MARKERDEFINE, SC_MARKNUM_HISTORY_REVERTED_TO_ORIGIN, SC_MARK_FULLRECT);
+	ScintillaBridge_sendMessage(sci, SCI_MARKERDEFINE, SC_MARKNUM_HISTORY_REVERTED_TO_MODIFIED, SC_MARK_FULLRECT);
+}
+
+void applyChangeHistoryColors(void* sci, bool isDark)
+{
+	if (!sci) return;
+
+	// Modified (unsaved changes) — orange/amber
+	ScintillaBridge_sendMessage(sci, SCI_MARKERSETBACK, SC_MARKNUM_HISTORY_MODIFIED,
+		isDark ? 0x00A5FF : 0x0080CC);  // BGR: orange tones
+	ScintillaBridge_sendMessage(sci, SCI_MARKERSETFORE, SC_MARKNUM_HISTORY_MODIFIED,
+		isDark ? 0x00A5FF : 0x0080CC);
+
+	// Saved (modified then saved) — green
+	ScintillaBridge_sendMessage(sci, SCI_MARKERSETBACK, SC_MARKNUM_HISTORY_SAVED,
+		isDark ? 0x50C850 : 0x008000);  // BGR: green tones
+	ScintillaBridge_sendMessage(sci, SCI_MARKERSETFORE, SC_MARKNUM_HISTORY_SAVED,
+		isDark ? 0x50C850 : 0x008000);
+
+	// Reverted to origin — blue
+	ScintillaBridge_sendMessage(sci, SCI_MARKERSETBACK, SC_MARKNUM_HISTORY_REVERTED_TO_ORIGIN,
+		isDark ? 0xFF8050 : 0xCC6600);  // BGR: blue tones
+	ScintillaBridge_sendMessage(sci, SCI_MARKERSETFORE, SC_MARKNUM_HISTORY_REVERTED_TO_ORIGIN,
+		isDark ? 0xFF8050 : 0xCC6600);
+
+	// Reverted to modified — cyan/teal
+	ScintillaBridge_sendMessage(sci, SCI_MARKERSETBACK, SC_MARKNUM_HISTORY_REVERTED_TO_MODIFIED,
+		isDark ? 0xD0D050 : 0xA0A000);  // BGR: cyan/teal tones
+	ScintillaBridge_sendMessage(sci, SCI_MARKERSETFORE, SC_MARKNUM_HISTORY_REVERTED_TO_MODIFIED,
+		isDark ? 0xD0D050 : 0xA0A000);
+}
+
+void setChangeHistoryMarginVisible(void* sci, bool visible)
+{
+	if (!sci) return;
+	ScintillaBridge_sendMessage(sci, SCI_SETMARGINWIDTHN, CHANGE_HISTORY_MARGIN,
+		visible ? kChangeHistoryMarginWidth : 0);
+}

--- a/macos/platform/change_history.mm
+++ b/macos/platform/change_history.mm
@@ -41,27 +41,28 @@ void applyChangeHistoryColors(void* sci, bool isDark)
 {
 	if (!sci) return;
 
+	// Scintilla colour parameters use IpRGB integer ordering (0x00BBGGRR).
 	// Modified (unsaved changes) — orange/amber
 	ScintillaBridge_sendMessage(sci, SCI_MARKERSETBACK, SC_MARKNUM_HISTORY_MODIFIED,
-		isDark ? 0x00A5FF : 0x0080CC);  // BGR: orange tones
+		isDark ? 0x00A5FF : 0x0080CC);
 	ScintillaBridge_sendMessage(sci, SCI_MARKERSETFORE, SC_MARKNUM_HISTORY_MODIFIED,
 		isDark ? 0x00A5FF : 0x0080CC);
 
 	// Saved (modified then saved) — green
 	ScintillaBridge_sendMessage(sci, SCI_MARKERSETBACK, SC_MARKNUM_HISTORY_SAVED,
-		isDark ? 0x50C850 : 0x008000);  // BGR: green tones
+		isDark ? 0x50C850 : 0x008000);
 	ScintillaBridge_sendMessage(sci, SCI_MARKERSETFORE, SC_MARKNUM_HISTORY_SAVED,
 		isDark ? 0x50C850 : 0x008000);
 
 	// Reverted to origin — blue
 	ScintillaBridge_sendMessage(sci, SCI_MARKERSETBACK, SC_MARKNUM_HISTORY_REVERTED_TO_ORIGIN,
-		isDark ? 0xFF8050 : 0xCC6600);  // BGR: blue tones
+		isDark ? 0xFF8050 : 0xCC6600);
 	ScintillaBridge_sendMessage(sci, SCI_MARKERSETFORE, SC_MARKNUM_HISTORY_REVERTED_TO_ORIGIN,
 		isDark ? 0xFF8050 : 0xCC6600);
 
 	// Reverted to modified — cyan/teal
 	ScintillaBridge_sendMessage(sci, SCI_MARKERSETBACK, SC_MARKNUM_HISTORY_REVERTED_TO_MODIFIED,
-		isDark ? 0xD0D050 : 0xA0A000);  // BGR: cyan/teal tones
+		isDark ? 0xD0D050 : 0xA0A000);
 	ScintillaBridge_sendMessage(sci, SCI_MARKERSETFORE, SC_MARKNUM_HISTORY_REVERTED_TO_MODIFIED,
 		isDark ? 0xD0D050 : 0xA0A000);
 }

--- a/macos/platform/menu_builder.mm
+++ b/macos/platform/menu_builder.mm
@@ -111,6 +111,7 @@ HMENU buildMenuBar()
 	AppendMenuW(hViewMenu, MF_STRING | (ctx().showWhitespace ? MF_CHECKED : MF_UNCHECKED), IDM_VIEW_SHOW_WS, L"Show &Whitespace && TAB");
 	AppendMenuW(hViewMenu, MF_STRING | (ctx().showEol ? MF_CHECKED : MF_UNCHECKED), IDM_VIEW_SHOW_EOL, L"Show &End of Line");
 	AppendMenuW(hViewMenu, MF_STRING | (ctx().showIndentGuides ? MF_CHECKED : MF_UNCHECKED), IDM_VIEW_SHOW_INDENT, L"Show &Indent Guides");
+	AppendMenuW(hViewMenu, MF_STRING | (ctx().showChangeHistory ? MF_CHECKED : MF_UNCHECKED), IDM_VIEW_CHANGE_HISTORY, L"Show Change &History");
 	AppendMenuW(hViewMenu, MF_SEPARATOR, 0, nullptr);
 	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_FOLDALL, L"&Fold All");
 	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_UNFOLDALL, L"&Unfold All");

--- a/macos/platform/npp_constants.h
+++ b/macos/platform/npp_constants.h
@@ -98,6 +98,7 @@ constexpr double NPP_STATUS_BAR_HEIGHT = 22.0;
 #define IDM_VIEW_SHOW_INDENT         42082
 #define IDM_VIEW_SYNCHRONIZE_SCROLLING 42083
 #define IDM_VIEW_DOCUMENTMAP         42084
+#define IDM_VIEW_CHANGE_HISTORY      42085
 
 // Tab context menu command IDs
 #define IDM_TAB_CLOSE            42200
@@ -347,6 +348,10 @@ enum {
 	SCI_INDICATORCLEARRANGE  = 2505,
 	SCI_WORDENDPOSITION      = 2267,
 	SCI_GETSELECTIONEMPTY    = 2650,
+
+	// Change history
+	SCI_SETCHANGEHISTORY     = 2780,
+	SCI_GETCHANGEHISTORY     = 2781,
 };
 
 // Scintilla key constants
@@ -437,6 +442,25 @@ enum {
 #define SC_FOLDACTION_TOGGLE      2
 #define SC_FOLDLEVELHEADERFLAG    0x2000
 #define SC_AUTOMATICFOLD_CLICK    0x0004
+
+// Change history constants
+#define SC_CHANGE_HISTORY_DISABLED  0
+#define SC_CHANGE_HISTORY_ENABLED   1
+#define SC_CHANGE_HISTORY_MARKERS   2
+#define SC_CHANGE_HISTORY_INDICATORS 4
+
+// Change history marker numbers (Scintilla-defined)
+#define SC_MARKNUM_HISTORY_REVERTED_TO_ORIGIN   21
+#define SC_MARKNUM_HISTORY_SAVED                22
+#define SC_MARKNUM_HISTORY_MODIFIED             23
+#define SC_MARKNUM_HISTORY_REVERTED_TO_MODIFIED 20
+
+// Change history margin
+#define CHANGE_HISTORY_MARGIN  3
+#define CHANGE_HISTORY_MASK    ((1 << SC_MARKNUM_HISTORY_REVERTED_TO_ORIGIN) | \
+                                (1 << SC_MARKNUM_HISTORY_SAVED) | \
+                                (1 << SC_MARKNUM_HISTORY_MODIFIED) | \
+                                (1 << SC_MARKNUM_HISTORY_REVERTED_TO_MODIFIED))
 
 // Scintilla notification codes
 #define SCN_CHARADDED        2001

--- a/macos/platform/npp_constants.h
+++ b/macos/platform/npp_constants.h
@@ -408,8 +408,8 @@ enum {
 #define INDIC_SMART_HIGHLIGHT    29
 #define INDIC_INCREMENTAL_SEARCH 28
 
-// Bookmark marker
-#define BOOKMARK_MARKER  24
+// Bookmark marker — uses 19 to avoid conflict with history markers (20-24)
+#define BOOKMARK_MARKER  19
 #define BOOKMARK_MASK    (1 << BOOKMARK_MARKER)
 
 // Scintilla marker shapes
@@ -453,7 +453,7 @@ enum {
 #define SC_MARKNUM_HISTORY_REVERTED_TO_ORIGIN   21
 #define SC_MARKNUM_HISTORY_SAVED                22
 #define SC_MARKNUM_HISTORY_MODIFIED             23
-#define SC_MARKNUM_HISTORY_REVERTED_TO_MODIFIED 20
+#define SC_MARKNUM_HISTORY_REVERTED_TO_MODIFIED 24
 
 // Change history margin
 #define CHANGE_HISTORY_MARGIN  3

--- a/macos/platform/npp_constants.h
+++ b/macos/platform/npp_constants.h
@@ -408,7 +408,7 @@ enum {
 #define INDIC_SMART_HIGHLIGHT    29
 #define INDIC_INCREMENTAL_SEARCH 28
 
-// Bookmark marker — uses 19 to avoid conflict with history markers (20-24)
+// Bookmark marker — uses 19 to avoid conflict with history markers (21-24)
 #define BOOKMARK_MARKER  19
 #define BOOKMARK_MASK    (1 << BOOKMARK_MARKER)
 

--- a/macos/platform/scintilla_config.mm
+++ b/macos/platform/scintilla_config.mm
@@ -7,6 +7,7 @@
 #include "scintilla_bridge.h"
 #include "keyboard_shortcuts.h"
 #include "smart_highlight.h"
+#include "change_history.h"
 
 void configureScintilla(void* sci)
 {
@@ -77,6 +78,8 @@ void configureScintilla(void* sci)
 	ScintillaBridge_sendMessage(sci, SCI_INDICSETALPHA, INDIC_INCREMENTAL_SEARCH, 80);
 	ScintillaBridge_sendMessage(sci, SCI_INDICSETOUTLINEALPHA, INDIC_INCREMENTAL_SEARCH, 200);
 	ScintillaBridge_sendMessage(sci, SCI_INDICSETUNDER, INDIC_INCREMENTAL_SEARCH, 1);
+
+	configureChangeHistory(sci);
 
 	configureKeyboardShortcuts(sci);
 }

--- a/macos/platform/settings_manager.h
+++ b/macos/platform/settings_manager.h
@@ -31,6 +31,7 @@ struct AppSettings
 	bool showIndentGuides = false;
 	bool syncScrolling = false;
 	bool documentMap = false;
+	bool showChangeHistory = true;
 	int documentMapWidth = 140;
 
 	// Recent files

--- a/macos/platform/settings_manager.mm
+++ b/macos/platform/settings_manager.mm
@@ -83,6 +83,7 @@ bool SettingsManager::load()
 	if ([json[@"showIndentGuides"] isKindOfClass:[NSNumber class]])settings.showIndentGuides = [json[@"showIndentGuides"] boolValue];
 	if ([json[@"syncScrolling"] isKindOfClass:[NSNumber class]])   settings.syncScrolling = [json[@"syncScrolling"] boolValue];
 	if ([json[@"documentMap"] isKindOfClass:[NSNumber class]])     settings.documentMap = [json[@"documentMap"] boolValue];
+	if ([json[@"showChangeHistory"] isKindOfClass:[NSNumber class]])settings.showChangeHistory = [json[@"showChangeHistory"] boolValue];
 	if ([json[@"documentMapWidth"] isKindOfClass:[NSNumber class]])settings.documentMapWidth = [json[@"documentMapWidth"] intValue];
 
 	// Recent files
@@ -151,6 +152,7 @@ bool SettingsManager::save()
 		@"showIndentGuides": @(settings.showIndentGuides),
 		@"syncScrolling": @(settings.syncScrolling),
 		@"documentMap": @(settings.documentMap),
+		@"showChangeHistory": @(settings.showChangeHistory),
 		@"documentMapWidth": @(settings.documentMapWidth),
 		@"recentFiles":  recentArr
 	};

--- a/macos/platform/wndproc.mm
+++ b/macos/platform/wndproc.mm
@@ -29,6 +29,7 @@
 #include "auto_close.h"
 #include "sync_scroll.h"
 #include "document_map.h"
+#include "change_history.h"
 #include "windows.h"
 #include "commctrl.h"
 
@@ -458,6 +459,21 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 					              MF_BYCOMMAND | (ctx().documentMapEnabled ? MF_CHECKED : MF_UNCHECKED));
 				return 0;
 			}
+			case IDM_VIEW_CHANGE_HISTORY:
+			{
+				ctx().showChangeHistory = !ctx().showChangeHistory;
+				void* views[] = { ctx().scintillaView, ctx().scintillaView2 };
+				for (void* v : views)
+				{
+					if (v)
+						setChangeHistoryMarginVisible(v, ctx().showChangeHistory);
+				}
+				HMENU hMenu = GetMenu(hWnd);
+				if (hMenu)
+					CheckMenuItem(hMenu, IDM_VIEW_CHANGE_HISTORY,
+					              MF_BYCOMMAND | (ctx().showChangeHistory ? MF_CHECKED : MF_UNCHECKED));
+				return 0;
+			}
 
 			case IDM_VIEW_FULLSCREEN:
 				if (ctx().mainWindow)
@@ -542,6 +558,8 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 					              MF_BYCOMMAND | (ctx().autoCloseBrackets ? MF_CHECKED : MF_UNCHECKED));
 					CheckMenuItem(hMenu, IDM_VIEW_SYNCHRONIZE_SCROLLING,
 					              MF_BYCOMMAND | (ctx().syncScrolling && ctx().isSplit ? MF_CHECKED : MF_UNCHECKED));
+					CheckMenuItem(hMenu, IDM_VIEW_CHANGE_HISTORY,
+					              MF_BYCOMMAND | (ctx().showChangeHistory ? MF_CHECKED : MF_UNCHECKED));
 				}
 			}
 			updateFilePathMenuState();


### PR DESCRIPTION
## Summary
- Adds Scintilla change history tracking with margin markers showing modified (orange), saved (green), and reverted (blue) lines since last save
- New dedicated margin (index 3) with narrow 4px change bars, configured before content load
- View menu toggle (Show Change History), persisted in settings, defaults to enabled
- Theme-aware marker colors reapplied on light/dark mode switch

## Files changed
- **New:** `change_history.h`, `change_history.mm` — module for margin setup, colors, and visibility toggle
- **Modified:** `npp_constants.h` — SCI_SETCHANGEHISTORY, marker IDs, margin constants
- **Modified:** `settings_manager.h/.mm` — `showChangeHistory` setting persistence
- **Modified:** `app_state.h`, `app_delegate.mm` — runtime state and load/save wiring
- **Modified:** `scintilla_config.mm` — init change history during editor setup
- **Modified:** `menu_builder.mm`, `wndproc.mm` — View menu item and command dispatch
- **Modified:** `appearance.mm` — theme-aware marker color application
- **Modified:** `CMakeLists.txt` — add new source file

## Known limitations
Change history may reset on tab switch due to current `SCI_SETTEXT`-based document switching. Documented as accepted limitation per sprint plan; `SCI_SETDOCPOINTER` refactor deferred.

## Test plan
- [ ] Modified lines show orange markers while editing
- [ ] Save transitions markers to green (saved state)
- [ ] Undo/revert shows blue markers
- [ ] View > Show Change History toggles margin on/off
- [ ] Setting persists across app restart
- [ ] Dark mode marker colors are readable
- [ ] Bookmark and fold margins remain unaffected
- [ ] Split view shows markers in both editors

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)