### PR TITLE
Sprint P2: Per-file zoom, case conversions, hash tools, macro recording

### DIFF
--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -375,6 +375,7 @@ add_executable(MacOSNotePP
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/toolbar.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/print_support.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/hash_tools.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/macro_manager.mm"
 )
 target_include_directories(MacOSNotePP PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/platform"

--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -374,6 +374,7 @@ add_executable(MacOSNotePP
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/search_results_panel.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/toolbar.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/print_support.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/hash_tools.mm"
 )
 target_include_directories(MacOSNotePP PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/platform"

--- a/macos/platform/app_delegate.mm
+++ b/macos/platform/app_delegate.mm
@@ -115,7 +115,6 @@ static void setDockIconFromLogo()
 	ctx().fontSize = s.fontSize;
 	ctx().tabWidth = s.tabWidth;
 	ctx().showLineNumbers = s.showLineNumbers;
-	ctx().zoomLevel = s.zoomLevel;
 	ctx().showCaretLine = s.showCaretLine;
 	ctx().autoIndent = s.autoIndent;
 	ctx().autoCloseBrackets = s.autoCloseBrackets;
@@ -581,7 +580,6 @@ static void setDockIconFromLogo()
 	s.fontSize = ctx().fontSize;
 	s.tabWidth = ctx().tabWidth;
 	s.showLineNumbers = ctx().showLineNumbers;
-	s.zoomLevel = ctx().zoomLevel;
 	s.showCaretLine = ctx().showCaretLine;
 	s.autoIndent = ctx().autoIndent;
 	s.autoCloseBrackets = ctx().autoCloseBrackets;

--- a/macos/platform/app_delegate.mm
+++ b/macos/platform/app_delegate.mm
@@ -30,6 +30,7 @@
 #include "function_list_panel.h"
 #include "toolbar.h"
 #include "scintilla_notify.h"
+#include "macro_manager.h"
 #include "windows.h"
 #include "commctrl.h"
 
@@ -347,6 +348,11 @@ static void setDockIconFromLogo()
 							scheduleFunctionListRefresh();
 						}
 					}
+				}
+				else if (scn->nmhdr.code == SCN_MACRORECORD)
+				{
+					if (MacroManager::instance().isRecording())
+						MacroManager::instance().recordStep(scn->message, scn->wParam, scn->lParam);
 				}
 			}
 		});

--- a/macos/platform/app_state.h
+++ b/macos/platform/app_state.h
@@ -51,7 +51,6 @@ struct AppContext
 	int tabWidth = 4;
 	std::string fontName = "Menlo";
 	bool showLineNumbers = true;
-	int zoomLevel = 0;
 	bool showCaretLine = true;
 	bool autoIndent = true;
 	bool useTabs = false;

--- a/macos/platform/document_data.h
+++ b/macos/platform/document_data.h
@@ -56,6 +56,7 @@ struct DocumentData
 	std::vector<int> bookmarkedLines; // Persisted across tab switches
 	int encoding = ENC_UTF8;
 	int eolMode = SC_EOL_LF;
+	int zoomLevel = 0;
 	uint64_t functionListDocumentId = 0;
 	uint64_t functionListRevision = 0;
 };

--- a/macos/platform/document_manager.mm
+++ b/macos/platform/document_manager.mm
@@ -232,6 +232,7 @@ void closeTabFromView(int viewIndex, int tabIndex)
 		ScintillaBridge_sendMessage(sci, SCI_CLEARALL, 0, 0);
 		ScintillaBridge_sendMessage(sci, SCI_EMPTYUNDOBUFFER, 0, 0);
 		ScintillaBridge_sendMessage(sci, SCI_SETSAVEPOINT, 0, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETZOOM, 0, 0);
 		ctx().suppressSavePointNotifications = false;
 		if (tabHwnd)
 		{

--- a/macos/platform/document_manager.mm
+++ b/macos/platform/document_manager.mm
@@ -44,6 +44,7 @@ void saveViewState(void* sci, std::vector<DocumentData>& docs, int tabIdx)
 	doc.cursorPos = ScintillaBridge_sendMessage(sci, SCI_GETCURRENTPOS, 0, 0);
 	doc.anchorPos = ScintillaBridge_sendMessage(sci, SCI_GETANCHOR, 0, 0);
 	doc.firstVisibleLine = ScintillaBridge_sendMessage(sci, SCI_GETFIRSTVISIBLELINE, 0, 0);
+	doc.zoomLevel = static_cast<int>(ScintillaBridge_sendMessage(sci, SCI_GETZOOM, 0, 0));
 	if (doc.savePointValid)
 		doc.modified = ScintillaBridge_sendMessage(sci, SCI_GETMODIFY, 0, 0) != 0;
 
@@ -86,6 +87,8 @@ void restoreViewToScintilla(void* sci, std::vector<DocumentData>& docs, int tabI
 
 	for (int bkLine : doc.bookmarkedLines)
 		ScintillaBridge_sendMessage(sci, SCI_MARKERADD, bkLine, BOOKMARK_MARKER);
+
+	ScintillaBridge_sendMessage(sci, SCI_SETZOOM, doc.zoomLevel, 0);
 
 	refreshLineNumberMargin(sci);
 }

--- a/macos/platform/edit_commands.h
+++ b/macos/platform/edit_commands.h
@@ -13,3 +13,16 @@ void doTabsToSpaces();
 void doSpacesToTabs();
 void insertDateTimeShort();
 void insertDateTimeLong();
+
+// Sprint P2 — additional case conversions
+void doSentenceCase();
+void doInvertCase();
+void doCamelCase();
+void doSnakeCase();
+
+// Sprint P2 — sort / line operation variants
+void doSortLinesCaseInsensitive();
+void doSortLinesReverse();
+void doRemoveDuplicateLines();
+void doSortLinesNumeric();
+void doSortLinesRandom();

--- a/macos/platform/edit_commands.mm
+++ b/macos/platform/edit_commands.mm
@@ -426,11 +426,18 @@ static bool readSelectedLines(void*& sci, intptr_t& startLine, intptr_t& endLine
 static void replaceSelectedLines(void* sci, intptr_t replStart, intptr_t replEnd,
                                  const std::vector<std::string>& lines)
 {
+	// Use the document's EOL mode so we don't silently rewrite CRLF/CR to LF
+	const char* eol = "\n";
+	int eolLen = 1;
+	int eolMode = static_cast<int>(ScintillaBridge_sendMessage(sci, SCI_GETEOLMODE, 0, 0));
+	if (eolMode == SC_EOL_CRLF) { eol = "\r\n"; eolLen = 2; }
+	else if (eolMode == SC_EOL_CR) { eol = "\r"; eolLen = 1; }
+
 	std::string result;
 	for (size_t i = 0; i < lines.size(); ++i)
 	{
 		result += lines[i];
-		if (i + 1 < lines.size()) result += '\n';
+		if (i + 1 < lines.size()) result.append(eol, eolLen);
 	}
 
 	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);

--- a/macos/platform/edit_commands.mm
+++ b/macos/platform/edit_commands.mm
@@ -10,6 +10,9 @@
 #include <algorithm>
 #include <cctype>
 #include <cstring>
+#include <random>
+#include <unordered_set>
+#include <vector>
 
 void doTitleCase()
 {
@@ -382,4 +385,358 @@ void insertDateTimeLong()
 	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
 	ScintillaBridge_sendMessage(sci, SCI_REPLACESEL, 0, reinterpret_cast<intptr_t>(utf8));
 	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
+}
+
+// ============================================================
+// Helper: read selected lines from the active editor
+// ============================================================
+static bool readSelectedLines(void*& sci, intptr_t& startLine, intptr_t& endLine,
+                              intptr_t& replStart, intptr_t& replEnd,
+                              std::vector<std::string>& lines)
+{
+	sci = ctx().activeScintillaView();
+	if (!sci) return false;
+
+	intptr_t selStart = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONSTART, 0, 0);
+	intptr_t selEnd = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONEND, 0, 0);
+	if (selStart == selEnd) return false;
+
+	startLine = ScintillaBridge_sendMessage(sci, SCI_LINEFROMPOSITION, selStart, 0);
+	endLine = ScintillaBridge_sendMessage(sci, SCI_LINEFROMPOSITION, selEnd, 0);
+	if (selEnd == ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, endLine, 0) && endLine > startLine)
+		--endLine;
+
+	for (intptr_t line = startLine; line <= endLine; ++line)
+	{
+		intptr_t lineStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, line, 0);
+		intptr_t lineEnd = ScintillaBridge_sendMessage(sci, SCI_GETLINEENDPOSITION, line, 0);
+		intptr_t len = lineEnd - lineStart;
+		std::string text(len, '\0');
+		for (intptr_t i = 0; i < len; ++i)
+			text[i] = (char)ScintillaBridge_sendMessage(sci, SCI_GETCHARAT, lineStart + i, 0);
+		lines.push_back(text);
+	}
+
+	replStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, startLine, 0);
+	replEnd = ScintillaBridge_sendMessage(sci, SCI_GETLINEENDPOSITION, endLine, 0);
+	return true;
+}
+
+// Helper: replace the selected line range with reordered lines
+static void replaceSelectedLines(void* sci, intptr_t replStart, intptr_t replEnd,
+                                 const std::vector<std::string>& lines)
+{
+	std::string result;
+	for (size_t i = 0; i < lines.size(); ++i)
+	{
+		result += lines[i];
+		if (i + 1 < lines.size()) result += '\n';
+	}
+
+	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, replStart, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, replEnd, 0);
+	ScintillaBridge_sendMessage(sci, SCI_REPLACETARGET, result.size(), (intptr_t)result.c_str());
+	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
+}
+
+// ============================================================
+// Sprint P2 — Case conversions
+// ============================================================
+
+void doSentenceCase()
+{
+	void* sci = ctx().activeScintillaView();
+	if (!sci) return;
+	intptr_t selStart = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONSTART, 0, 0);
+	intptr_t selEnd = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONEND, 0, 0);
+	if (selStart == selEnd) return;
+
+	intptr_t len = selEnd - selStart;
+	std::string text(len + 1, '\0');
+	ScintillaBridge_sendMessage(sci, SCI_GETSELTEXT, 0, (intptr_t)text.data());
+	text.resize(len);
+
+	bool capitalize = true;
+	for (size_t i = 0; i < text.size(); ++i)
+	{
+		unsigned char ch = static_cast<unsigned char>(text[i]);
+		if (capitalize && isalpha(ch))
+		{
+			text[i] = toupper(ch);
+			capitalize = false;
+		}
+		else if (isalpha(ch))
+		{
+			text[i] = tolower(ch);
+		}
+
+		// Sentence boundary: . ! ? followed by whitespace
+		if ((text[i] == '.' || text[i] == '!' || text[i] == '?') &&
+		    i + 1 < text.size() && isspace(static_cast<unsigned char>(text[i + 1])))
+		{
+			capitalize = true;
+		}
+	}
+
+	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, selStart, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, selEnd, 0);
+	ScintillaBridge_sendMessage(sci, SCI_REPLACETARGET, len, (intptr_t)text.c_str());
+	ScintillaBridge_sendMessage(sci, SCI_SETSEL, selStart, selStart + (intptr_t)text.size());
+	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
+}
+
+void doInvertCase()
+{
+	void* sci = ctx().activeScintillaView();
+	if (!sci) return;
+	intptr_t selStart = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONSTART, 0, 0);
+	intptr_t selEnd = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONEND, 0, 0);
+	if (selStart == selEnd) return;
+
+	intptr_t len = selEnd - selStart;
+	std::string text(len + 1, '\0');
+	ScintillaBridge_sendMessage(sci, SCI_GETSELTEXT, 0, (intptr_t)text.data());
+	text.resize(len);
+
+	for (size_t i = 0; i < text.size(); ++i)
+	{
+		unsigned char ch = static_cast<unsigned char>(text[i]);
+		if (isupper(ch))
+			text[i] = tolower(ch);
+		else if (islower(ch))
+			text[i] = toupper(ch);
+	}
+
+	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, selStart, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, selEnd, 0);
+	ScintillaBridge_sendMessage(sci, SCI_REPLACETARGET, len, (intptr_t)text.c_str());
+	ScintillaBridge_sendMessage(sci, SCI_SETSEL, selStart, selStart + (intptr_t)text.size());
+	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
+}
+
+void doCamelCase()
+{
+	void* sci = ctx().activeScintillaView();
+	if (!sci) return;
+	intptr_t selStart = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONSTART, 0, 0);
+	intptr_t selEnd = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONEND, 0, 0);
+	if (selStart == selEnd) return;
+
+	intptr_t len = selEnd - selStart;
+	std::string text(len + 1, '\0');
+	ScintillaBridge_sendMessage(sci, SCI_GETSELTEXT, 0, (intptr_t)text.data());
+	text.resize(len);
+
+	// Split on whitespace, underscores, hyphens, and punctuation runs
+	std::vector<std::string> tokens;
+	std::string token;
+	for (size_t i = 0; i < text.size(); ++i)
+	{
+		unsigned char ch = static_cast<unsigned char>(text[i]);
+		if (isspace(ch) || ch == '_' || ch == '-' || (ispunct(ch) && ch != '\''))
+		{
+			if (!token.empty())
+			{
+				tokens.push_back(token);
+				token.clear();
+			}
+		}
+		else
+		{
+			token += text[i];
+		}
+	}
+	if (!token.empty())
+		tokens.push_back(token);
+
+	// First token all lowercase, subsequent tokens leading-capitalized
+	std::string result;
+	for (size_t t = 0; t < tokens.size(); ++t)
+	{
+		std::string& tok = tokens[t];
+		if (t == 0)
+		{
+			for (size_t i = 0; i < tok.size(); ++i)
+				tok[i] = tolower(static_cast<unsigned char>(tok[i]));
+		}
+		else
+		{
+			tok[0] = toupper(static_cast<unsigned char>(tok[0]));
+			for (size_t i = 1; i < tok.size(); ++i)
+				tok[i] = tolower(static_cast<unsigned char>(tok[i]));
+		}
+		result += tok;
+	}
+
+	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, selStart, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, selEnd, 0);
+	ScintillaBridge_sendMessage(sci, SCI_REPLACETARGET, result.size(), (intptr_t)result.c_str());
+	ScintillaBridge_sendMessage(sci, SCI_SETSEL, selStart, selStart + (intptr_t)result.size());
+	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
+}
+
+void doSnakeCase()
+{
+	void* sci = ctx().activeScintillaView();
+	if (!sci) return;
+	intptr_t selStart = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONSTART, 0, 0);
+	intptr_t selEnd = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONEND, 0, 0);
+	if (selStart == selEnd) return;
+
+	intptr_t len = selEnd - selStart;
+	std::string text(len + 1, '\0');
+	ScintillaBridge_sendMessage(sci, SCI_GETSELTEXT, 0, (intptr_t)text.data());
+	text.resize(len);
+
+	// Split on whitespace/hyphens/underscores AND camelCase transitions
+	std::vector<std::string> tokens;
+	std::string token;
+	for (size_t i = 0; i < text.size(); ++i)
+	{
+		unsigned char ch = static_cast<unsigned char>(text[i]);
+		if (isspace(ch) || ch == '-' || ch == '_')
+		{
+			if (!token.empty())
+			{
+				tokens.push_back(token);
+				token.clear();
+			}
+		}
+		else if (isupper(ch) && !token.empty() &&
+		         islower(static_cast<unsigned char>(token.back())))
+		{
+			// camelCase transition: lowercase followed by uppercase
+			tokens.push_back(token);
+			token.clear();
+			token += text[i];
+		}
+		else
+		{
+			token += text[i];
+		}
+	}
+	if (!token.empty())
+		tokens.push_back(token);
+
+	// Join with underscores, all lowercase
+	std::string result;
+	for (size_t t = 0; t < tokens.size(); ++t)
+	{
+		if (t > 0) result += '_';
+		for (size_t i = 0; i < tokens[t].size(); ++i)
+			result += tolower(static_cast<unsigned char>(tokens[t][i]));
+	}
+
+	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, selStart, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, selEnd, 0);
+	ScintillaBridge_sendMessage(sci, SCI_REPLACETARGET, result.size(), (intptr_t)result.c_str());
+	ScintillaBridge_sendMessage(sci, SCI_SETSEL, selStart, selStart + (intptr_t)result.size());
+	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
+}
+
+// ============================================================
+// Sprint P2 — Sort / line operation variants
+// ============================================================
+
+void doSortLinesCaseInsensitive()
+{
+	void* sci = nullptr;
+	intptr_t startLine = 0, endLine = 0, replStart = 0, replEnd = 0;
+	std::vector<std::string> lines;
+	if (!readSelectedLines(sci, startLine, endLine, replStart, replEnd, lines))
+		return;
+
+	std::sort(lines.begin(), lines.end(), [](const std::string& a, const std::string& b)
+	{
+		size_t minLen = (a.size() < b.size()) ? a.size() : b.size();
+		for (size_t i = 0; i < minLen; ++i)
+		{
+			int ca = tolower(static_cast<unsigned char>(a[i]));
+			int cb = tolower(static_cast<unsigned char>(b[i]));
+			if (ca != cb) return ca < cb;
+		}
+		return a.size() < b.size();
+	});
+
+	replaceSelectedLines(sci, replStart, replEnd, lines);
+}
+
+void doSortLinesReverse()
+{
+	void* sci = nullptr;
+	intptr_t startLine = 0, endLine = 0, replStart = 0, replEnd = 0;
+	std::vector<std::string> lines;
+	if (!readSelectedLines(sci, startLine, endLine, replStart, replEnd, lines))
+		return;
+
+	std::reverse(lines.begin(), lines.end());
+	replaceSelectedLines(sci, replStart, replEnd, lines);
+}
+
+void doRemoveDuplicateLines()
+{
+	void* sci = nullptr;
+	intptr_t startLine = 0, endLine = 0, replStart = 0, replEnd = 0;
+	std::vector<std::string> lines;
+	if (!readSelectedLines(sci, startLine, endLine, replStart, replEnd, lines))
+		return;
+
+	// Preserve first-occurrence order
+	std::unordered_set<std::string> seen;
+	std::vector<std::string> unique;
+	for (auto& line : lines)
+	{
+		if (seen.insert(line).second)
+			unique.push_back(line);
+	}
+
+	replaceSelectedLines(sci, replStart, replEnd, unique);
+}
+
+void doSortLinesNumeric()
+{
+	void* sci = nullptr;
+	intptr_t startLine = 0, endLine = 0, replStart = 0, replEnd = 0;
+	std::vector<std::string> lines;
+	if (!readSelectedLines(sci, startLine, endLine, replStart, replEnd, lines))
+		return;
+
+	std::sort(lines.begin(), lines.end(), [](const std::string& a, const std::string& b)
+	{
+		char* endA = nullptr;
+		char* endB = nullptr;
+		long numA = strtol(a.c_str(), &endA, 10);
+		long numB = strtol(b.c_str(), &endB, 10);
+		bool aIsNum = (endA != a.c_str());
+		bool bIsNum = (endB != b.c_str());
+
+		// Numeric lines sort before non-numeric
+		if (aIsNum && !bIsNum) return true;
+		if (!aIsNum && bIsNum) return false;
+		if (!aIsNum && !bIsNum) return a < b;
+		if (numA != numB) return numA < numB;
+		return a < b;
+	});
+
+	replaceSelectedLines(sci, replStart, replEnd, lines);
+}
+
+void doSortLinesRandom()
+{
+	void* sci = nullptr;
+	intptr_t startLine = 0, endLine = 0, replStart = 0, replEnd = 0;
+	std::vector<std::string> lines;
+	if (!readSelectedLines(sci, startLine, endLine, replStart, replEnd, lines))
+		return;
+
+	std::random_device rd;
+	std::mt19937 gen(rd());
+	std::shuffle(lines.begin(), lines.end(), gen);
+
+	replaceSelectedLines(sci, replStart, replEnd, lines);
 }

--- a/macos/platform/edit_commands.mm
+++ b/macos/platform/edit_commands.mm
@@ -168,52 +168,27 @@ void doToggleLineComment()
 	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
 }
 
+// Forward declarations for helpers defined later (Sprint P2)
+static bool readSelectedLines(void*& sci, intptr_t& startLine, intptr_t& endLine,
+                              intptr_t& replStart, intptr_t& replEnd,
+                              std::vector<std::string>& lines);
+static void replaceSelectedLines(void* sci, intptr_t replStart, intptr_t replEnd,
+                                 const std::vector<std::string>& lines);
+
 void doSortLines(bool ascending)
 {
-	void* sci = ctx().activeScintillaView();
-	if (!sci) return;
-
-	intptr_t selStart = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONSTART, 0, 0);
-	intptr_t selEnd = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONEND, 0, 0);
-	if (selStart == selEnd) return;
-
-	intptr_t startLine = ScintillaBridge_sendMessage(sci, SCI_LINEFROMPOSITION, selStart, 0);
-	intptr_t endLine = ScintillaBridge_sendMessage(sci, SCI_LINEFROMPOSITION, selEnd, 0);
-	if (selEnd == ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, endLine, 0) && endLine > startLine)
-		--endLine;
-
+	void* sci = nullptr;
+	intptr_t startLine = 0, endLine = 0, replStart = 0, replEnd = 0;
 	std::vector<std::string> lines;
-	for (intptr_t line = startLine; line <= endLine; ++line)
-	{
-		intptr_t lineStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, line, 0);
-		intptr_t lineEnd = ScintillaBridge_sendMessage(sci, SCI_GETLINEENDPOSITION, line, 0);
-		intptr_t len = lineEnd - lineStart;
-		std::string text(len, '\0');
-		for (intptr_t i = 0; i < len; ++i)
-			text[i] = (char)ScintillaBridge_sendMessage(sci, SCI_GETCHARAT, lineStart + i, 0);
-		lines.push_back(text);
-	}
+	if (!readSelectedLines(sci, startLine, endLine, replStart, replEnd, lines))
+		return;
 
 	if (ascending)
 		std::sort(lines.begin(), lines.end());
 	else
 		std::sort(lines.begin(), lines.end(), std::greater<std::string>());
 
-	std::string result;
-	for (size_t i = 0; i < lines.size(); ++i)
-	{
-		result += lines[i];
-		if (i + 1 < lines.size()) result += '\n';
-	}
-
-	intptr_t replStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, startLine, 0);
-	intptr_t replEnd = ScintillaBridge_sendMessage(sci, SCI_GETLINEENDPOSITION, endLine, 0);
-
-	ScintillaBridge_sendMessage(sci, SCI_BEGINUNDOACTION, 0, 0);
-	ScintillaBridge_sendMessage(sci, SCI_SETTARGETSTART, replStart, 0);
-	ScintillaBridge_sendMessage(sci, SCI_SETTARGETEND, replEnd, 0);
-	ScintillaBridge_sendMessage(sci, SCI_REPLACETARGET, result.size(), (intptr_t)result.c_str());
-	ScintillaBridge_sendMessage(sci, SCI_ENDUNDOACTION, 0, 0);
+	replaceSelectedLines(sci, replStart, replEnd, lines);
 }
 
 void doJoinLines()

--- a/macos/platform/edit_commands.mm
+++ b/macos/platform/edit_commands.mm
@@ -410,11 +410,19 @@ static bool readSelectedLines(void*& sci, intptr_t& startLine, intptr_t& endLine
 	{
 		intptr_t lineStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, line, 0);
 		intptr_t lineEnd = ScintillaBridge_sendMessage(sci, SCI_GETLINEENDPOSITION, line, 0);
-		intptr_t len = lineEnd - lineStart;
-		std::string text(len, '\0');
-		for (intptr_t i = 0; i < len; ++i)
-			text[i] = (char)ScintillaBridge_sendMessage(sci, SCI_GETCHARAT, lineStart + i, 0);
-		lines.push_back(text);
+		intptr_t contentLen = lineEnd - lineStart;
+		// Use SCI_GETLINE for bulk read (includes EOL), then truncate to content length
+		intptr_t fullLen = ScintillaBridge_sendMessage(sci, SCI_LINELENGTH, line, 0);
+		if (fullLen > 0)
+		{
+			std::string buf(static_cast<size_t>(fullLen) + 1, '\0');
+			ScintillaBridge_sendMessage(sci, SCI_GETLINE, line, reinterpret_cast<intptr_t>(buf.data()));
+			lines.push_back(buf.substr(0, static_cast<size_t>(contentLen)));
+		}
+		else
+		{
+			lines.push_back(std::string());
+		}
 	}
 
 	replStart = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE, startLine, 0);

--- a/macos/platform/hash_tools.h
+++ b/macos/platform/hash_tools.h
@@ -1,0 +1,9 @@
+// hash_tools.h — Hash tool declarations (MD5, SHA-1, SHA-256, SHA-512)
+// Part of the Notepad++ macOS port.
+
+#pragma once
+
+void doHashMD5();
+void doHashSHA1();
+void doHashSHA256();
+void doHashSHA512();

--- a/macos/platform/hash_tools.mm
+++ b/macos/platform/hash_tools.mm
@@ -19,29 +19,61 @@
 // Helper: compute a hex-encoded hash digest
 // ------------------------------------------------------------------
 
+// Use incremental CommonCrypto APIs (Init/Update/Final) to avoid CC_LONG
+// truncation on inputs larger than UINT32_MAX. Data is fed in chunks.
 static std::string computeHash(const void* data, size_t length, const std::string& algorithm)
 {
-	unsigned char digest[CC_SHA512_DIGEST_LENGTH]; // largest possible
+	unsigned char digest[CC_SHA512_DIGEST_LENGTH];
 	unsigned int digestLen = 0;
+	constexpr size_t kChunkSize = 1024 * 1024; // 1 MB
+	const auto* bytes = static_cast<const unsigned char*>(data);
 
 	if (algorithm == "MD5")
 	{
-		CC_MD5(data, static_cast<CC_LONG>(length), digest);
+		CC_MD5_CTX ctx;
+		CC_MD5_Init(&ctx);
+		for (size_t offset = 0; offset < length; offset += kChunkSize)
+		{
+			size_t chunk = (length - offset < kChunkSize) ? (length - offset) : kChunkSize;
+			CC_MD5_Update(&ctx, bytes + offset, static_cast<CC_LONG>(chunk));
+		}
+		CC_MD5_Final(digest, &ctx);
 		digestLen = CC_MD5_DIGEST_LENGTH;
 	}
 	else if (algorithm == "SHA1")
 	{
-		CC_SHA1(data, static_cast<CC_LONG>(length), digest);
+		CC_SHA1_CTX ctx;
+		CC_SHA1_Init(&ctx);
+		for (size_t offset = 0; offset < length; offset += kChunkSize)
+		{
+			size_t chunk = (length - offset < kChunkSize) ? (length - offset) : kChunkSize;
+			CC_SHA1_Update(&ctx, bytes + offset, static_cast<CC_LONG>(chunk));
+		}
+		CC_SHA1_Final(digest, &ctx);
 		digestLen = CC_SHA1_DIGEST_LENGTH;
 	}
 	else if (algorithm == "SHA256")
 	{
-		CC_SHA256(data, static_cast<CC_LONG>(length), digest);
+		CC_SHA256_CTX ctx;
+		CC_SHA256_Init(&ctx);
+		for (size_t offset = 0; offset < length; offset += kChunkSize)
+		{
+			size_t chunk = (length - offset < kChunkSize) ? (length - offset) : kChunkSize;
+			CC_SHA256_Update(&ctx, bytes + offset, static_cast<CC_LONG>(chunk));
+		}
+		CC_SHA256_Final(digest, &ctx);
 		digestLen = CC_SHA256_DIGEST_LENGTH;
 	}
 	else if (algorithm == "SHA512")
 	{
-		CC_SHA512(data, static_cast<CC_LONG>(length), digest);
+		CC_SHA512_CTX ctx;
+		CC_SHA512_Init(&ctx);
+		for (size_t offset = 0; offset < length; offset += kChunkSize)
+		{
+			size_t chunk = (length - offset < kChunkSize) ? (length - offset) : kChunkSize;
+			CC_SHA512_Update(&ctx, bytes + offset, static_cast<CC_LONG>(chunk));
+		}
+		CC_SHA512_Final(digest, &ctx);
 		digestLen = CC_SHA512_DIGEST_LENGTH;
 	}
 	else
@@ -50,13 +82,13 @@ static std::string computeHash(const void* data, size_t length, const std::strin
 	}
 
 	// Convert to lowercase hex string
+	static const char hexDigits[] = "0123456789abcdef";
 	std::string hex;
 	hex.reserve(digestLen * 2);
 	for (unsigned int i = 0; i < digestLen; ++i)
 	{
-		char buf[3];
-		snprintf(buf, sizeof(buf), "%02x", digest[i]);
-		hex += buf;
+		hex += hexDigits[digest[i] >> 4];
+		hex += hexDigits[digest[i] & 0x0F];
 	}
 	return hex;
 }

--- a/macos/platform/hash_tools.mm
+++ b/macos/platform/hash_tools.mm
@@ -1,0 +1,255 @@
+// hash_tools.mm — Hash tools (MD5, SHA-1, SHA-256, SHA-512)
+// Part of the Notepad++ macOS port.
+//
+// Hashes the current selection if non-empty, otherwise the entire document.
+// Shows result in a modal NSPanel with Copy / Insert at Cursor / Close buttons.
+
+#import <Cocoa/Cocoa.h>
+#include <CommonCrypto/CommonDigest.h>
+#include <string>
+#include <vector>
+
+#include "hash_tools.h"
+#include "app_state.h"
+#include "npp_constants.h"
+#include "scintilla_bridge.h"
+
+// ------------------------------------------------------------------
+// Helper: compute a hex-encoded hash digest
+// ------------------------------------------------------------------
+
+static std::string computeHash(const void* data, size_t length, const std::string& algorithm)
+{
+	unsigned char digest[CC_SHA512_DIGEST_LENGTH]; // largest possible
+	unsigned int digestLen = 0;
+
+	if (algorithm == "MD5")
+	{
+		CC_MD5(data, static_cast<CC_LONG>(length), digest);
+		digestLen = CC_MD5_DIGEST_LENGTH;
+	}
+	else if (algorithm == "SHA1")
+	{
+		CC_SHA1(data, static_cast<CC_LONG>(length), digest);
+		digestLen = CC_SHA1_DIGEST_LENGTH;
+	}
+	else if (algorithm == "SHA256")
+	{
+		CC_SHA256(data, static_cast<CC_LONG>(length), digest);
+		digestLen = CC_SHA256_DIGEST_LENGTH;
+	}
+	else if (algorithm == "SHA512")
+	{
+		CC_SHA512(data, static_cast<CC_LONG>(length), digest);
+		digestLen = CC_SHA512_DIGEST_LENGTH;
+	}
+
+	// Convert to lowercase hex string
+	std::string hex;
+	hex.reserve(digestLen * 2);
+	for (unsigned int i = 0; i < digestLen; ++i)
+	{
+		char buf[3];
+		snprintf(buf, sizeof(buf), "%02x", digest[i]);
+		hex += buf;
+	}
+	return hex;
+}
+
+// ------------------------------------------------------------------
+// Helper: get input bytes (selection or whole document)
+// ------------------------------------------------------------------
+
+static std::vector<char> getInputBytes()
+{
+	void* sci = ctx().activeScintillaView();
+	if (!sci)
+		return {};
+
+	intptr_t selStart = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONSTART, 0, 0);
+	intptr_t selEnd = ScintillaBridge_sendMessage(sci, SCI_GETSELECTIONEND, 0, 0);
+
+	if (selEnd > selStart)
+	{
+		// Hash the selection
+		intptr_t selLen = selEnd - selStart;
+		std::vector<char> buf(selLen + 1, '\0');
+		ScintillaBridge_sendMessage(sci, SCI_GETSELTEXT, 0, reinterpret_cast<intptr_t>(buf.data()));
+		buf.resize(selLen); // trim null terminator
+		return buf;
+	}
+
+	// Hash the entire document
+	intptr_t docLen = ScintillaBridge_sendMessage(sci, SCI_GETTEXTLENGTH, 0, 0);
+	if (docLen <= 0)
+		return {};
+
+	std::vector<char> buf(docLen + 1, '\0');
+	ScintillaBridge_sendMessage(sci, SCI_GETTEXT, docLen + 1, reinterpret_cast<intptr_t>(buf.data()));
+	buf.resize(docLen); // trim null terminator
+	return buf;
+}
+
+// ------------------------------------------------------------------
+// Helper: show the hash result dialog
+// ------------------------------------------------------------------
+
+@interface HashDialogController : NSObject <NSWindowDelegate>
+@property (nonatomic, copy) NSString* hashValue;
+@end
+
+@implementation HashDialogController
+
+- (void)copyHash:(id)sender
+{
+	NSPasteboard* pb = [NSPasteboard generalPasteboard];
+	[pb clearContents];
+	[pb setString:_hashValue forType:NSPasteboardTypeString];
+}
+
+- (void)insertAtCursor:(id)sender
+{
+	void* sci = ctx().activeScintillaView();
+	if (sci && _hashValue)
+	{
+		const char* utf8 = [_hashValue UTF8String];
+		ScintillaBridge_sendMessage(sci, SCI_REPLACESEL, 0, reinterpret_cast<intptr_t>(utf8));
+	}
+	[NSApp stopModal];
+}
+
+- (void)closePanel:(id)sender
+{
+	[NSApp stopModal];
+}
+
+- (void)windowWillClose:(NSNotification*)notification
+{
+	[NSApp stopModal];
+}
+
+@end
+
+static void showHashResult(const std::string& algorithm, const std::string& hex)
+{
+	@autoreleasepool {
+		NSString* title = [NSString stringWithFormat:@"%s Hash", algorithm.c_str()];
+		NSString* hashStr = [NSString stringWithUTF8String:hex.c_str()];
+
+		NSPanel* panel = [[NSPanel alloc]
+			initWithContentRect:NSMakeRect(0, 0, 480, 160)
+			styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable
+			backing:NSBackingStoreBuffered
+			defer:NO];
+		[panel setTitle:title];
+		[panel center];
+		[panel setReleasedWhenClosed:NO];
+
+		HashDialogController* controller = [[HashDialogController alloc] init];
+		controller.hashValue = hashStr;
+
+		NSView* contentView = [panel contentView];
+
+		// Algorithm label
+		NSTextField* algoLabel = [NSTextField labelWithString:title];
+		[algoLabel setFont:[NSFont boldSystemFontOfSize:14]];
+		[algoLabel setFrame:NSMakeRect(20, 120, 440, 20)];
+		[contentView addSubview:algoLabel];
+
+		// Hash value field (selectable, not editable)
+		NSTextField* hashField = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 70, 440, 40)];
+		[hashField setStringValue:hashStr];
+		[hashField setEditable:NO];
+		[hashField setSelectable:YES];
+		[hashField setBezeled:YES];
+		[hashField setBezelStyle:NSTextFieldSquareBezel];
+		[hashField setFont:[NSFont monospacedSystemFontOfSize:12 weight:NSFontWeightRegular]];
+		[hashField setLineBreakMode:NSLineBreakByCharWrapping];
+		[hashField setUsesSingleLineMode:NO];
+		[[hashField cell] setWraps:YES];
+		[contentView addSubview:hashField];
+
+		// Buttons
+		CGFloat btnY = 16;
+		CGFloat btnW = 130;
+		CGFloat spacing = 14;
+		CGFloat totalW = btnW * 3 + spacing * 2;
+		CGFloat startX = (480 - totalW) / 2;
+
+		NSButton* copyBtn = [[NSButton alloc] initWithFrame:NSMakeRect(startX, btnY, btnW, 32)];
+		[copyBtn setTitle:@"Copy"];
+		[copyBtn setBezelStyle:NSBezelStyleRounded];
+		[copyBtn setTarget:controller];
+		[copyBtn setAction:@selector(copyHash:)];
+		[contentView addSubview:copyBtn];
+
+		NSButton* insertBtn = [[NSButton alloc] initWithFrame:NSMakeRect(startX + btnW + spacing, btnY, btnW, 32)];
+		[insertBtn setTitle:@"Insert at Cursor"];
+		[insertBtn setBezelStyle:NSBezelStyleRounded];
+		[insertBtn setTarget:controller];
+		[insertBtn setAction:@selector(insertAtCursor:)];
+		[contentView addSubview:insertBtn];
+
+		NSButton* closeBtn = [[NSButton alloc] initWithFrame:NSMakeRect(startX + (btnW + spacing) * 2, btnY, btnW, 32)];
+		[closeBtn setTitle:@"Close"];
+		[closeBtn setBezelStyle:NSBezelStyleRounded];
+		[closeBtn setTarget:controller];
+		[closeBtn setAction:@selector(closePanel:)];
+		[closeBtn setKeyEquivalent:@"\r"];
+		[contentView addSubview:closeBtn];
+
+		[panel setDefaultButtonCell:[closeBtn cell]];
+		[panel setDelegate:controller];
+
+		[NSApp runModalForWindow:panel];
+		[panel close];
+
+		// Prevent ARC from releasing controller during modal
+		(void)controller;
+	}
+}
+
+// ------------------------------------------------------------------
+// Shared pipeline: get input -> compute hash -> show result
+// ------------------------------------------------------------------
+
+static void doHash(const std::string& algorithm)
+{
+	std::vector<char> input = getInputBytes();
+	if (input.empty())
+	{
+		NSAlert* alert = [[NSAlert alloc] init];
+		[alert setMessageText:@"Nothing to Hash"];
+		[alert setInformativeText:@"The document is empty and there is no selection."];
+		[alert addButtonWithTitle:@"OK"];
+		[alert runModal];
+		return;
+	}
+
+	std::string hex = computeHash(input.data(), input.size(), algorithm);
+	showHashResult(algorithm, hex);
+}
+
+// ------------------------------------------------------------------
+// Public API
+// ------------------------------------------------------------------
+
+void doHashMD5()
+{
+	doHash("MD5");
+}
+
+void doHashSHA1()
+{
+	doHash("SHA1");
+}
+
+void doHashSHA256()
+{
+	doHash("SHA256");
+}
+
+void doHashSHA512()
+{
+	doHash("SHA512");
+}

--- a/macos/platform/hash_tools.mm
+++ b/macos/platform/hash_tools.mm
@@ -6,6 +6,7 @@
 
 #import <Cocoa/Cocoa.h>
 #include <CommonCrypto/CommonDigest.h>
+#include <cstdio>
 #include <string>
 #include <vector>
 
@@ -42,6 +43,10 @@ static std::string computeHash(const void* data, size_t length, const std::strin
 	{
 		CC_SHA512(data, static_cast<CC_LONG>(length), digest);
 		digestLen = CC_SHA512_DIGEST_LENGTH;
+	}
+	else
+	{
+		return "(unsupported algorithm)";
 	}
 
 	// Convert to lowercase hex string

--- a/macos/platform/macro_manager.h
+++ b/macos/platform/macro_manager.h
@@ -1,0 +1,44 @@
+// macro_manager.h — Macro recording, playback, and persistence
+// Part of the Notepad++ macOS port.
+
+#pragma once
+#include <string>
+#include <vector>
+
+struct MacroStep
+{
+	int message;
+	uintptr_t wParam;
+	intptr_t lParam;
+	std::string text; // Copied string payload (when lParam is a string pointer)
+};
+
+class MacroManager
+{
+public:
+	static MacroManager& instance();
+
+	// Recording
+	void startRecording(void* sci);
+	void stopRecording(void* sci);
+	bool isRecording() const;
+	void recordStep(int message, uintptr_t wParam, intptr_t lParam);
+
+	// Playback
+	void playback(void* sci);
+	void playbackMultiple(void* sci, int count);
+	bool hasRecordedMacro() const;
+
+	// Persistence
+	void saveMacro(const std::string& name);
+	void loadMacro(const std::string& name);
+	std::vector<std::string> savedMacroNames() const;
+
+private:
+	MacroManager() = default;
+	bool _recording = false;
+	std::vector<MacroStep> _currentMacro;
+
+	std::string macrosDir() const;
+	std::string macrosPath() const;
+};

--- a/macos/platform/macro_manager.mm
+++ b/macos/platform/macro_manager.mm
@@ -6,7 +6,9 @@
 #include "scintilla_bridge.h"
 #include "npp_constants.h"
 
-// Messages that use lParam as a string pointer and need text copying during record
+// Messages that use lParam as a string pointer and need text copying during record.
+// This list matches Notepad++ upstream's recordedMacroStep handling for Scintilla
+// messages that pass string data via lParam.
 static bool isStringMessage(int message)
 {
 	switch (message)
@@ -15,6 +17,13 @@ static bool isStringMessage(int message)
 		case SCI_INSERTTEXT:     // 2003
 		case SCI_SEARCHINTARGET: // 2197
 		case SCI_SETTEXT:        // 2181
+		case SCI_REPLACETARGET:  // 2194 — used by Find & Replace
+		case 2195:               // SCI_REPLACETARGETRE
+		case 2282:               // SCI_SEARCHNEXT
+		case 2283:               // SCI_SEARCHPREV
+		case 2014:               // SCI_ADDTEXT (via length + lParam)
+		case SCI_TEXTWIDTH:      // 2276
+		case SCI_STYLESETFONT:   // 2056
 			return true;
 		default:
 			return false;

--- a/macos/platform/macro_manager.mm
+++ b/macos/platform/macro_manager.mm
@@ -19,9 +19,9 @@ static bool isStringMessage(int message)
 		case SCI_SETTEXT:        // 2181
 		case SCI_REPLACETARGET:  // 2194 — used by Find & Replace
 		case 2195:               // SCI_REPLACETARGETRE
-		case 2282:               // SCI_SEARCHNEXT
-		case 2283:               // SCI_SEARCHPREV
-		case 2014:               // SCI_ADDTEXT (via length + lParam)
+		case 2367:               // SCI_SEARCHNEXT
+		case 2368:               // SCI_SEARCHPREV
+		case 2001:               // SCI_ADDTEXT (via length + lParam)
 		case SCI_TEXTWIDTH:      // 2276
 		case SCI_STYLESETFONT:   // 2056
 			return true;

--- a/macos/platform/macro_manager.mm
+++ b/macos/platform/macro_manager.mm
@@ -60,6 +60,23 @@ bool MacroManager::isRecording() const
 
 void MacroManager::recordStep(int message, uintptr_t wParam, intptr_t lParam)
 {
+	// Normalize newline insertions to SCI_NEWLINE so playback uses the
+	// document's EOL mode rather than replaying a raw \r or \n byte.
+	// This matches Notepad++ upstream behavior.
+	if (message == SCI_REPLACESEL && lParam != 0)
+	{
+		const char* str = reinterpret_cast<const char*>(lParam);
+		if ((str[0] == '\n' || str[0] == '\r') && str[1] == '\0')
+		{
+			MacroStep nlStep;
+			nlStep.message = SCI_NEWLINE;
+			nlStep.wParam = 0;
+			nlStep.lParam = 0;
+			_currentMacro.push_back(nlStep);
+			return;
+		}
+	}
+
 	MacroStep step;
 	step.message = message;
 	step.wParam = wParam;

--- a/macos/platform/macro_manager.mm
+++ b/macos/platform/macro_manager.mm
@@ -13,17 +13,17 @@ static bool isStringMessage(int message)
 {
 	switch (message)
 	{
-		case SCI_REPLACESEL:     // 2170
-		case SCI_INSERTTEXT:     // 2003
-		case SCI_SEARCHINTARGET: // 2197
-		case SCI_SETTEXT:        // 2181
-		case SCI_REPLACETARGET:  // 2194 — used by Find & Replace
-		case 2195:               // SCI_REPLACETARGETRE
-		case 2367:               // SCI_SEARCHNEXT
-		case 2368:               // SCI_SEARCHPREV
-		case 2001:               // SCI_ADDTEXT (via length + lParam)
-		case SCI_TEXTWIDTH:      // 2276
-		case SCI_STYLESETFONT:   // 2056
+		case SCI_REPLACESEL:      // 2170
+		case SCI_INSERTTEXT:      // 2003
+		case SCI_SEARCHINTARGET:  // 2197
+		case SCI_SETTEXT:         // 2181
+		case SCI_REPLACETARGET:   // 2194 — used by Find & Replace
+		case SCI_REPLACETARGETRE: // 2195
+		case SCI_SEARCHNEXT:      // 2367
+		case SCI_SEARCHPREV:      // 2368
+		case SCI_ADDTEXT:         // 2001 (via length + lParam)
+		case SCI_TEXTWIDTH:       // 2276
+		case SCI_STYLESETFONT:    // 2056
 			return true;
 		default:
 			return false;
@@ -67,7 +67,23 @@ void MacroManager::recordStep(int message, uintptr_t wParam, intptr_t lParam)
 	if (isStringMessage(message) && lParam != 0)
 	{
 		const char* str = reinterpret_cast<const char*>(lParam);
-		step.text = str;
+		// For messages where wParam is an explicit byte length and the buffer
+		// is not guaranteed NUL-terminated, copy using the length to avoid
+		// reading past the buffer. Fall back to NUL-terminated for the rest.
+		switch (message)
+		{
+			case SCI_ADDTEXT:         // wParam = length
+			case SCI_REPLACETARGET:   // wParam = length (-1 for NUL-term)
+			case SCI_REPLACETARGETRE: // wParam = length (-1 for NUL-term)
+				if (wParam != static_cast<uintptr_t>(-1))
+					step.text.assign(str, static_cast<size_t>(wParam));
+				else
+					step.text = str;
+				break;
+			default:
+				step.text = str;
+				break;
+		}
 		step.lParam = 0; // Marker: use text field on playback
 	}
 	else
@@ -241,8 +257,22 @@ void MacroManager::saveMacro(const std::string& name)
 	NSData* data = [NSJSONSerialization dataWithJSONObject:allMacros
 	                                              options:NSJSONWritingPrettyPrinted
 	                                                error:&error];
-	if (data && !error && path)
-		[data writeToFile:path atomically:YES];
+	if (!data || error)
+	{
+		NSAlert* errAlert = [[NSAlert alloc] init];
+		errAlert.messageText = @"Save Failed";
+		errAlert.informativeText = error ? error.localizedDescription : @"Could not serialize macro data.";
+		[errAlert runModal];
+		return;
+	}
+
+	if (path && ![data writeToFile:path atomically:YES])
+	{
+		NSAlert* errAlert = [[NSAlert alloc] init];
+		errAlert.messageText = @"Save Failed";
+		errAlert.informativeText = @"Could not write macros file to disk.";
+		[errAlert runModal];
+	}
 }
 
 void MacroManager::loadMacro(const std::string& name)
@@ -251,14 +281,35 @@ void MacroManager::loadMacro(const std::string& name)
 	if (!path) return;
 
 	NSData* data = [NSData dataWithContentsOfFile:path];
-	if (!data) return;
+	if (!data)
+	{
+		NSAlert* errAlert = [[NSAlert alloc] init];
+		errAlert.messageText = @"Load Failed";
+		errAlert.informativeText = @"No saved macros file found.";
+		[errAlert runModal];
+		return;
+	}
 
-	id parsed = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
-	if (![parsed isKindOfClass:[NSDictionary class]]) return;
+	NSError* jsonError = nil;
+	id parsed = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
+	if (![parsed isKindOfClass:[NSDictionary class]])
+	{
+		NSAlert* errAlert = [[NSAlert alloc] init];
+		errAlert.messageText = @"Load Failed";
+		errAlert.informativeText = jsonError ? jsonError.localizedDescription : @"Macros file is corrupted.";
+		[errAlert runModal];
+		return;
+	}
 	NSDictionary* allMacros = parsed;
 
 	if (allMacros.count == 0)
+	{
+		NSAlert* errAlert = [[NSAlert alloc] init];
+		errAlert.messageText = @"No Macros";
+		errAlert.informativeText = @"No saved macros found.";
+		[errAlert runModal];
 		return;
+	}
 
 	NSString* macroName = nil;
 

--- a/macos/platform/macro_manager.mm
+++ b/macos/platform/macro_manager.mm
@@ -1,0 +1,336 @@
+// macro_manager.mm — Macro recording, playback, and persistence
+// Part of the Notepad++ macOS port.
+
+#import <Cocoa/Cocoa.h>
+#include "macro_manager.h"
+#include "scintilla_bridge.h"
+#include "npp_constants.h"
+
+// Messages that use lParam as a string pointer and need text copying during record
+static bool isStringMessage(int message)
+{
+	switch (message)
+	{
+		case SCI_REPLACESEL:     // 2170
+		case SCI_INSERTTEXT:     // 2003
+		case SCI_SEARCHINTARGET: // 2197
+		case SCI_SETTEXT:        // 2181
+			return true;
+		default:
+			return false;
+	}
+}
+
+MacroManager& MacroManager::instance()
+{
+	static MacroManager mgr;
+	return mgr;
+}
+
+// ============================================================
+// Recording
+// ============================================================
+
+void MacroManager::startRecording(void* sci)
+{
+	_currentMacro.clear();
+	_recording = true;
+	ScintillaBridge_sendMessage(sci, SCI_STARTRECORD, 0, 0);
+}
+
+void MacroManager::stopRecording(void* sci)
+{
+	_recording = false;
+	ScintillaBridge_sendMessage(sci, SCI_STOPRECORD, 0, 0);
+}
+
+bool MacroManager::isRecording() const
+{
+	return _recording;
+}
+
+void MacroManager::recordStep(int message, uintptr_t wParam, intptr_t lParam)
+{
+	MacroStep step;
+	step.message = message;
+	step.wParam = wParam;
+
+	if (isStringMessage(message) && lParam != 0)
+	{
+		const char* str = reinterpret_cast<const char*>(lParam);
+		step.text = str;
+		step.lParam = 0; // Marker: use text field on playback
+	}
+	else
+	{
+		step.lParam = lParam;
+	}
+
+	_currentMacro.push_back(step);
+}
+
+// ============================================================
+// Playback
+// ============================================================
+
+void MacroManager::playback(void* sci)
+{
+	if (_currentMacro.empty() || !sci)
+		return;
+
+	for (const auto& step : _currentMacro)
+	{
+		intptr_t lp = step.lParam;
+		if (!step.text.empty())
+			lp = reinterpret_cast<intptr_t>(step.text.c_str());
+		ScintillaBridge_sendMessage(sci, step.message, step.wParam, lp);
+	}
+}
+
+void MacroManager::playbackMultiple(void* sci, int count)
+{
+	if (_currentMacro.empty() || !sci)
+		return;
+
+	// If count is 0 or negative, prompt the user for a repeat count
+	if (count <= 0)
+	{
+		NSAlert* alert = [[NSAlert alloc] init];
+		alert.messageText = @"Run Macro Multiple Times";
+		alert.informativeText = @"Enter number of times to repeat:";
+		[alert addButtonWithTitle:@"OK"];
+		[alert addButtonWithTitle:@"Cancel"];
+
+		NSTextField* input = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 200, 24)];
+		input.stringValue = @"10";
+		alert.accessoryView = input;
+
+		NSModalResponse response = [alert runModal];
+		if (response != NSAlertFirstButtonReturn)
+			return;
+
+		count = [input intValue];
+		if (count <= 0)
+			return;
+	}
+
+	for (int i = 0; i < count; ++i)
+	{
+		playback(sci);
+	}
+}
+
+bool MacroManager::hasRecordedMacro() const
+{
+	return !_currentMacro.empty();
+}
+
+// ============================================================
+// Persistence
+// ============================================================
+
+std::string MacroManager::macrosDir() const
+{
+	NSString* home = NSHomeDirectory();
+	NSString* dir = [home stringByAppendingPathComponent:@".npp-macos"];
+	const char* fs = [dir fileSystemRepresentation];
+	if (!fs) return "";
+	return std::string(fs);
+}
+
+std::string MacroManager::macrosPath() const
+{
+	std::string dir = macrosDir();
+	if (dir.empty()) return "";
+	return dir + "/macros.json";
+}
+
+static NSString* stringFromFileSystemPath(const std::string& path)
+{
+	if (path.empty()) return nil;
+	return [[NSFileManager defaultManager] stringWithFileSystemRepresentation:path.c_str()
+	                                                                   length:path.size()];
+}
+
+void MacroManager::saveMacro(const std::string& name)
+{
+	if (_currentMacro.empty())
+		return;
+
+	NSString* macroName = nil;
+
+	if (name.empty())
+	{
+		// Prompt for macro name
+		NSAlert* alert = [[NSAlert alloc] init];
+		alert.messageText = @"Save Macro";
+		alert.informativeText = @"Enter a name for this macro:";
+		[alert addButtonWithTitle:@"Save"];
+		[alert addButtonWithTitle:@"Cancel"];
+
+		NSTextField* input = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 200, 24)];
+		input.stringValue = @"My Macro";
+		alert.accessoryView = input;
+
+		NSModalResponse response = [alert runModal];
+		if (response != NSAlertFirstButtonReturn)
+			return;
+
+		macroName = input.stringValue;
+		if (macroName.length == 0)
+			return;
+	}
+	else
+	{
+		macroName = [NSString stringWithUTF8String:name.c_str()];
+	}
+
+	// Ensure directory exists
+	NSString* dir = stringFromFileSystemPath(macrosDir());
+	if (!dir) return;
+
+	[[NSFileManager defaultManager] createDirectoryAtPath:dir
+	                           withIntermediateDirectories:YES
+	                                           attributes:nil
+	                                                error:nil];
+
+	// Load existing macros file
+	NSMutableDictionary* allMacros = [NSMutableDictionary dictionary];
+	NSString* path = stringFromFileSystemPath(macrosPath());
+	if (path)
+	{
+		NSData* existingData = [NSData dataWithContentsOfFile:path];
+		if (existingData)
+		{
+			id parsed = [NSJSONSerialization JSONObjectWithData:existingData options:0 error:nil];
+			if ([parsed isKindOfClass:[NSDictionary class]])
+				allMacros = [parsed mutableCopy];
+		}
+	}
+
+	// Convert current macro to JSON array
+	NSMutableArray* stepsArray = [NSMutableArray array];
+	for (const auto& step : _currentMacro)
+	{
+		NSMutableDictionary* stepDict = [NSMutableDictionary dictionary];
+		stepDict[@"message"] = @(step.message);
+		stepDict[@"wParam"] = @(static_cast<long long>(step.wParam));
+		stepDict[@"lParam"] = @(static_cast<long long>(step.lParam));
+		if (!step.text.empty())
+		{
+			NSString* text = [NSString stringWithUTF8String:step.text.c_str()];
+			if (text)
+				stepDict[@"text"] = text;
+		}
+		[stepsArray addObject:stepDict];
+	}
+
+	allMacros[macroName] = stepsArray;
+
+	// Write back
+	NSError* error = nil;
+	NSData* data = [NSJSONSerialization dataWithJSONObject:allMacros
+	                                              options:NSJSONWritingPrettyPrinted
+	                                                error:&error];
+	if (data && !error && path)
+		[data writeToFile:path atomically:YES];
+}
+
+void MacroManager::loadMacro(const std::string& name)
+{
+	NSString* path = stringFromFileSystemPath(macrosPath());
+	if (!path) return;
+
+	NSData* data = [NSData dataWithContentsOfFile:path];
+	if (!data) return;
+
+	id parsed = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+	if (![parsed isKindOfClass:[NSDictionary class]]) return;
+	NSDictionary* allMacros = parsed;
+
+	if (allMacros.count == 0)
+		return;
+
+	NSString* macroName = nil;
+
+	if (name.empty())
+	{
+		// Prompt user to select a macro
+		NSArray<NSString*>* names = [allMacros.allKeys sortedArrayUsingSelector:@selector(compare:)];
+		if (names.count == 0)
+			return;
+
+		NSAlert* alert = [[NSAlert alloc] init];
+		alert.messageText = @"Load Macro";
+		alert.informativeText = @"Select a macro to load:";
+		[alert addButtonWithTitle:@"Load"];
+		[alert addButtonWithTitle:@"Cancel"];
+
+		NSPopUpButton* popup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 200, 24) pullsDown:NO];
+		for (NSString* n in names)
+			[popup addItemWithTitle:n];
+		alert.accessoryView = popup;
+
+		NSModalResponse response = [alert runModal];
+		if (response != NSAlertFirstButtonReturn)
+			return;
+
+		macroName = popup.titleOfSelectedItem;
+	}
+	else
+	{
+		macroName = [NSString stringWithUTF8String:name.c_str()];
+	}
+
+	if (!macroName) return;
+
+	NSArray* steps = allMacros[macroName];
+	if (![steps isKindOfClass:[NSArray class]])
+		return;
+
+	_currentMacro.clear();
+	for (NSDictionary* stepDict in steps)
+	{
+		if (![stepDict isKindOfClass:[NSDictionary class]])
+			continue;
+
+		MacroStep step;
+		step.message = [stepDict[@"message"] intValue];
+		step.wParam = static_cast<uintptr_t>([stepDict[@"wParam"] longLongValue]);
+		step.lParam = static_cast<intptr_t>([stepDict[@"lParam"] longLongValue]);
+
+		NSString* text = stepDict[@"text"];
+		if ([text isKindOfClass:[NSString class]])
+		{
+			const char* utf8 = [text UTF8String];
+			if (utf8)
+				step.text = utf8;
+		}
+
+		_currentMacro.push_back(step);
+	}
+}
+
+std::vector<std::string> MacroManager::savedMacroNames() const
+{
+	std::vector<std::string> result;
+
+	NSString* path = stringFromFileSystemPath(macrosPath());
+	if (!path) return result;
+
+	NSData* data = [NSData dataWithContentsOfFile:path];
+	if (!data) return result;
+
+	id parsed = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+	if (![parsed isKindOfClass:[NSDictionary class]]) return result;
+
+	NSDictionary* allMacros = parsed;
+	for (NSString* key in [allMacros.allKeys sortedArrayUsingSelector:@selector(compare:)])
+	{
+		const char* utf8 = [key UTF8String];
+		if (utf8)
+			result.push_back(utf8);
+	}
+
+	return result;
+}

--- a/macos/platform/menu_builder.mm
+++ b/macos/platform/menu_builder.mm
@@ -166,7 +166,19 @@ HMENU buildMenuBar()
 
 	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hFormatMenu), L"F&ormat");
 
-	// Tools menu (between Format and Language)
+	// Macro menu
+	HMENU hMacroMenu = CreatePopupMenu();
+	AppendMenuW(hMacroMenu, MF_STRING, IDM_MACRO_START_RECORD, L"Start &Recording");
+	AppendMenuW(hMacroMenu, MF_STRING, IDM_MACRO_STOP_RECORD, L"S&top Recording");
+	AppendMenuW(hMacroMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hMacroMenu, MF_STRING, IDM_MACRO_PLAYBACK, L"&Playback");
+	AppendMenuW(hMacroMenu, MF_STRING, IDM_MACRO_PLAYBACK_MULTI, L"Run &Multiple Times...");
+	AppendMenuW(hMacroMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hMacroMenu, MF_STRING, IDM_MACRO_SAVE, L"&Save Current Macro...");
+	AppendMenuW(hMacroMenu, MF_STRING, IDM_MACRO_LOAD, L"&Load Macro...");
+	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hMacroMenu), L"&Macro");
+
+	// Tools menu (between Macro and Language)
 	HMENU hToolsMenu = CreatePopupMenu();
 	HMENU hHashMenu = CreatePopupMenu();
 	AppendMenuW(hHashMenu, MF_STRING, IDM_TOOLS_HASH_MD5, L"&MD5");

--- a/macos/platform/menu_builder.mm
+++ b/macos/platform/menu_builder.mm
@@ -57,6 +57,11 @@ HMENU buildMenuBar()
 	AppendMenuW(hCaseMenu, MF_STRING, IDM_EDIT_UPPERCASE, L"&UPPERCASE\tCtrl+Shift+U");
 	AppendMenuW(hCaseMenu, MF_STRING, IDM_EDIT_LOWERCASE, L"&lowercase\tCtrl+U");
 	AppendMenuW(hCaseMenu, MF_STRING, IDM_EDIT_TITLECASE, L"&Title Case");
+	AppendMenuW(hCaseMenu, MF_STRING, IDM_EDIT_SENTENCECASE, L"&Sentence case");
+	AppendMenuW(hCaseMenu, MF_STRING, IDM_EDIT_INVERTCASE, L"&iNVERT cASE");
+	AppendMenuW(hCaseMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hCaseMenu, MF_STRING, IDM_EDIT_CAMELCASE, L"&camelCase");
+	AppendMenuW(hCaseMenu, MF_STRING, IDM_EDIT_SNAKECASE, L"sna&ke_case");
 	AppendMenuW(hEditMenu, MF_POPUP, reinterpret_cast<UINT_PTR>(hCaseMenu), L"Case Conversion");
 
 	HMENU hLineMenu = CreatePopupMenu();
@@ -67,6 +72,11 @@ HMENU buildMenuBar()
 	AppendMenuW(hLineMenu, MF_SEPARATOR, 0, nullptr);
 	AppendMenuW(hLineMenu, MF_STRING, IDM_EDIT_SORTASC, L"&Sort Lines (Ascending)");
 	AppendMenuW(hLineMenu, MF_STRING, IDM_EDIT_SORTDESC, L"Sort Lines (&Descending)");
+	AppendMenuW(hLineMenu, MF_STRING, IDM_EDIT_SORT_CASE_INSENSITIVE, L"Sort Lines (&Case Insensitive)");
+	AppendMenuW(hLineMenu, MF_STRING, IDM_EDIT_SORT_REVERSE, L"&Reverse Line Order");
+	AppendMenuW(hLineMenu, MF_STRING, IDM_EDIT_SORT_NUMERIC, L"Sort Lines (&Numeric)");
+	AppendMenuW(hLineMenu, MF_STRING, IDM_EDIT_SORT_RANDOM, L"Sort Lines (R&andom)");
+	AppendMenuW(hLineMenu, MF_STRING, IDM_EDIT_REMOVE_DUPLICATES, L"Remove &Duplicate Lines");
 	AppendMenuW(hLineMenu, MF_STRING, IDM_EDIT_JOINLINES, L"&Join Lines");
 	AppendMenuW(hEditMenu, MF_POPUP, reinterpret_cast<UINT_PTR>(hLineMenu), L"Line Operations");
 

--- a/macos/platform/menu_builder.mm
+++ b/macos/platform/menu_builder.mm
@@ -168,10 +168,10 @@ HMENU buildMenuBar()
 
 	// Macro menu
 	HMENU hMacroMenu = CreatePopupMenu();
-	AppendMenuW(hMacroMenu, MF_STRING, IDM_MACRO_START_RECORD, L"Start &Recording");
-	AppendMenuW(hMacroMenu, MF_STRING, IDM_MACRO_STOP_RECORD, L"S&top Recording");
+	AppendMenuW(hMacroMenu, MF_STRING, IDM_MACRO_START_RECORD, L"Start &Recording\tCtrl+Shift+R");
+	AppendMenuW(hMacroMenu, MF_STRING, IDM_MACRO_STOP_RECORD, L"S&top Recording\tCtrl+Shift+R");
 	AppendMenuW(hMacroMenu, MF_SEPARATOR, 0, nullptr);
-	AppendMenuW(hMacroMenu, MF_STRING, IDM_MACRO_PLAYBACK, L"&Playback");
+	AppendMenuW(hMacroMenu, MF_STRING, IDM_MACRO_PLAYBACK, L"&Playback\tCtrl+Shift+P");
 	AppendMenuW(hMacroMenu, MF_STRING, IDM_MACRO_PLAYBACK_MULTI, L"Run &Multiple Times...");
 	AppendMenuW(hMacroMenu, MF_SEPARATOR, 0, nullptr);
 	AppendMenuW(hMacroMenu, MF_STRING, IDM_MACRO_SAVE, L"&Save Current Macro...");

--- a/macos/platform/menu_builder.mm
+++ b/macos/platform/menu_builder.mm
@@ -166,6 +166,16 @@ HMENU buildMenuBar()
 
 	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hFormatMenu), L"F&ormat");
 
+	// Tools menu (between Format and Language)
+	HMENU hToolsMenu = CreatePopupMenu();
+	HMENU hHashMenu = CreatePopupMenu();
+	AppendMenuW(hHashMenu, MF_STRING, IDM_TOOLS_HASH_MD5, L"&MD5");
+	AppendMenuW(hHashMenu, MF_STRING, IDM_TOOLS_HASH_SHA1, L"SHA-&1");
+	AppendMenuW(hHashMenu, MF_STRING, IDM_TOOLS_HASH_SHA256, L"SHA-&256");
+	AppendMenuW(hHashMenu, MF_STRING, IDM_TOOLS_HASH_SHA512, L"SHA-&512");
+	AppendMenuW(hToolsMenu, MF_POPUP, reinterpret_cast<UINT_PTR>(hHashMenu), L"&Hash");
+	AppendMenuW(hMenuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(hToolsMenu), L"&Tools");
+
 	// Language menu
 	HMENU hLangMenu = CreatePopupMenu();
 	for (int i = 0; i < g_numLanguages; ++i)

--- a/macos/platform/npp_constants.h
+++ b/macos/platform/npp_constants.h
@@ -389,6 +389,12 @@ enum {
 	// Macro recording
 	SCI_STARTRECORD          = 3001,
 	SCI_STOPRECORD           = 3002,
+
+	// Additional messages used by macro string-payload detection
+	SCI_ADDTEXT              = 2001,
+	SCI_REPLACETARGETRE      = 2195,
+	SCI_SEARCHNEXT           = 2367,
+	SCI_SEARCHPREV           = 2368,
 };
 
 // Scintilla key constants

--- a/macos/platform/npp_constants.h
+++ b/macos/platform/npp_constants.h
@@ -127,6 +127,12 @@ constexpr double NPP_STATUS_BAR_HEIGHT = 22.0;
 // Help menu commands
 #define IDM_HELP_ABOUT           46001
 
+// Tools menu commands (Sprint P2)
+#define IDM_TOOLS_HASH_MD5       48001
+#define IDM_TOOLS_HASH_SHA1      48002
+#define IDM_TOOLS_HASH_SHA256    48003
+#define IDM_TOOLS_HASH_SHA512    48004
+
 // Phase 7 — Format/Encoding commands
 #define IDM_FORMAT_EOL_LF            45001
 #define IDM_FORMAT_EOL_CRLF          45002

--- a/macos/platform/npp_constants.h
+++ b/macos/platform/npp_constants.h
@@ -71,6 +71,19 @@ constexpr double NPP_STATUS_BAR_HEIGHT = 22.0;
 #define IDM_EDIT_INSERT_DATETIME_LONG  42047
 #define IDM_EDIT_AUTOCLOSE_BRACKETS  42048
 
+// Case conversions (Sprint P2)
+#define IDM_EDIT_SENTENCECASE    42100
+#define IDM_EDIT_INVERTCASE      42101
+#define IDM_EDIT_CAMELCASE       42102
+#define IDM_EDIT_SNAKECASE       42103
+
+// Line operations (Sprint P2)
+#define IDM_EDIT_SORT_CASE_INSENSITIVE  42104
+#define IDM_EDIT_SORT_REVERSE           42105
+#define IDM_EDIT_REMOVE_DUPLICATES      42106
+#define IDM_EDIT_SORT_NUMERIC           42107
+#define IDM_EDIT_SORT_RANDOM            42108
+
 // Phase 7 — View commands
 #define IDM_VIEW_SPLIT               42070
 #define IDM_VIEW_UNSPLIT             42071

--- a/macos/platform/npp_constants.h
+++ b/macos/platform/npp_constants.h
@@ -127,6 +127,14 @@ constexpr double NPP_STATUS_BAR_HEIGHT = 22.0;
 // Help menu commands
 #define IDM_HELP_ABOUT           46001
 
+// Macro menu commands (Sprint P2)
+#define IDM_MACRO_START_RECORD   47001
+#define IDM_MACRO_STOP_RECORD    47002
+#define IDM_MACRO_PLAYBACK       47003
+#define IDM_MACRO_PLAYBACK_MULTI 47004
+#define IDM_MACRO_SAVE           47005
+#define IDM_MACRO_LOAD           47006
+
 // Tools menu commands (Sprint P2)
 #define IDM_TOOLS_HASH_MD5       48001
 #define IDM_TOOLS_HASH_SHA1      48002
@@ -377,6 +385,10 @@ enum {
 	// Change history
 	SCI_SETCHANGEHISTORY     = 2780,
 	SCI_GETCHANGEHISTORY     = 2781,
+
+	// Macro recording
+	SCI_STARTRECORD          = 3001,
+	SCI_STOPRECORD           = 3002,
 };
 
 // Scintilla key constants
@@ -493,6 +505,7 @@ enum {
 #define SCN_SAVEPOINTLEFT    2003
 #define SCN_UPDATEUI         2007
 #define SCN_MODIFIED         2008
+#define SCN_MACRORECORD      2009
 #define SCN_FOCUSIN          2028
 
 // Scintilla modification flags

--- a/macos/platform/npp_constants.h
+++ b/macos/platform/npp_constants.h
@@ -386,6 +386,9 @@ enum {
 	SCI_SETCHANGEHISTORY     = 2780,
 	SCI_GETCHANGEHISTORY     = 2781,
 
+	// Newline insertion (document-context-aware EOL)
+	SCI_NEWLINE              = 2329,
+
 	// Macro recording
 	SCI_STARTRECORD          = 3001,
 	SCI_STOPRECORD           = 3002,

--- a/macos/platform/scintilla_config.mm
+++ b/macos/platform/scintilla_config.mm
@@ -122,9 +122,6 @@ void configureScintilla(void* sci)
 	if (ctx().showCaretLine)
 		ScintillaBridge_sendMessage(sci, SCI_SETCARETLINEBACK, 0xF0F0F0, 0);
 
-	if (ctx().zoomLevel != 0)
-		ScintillaBridge_sendMessage(sci, SCI_SETZOOM, ctx().zoomLevel, 0);
-
 	configureSmartHighlightIndicator(sci, false);
 
 	// Incremental search match highlighting (orange rounded box)

--- a/macos/platform/scintilla_config.mm
+++ b/macos/platform/scintilla_config.mm
@@ -109,8 +109,8 @@ void configureScintilla(void* sci)
 	ScintillaBridge_sendMessage(sci, SCI_SETMULTIPASTE, SC_MULTIPASTE_EACH, 0);
 	ScintillaBridge_sendMessage(sci, SCI_SETADDITIONALCARETSVISIBLE, 1, 0);
 
-	// Multi-cursor visual styling (Scintilla uses BGR byte order)
-	ScintillaBridge_sendMessage(sci, SCI_SETADDITIONALCARETFORE, 0xCC0000, 0);  // BGR 0xCC0000 = blue
+	// Multi-cursor visual styling
+	ScintillaBridge_sendMessage(sci, SCI_SETADDITIONALCARETFORE, 0x0000CC, 0);  // RGB 0x0000CC = blue
 	ScintillaBridge_sendMessage(sci, SCI_SETADDITIONALSELALPHA, 80, 0);  // semi-transparent selections
 
 	// Whitespace / EOL / indent guide visibility

--- a/macos/platform/session_manager.mm
+++ b/macos/platform/session_manager.mm
@@ -44,6 +44,7 @@ void saveSession()
 			@"languageIndex": @(doc.languageIndex),
 			@"encoding": @(doc.encoding),
 			@"eolMode": @(doc.eolMode),
+			@"zoomLevel": @(doc.zoomLevel),
 		}];
 	}
 
@@ -63,6 +64,7 @@ void saveSession()
 				@"languageIndex": @(doc.languageIndex),
 				@"encoding": @(doc.encoding),
 				@"eolMode": @(doc.eolMode),
+				@"zoomLevel": @(doc.zoomLevel),
 			}];
 		}
 	}
@@ -120,6 +122,8 @@ void restoreSession()
 					ctx().documents[idx].encoding = [tab[@"encoding"] intValue];
 				if (tab[@"eolMode"])
 					ctx().documents[idx].eolMode = [tab[@"eolMode"] intValue];
+				if (tab[@"zoomLevel"])
+					ctx().documents[idx].zoomLevel = [tab[@"zoomLevel"] intValue];
 			}
 		}
 	}
@@ -170,6 +174,8 @@ void restoreSession()
 							ctx().documents2[idx].encoding = [tab[@"encoding"] intValue];
 						if (tab[@"eolMode"])
 							ctx().documents2[idx].eolMode = [tab[@"eolMode"] intValue];
+						if (tab[@"zoomLevel"])
+							ctx().documents2[idx].zoomLevel = [tab[@"zoomLevel"] intValue];
 					}
 				}
 

--- a/macos/platform/session_manager.mm
+++ b/macos/platform/session_manager.mm
@@ -123,7 +123,13 @@ void restoreSession()
 				if (tab[@"eolMode"])
 					ctx().documents[idx].eolMode = [tab[@"eolMode"] intValue];
 				if (tab[@"zoomLevel"])
+				{
 					ctx().documents[idx].zoomLevel = [tab[@"zoomLevel"] intValue];
+					// Apply zoom to Scintilla immediately so saveViewState()
+					// reads the correct value when the next tab is opened
+					ScintillaBridge_sendMessage(ctx().scintillaView, SCI_SETZOOM,
+					                            ctx().documents[idx].zoomLevel, 0);
+				}
 			}
 		}
 	}
@@ -175,7 +181,11 @@ void restoreSession()
 						if (tab[@"eolMode"])
 							ctx().documents2[idx].eolMode = [tab[@"eolMode"] intValue];
 						if (tab[@"zoomLevel"])
+						{
 							ctx().documents2[idx].zoomLevel = [tab[@"zoomLevel"] intValue];
+							ScintillaBridge_sendMessage(ctx().scintillaView2, SCI_SETZOOM,
+							                            ctx().documents2[idx].zoomLevel, 0);
+						}
 					}
 				}
 

--- a/macos/platform/settings_manager.h
+++ b/macos/platform/settings_manager.h
@@ -21,7 +21,6 @@ struct AppSettings
 	// View state
 	bool wordWrap = false;
 	bool showLineNumbers = true;
-	int zoomLevel = 0;
 	bool showCaretLine = true;
 	bool autoIndent = true;
 	bool autoCloseBrackets = true;

--- a/macos/platform/settings_manager.mm
+++ b/macos/platform/settings_manager.mm
@@ -73,7 +73,6 @@ bool SettingsManager::load()
 	// View state
 	if ([json[@"wordWrap"] isKindOfClass:[NSNumber class]])        settings.wordWrap = [json[@"wordWrap"] boolValue];
 	if ([json[@"showLineNumbers"] isKindOfClass:[NSNumber class]]) settings.showLineNumbers = [json[@"showLineNumbers"] boolValue];
-	if ([json[@"zoomLevel"] isKindOfClass:[NSNumber class]])       settings.zoomLevel = [json[@"zoomLevel"] intValue];
 	if ([json[@"showCaretLine"] isKindOfClass:[NSNumber class]])   settings.showCaretLine = [json[@"showCaretLine"] boolValue];
 	if ([json[@"autoIndent"] isKindOfClass:[NSNumber class]])      settings.autoIndent = [json[@"autoIndent"] boolValue];
 	if ([json[@"autoCloseBrackets"] isKindOfClass:[NSNumber class]]) settings.autoCloseBrackets = [json[@"autoCloseBrackets"] boolValue];
@@ -144,7 +143,6 @@ bool SettingsManager::save()
 		@"tabWidth":     @(settings.tabWidth),
 		@"wordWrap":     @(settings.wordWrap),
 		@"showLineNumbers": @(settings.showLineNumbers),
-		@"zoomLevel":    @(settings.zoomLevel),
 		@"showCaretLine": @(settings.showCaretLine),
 		@"autoIndent":   @(settings.autoIndent),
 		@"autoCloseBrackets": @(settings.autoCloseBrackets),

--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -21,6 +21,7 @@
 #include "document_map.h"
 #include "function_list_panel.h"
 #include "scintilla_notify.h"
+#include "macro_manager.h"
 #include "windows.h"
 #include "commctrl.h"
 
@@ -219,6 +220,11 @@ void doSplit()
 								scheduleFunctionListRefresh();
 							}
 						}
+					}
+					else if (scn->nmhdr.code == SCN_MACRORECORD)
+					{
+						if (MacroManager::instance().isRecording())
+							MacroManager::instance().recordStep(scn->message, scn->wParam, scn->lParam);
 					}
 				}
 			});

--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -384,6 +384,7 @@ void doMoveToOtherView()
 		dstDocs[dstIdx].anchorPos = docCopy.anchorPos;
 		dstDocs[dstIdx].firstVisibleLine = docCopy.firstVisibleLine;
 		dstDocs[dstIdx].bookmarkedLines = docCopy.bookmarkedLines;
+		dstDocs[dstIdx].zoomLevel = docCopy.zoomLevel;
 	}
 
 	closeTabFromView(srcView, srcTab);
@@ -416,5 +417,6 @@ void doCloneToOtherView()
 		dstDocs[dstIdx].anchorPos = docCopy.anchorPos;
 		dstDocs[dstIdx].firstVisibleLine = docCopy.firstVisibleLine;
 		dstDocs[dstIdx].bookmarkedLines = docCopy.bookmarkedLines;
+		dstDocs[dstIdx].zoomLevel = docCopy.zoomLevel;
 	}
 }

--- a/macos/platform/wndproc.mm
+++ b/macos/platform/wndproc.mm
@@ -349,6 +349,33 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 				case IDM_EDIT_SORTDESC:
 					doSortLines(false);
 					return 0;
+				case IDM_EDIT_SENTENCECASE:
+					doSentenceCase();
+					return 0;
+				case IDM_EDIT_INVERTCASE:
+					doInvertCase();
+					return 0;
+				case IDM_EDIT_CAMELCASE:
+					doCamelCase();
+					return 0;
+				case IDM_EDIT_SNAKECASE:
+					doSnakeCase();
+					return 0;
+				case IDM_EDIT_SORT_CASE_INSENSITIVE:
+					doSortLinesCaseInsensitive();
+					return 0;
+				case IDM_EDIT_SORT_REVERSE:
+					doSortLinesReverse();
+					return 0;
+				case IDM_EDIT_REMOVE_DUPLICATES:
+					doRemoveDuplicateLines();
+					return 0;
+				case IDM_EDIT_SORT_NUMERIC:
+					doSortLinesNumeric();
+					return 0;
+				case IDM_EDIT_SORT_RANDOM:
+					doSortLinesRandom();
+					return 0;
 				case IDM_EDIT_JOINLINES:
 					doJoinLines();
 					return 0;

--- a/macos/platform/wndproc.mm
+++ b/macos/platform/wndproc.mm
@@ -33,6 +33,7 @@
 #include "function_list_panel.h"
 #include "change_history.h"
 #include "hash_tools.h"
+#include "macro_manager.h"
 #include "windows.h"
 #include "commctrl.h"
 
@@ -562,6 +563,37 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 					return 0;
 				case IDM_TOOLS_HASH_SHA512:
 					doHashSHA512();
+					return 0;
+
+				case IDM_MACRO_START_RECORD:
+				{
+					void* sci = ctx().activeScintillaView();
+					if (sci) MacroManager::instance().startRecording(sci);
+					return 0;
+				}
+				case IDM_MACRO_STOP_RECORD:
+				{
+					void* sci = ctx().activeScintillaView();
+					if (sci) MacroManager::instance().stopRecording(sci);
+					return 0;
+				}
+				case IDM_MACRO_PLAYBACK:
+				{
+					void* sci = ctx().activeScintillaView();
+					if (sci) MacroManager::instance().playback(sci);
+					return 0;
+				}
+				case IDM_MACRO_PLAYBACK_MULTI:
+				{
+					void* sci = ctx().activeScintillaView();
+					if (sci) MacroManager::instance().playbackMultiple(sci, 0);
+					return 0;
+				}
+				case IDM_MACRO_SAVE:
+					MacroManager::instance().saveMacro("");
+					return 0;
+				case IDM_MACRO_LOAD:
+					MacroManager::instance().loadMacro("");
 					return 0;
 
 				case IDM_HELP_ABOUT:

--- a/macos/platform/wndproc.mm
+++ b/macos/platform/wndproc.mm
@@ -32,6 +32,7 @@
 #include "document_map.h"
 #include "function_list_panel.h"
 #include "change_history.h"
+#include "hash_tools.h"
 #include "windows.h"
 #include "commctrl.h"
 
@@ -548,6 +549,19 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 					return 0;
 				case IDM_VIEW_CLONETOOTHER:
 					doCloneToOtherView();
+					return 0;
+
+				case IDM_TOOLS_HASH_MD5:
+					doHashMD5();
+					return 0;
+				case IDM_TOOLS_HASH_SHA1:
+					doHashSHA1();
+					return 0;
+				case IDM_TOOLS_HASH_SHA256:
+					doHashSHA256();
+					return 0;
+				case IDM_TOOLS_HASH_SHA512:
+					doHashSHA512();
 					return 0;
 
 				case IDM_HELP_ABOUT:

--- a/macos/platform/wndproc.mm
+++ b/macos/platform/wndproc.mm
@@ -367,33 +367,43 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
 				case IDM_VIEW_ZOOMIN:
 				{
-					if (ctx().scintillaView)
-						ScintillaBridge_sendMessage(ctx().scintillaView, SCI_ZOOMIN, 0, 0);
-					if (ctx().isSplit && ctx().scintillaView2)
-						ScintillaBridge_sendMessage(ctx().scintillaView2, SCI_ZOOMIN, 0, 0);
-					if (ctx().scintillaView)
-						ctx().zoomLevel = static_cast<int>(ScintillaBridge_sendMessage(ctx().scintillaView, SCI_GETZOOM, 0, 0));
+					void* sci = ctx().activeScintillaView();
+					if (sci)
+					{
+						ScintillaBridge_sendMessage(sci, SCI_ZOOMIN, 0, 0);
+						auto& docs = ctx().activeDocuments();
+						int tabIdx = ctx().activeTabIndex();
+						if (tabIdx >= 0 && tabIdx < static_cast<int>(docs.size()))
+							docs[tabIdx].zoomLevel = static_cast<int>(ScintillaBridge_sendMessage(sci, SCI_GETZOOM, 0, 0));
+					}
 					refreshLineNumberMargins();
 					return 0;
 				}
 				case IDM_VIEW_ZOOMOUT:
 				{
-					if (ctx().scintillaView)
-						ScintillaBridge_sendMessage(ctx().scintillaView, SCI_ZOOMOUT, 0, 0);
-					if (ctx().isSplit && ctx().scintillaView2)
-						ScintillaBridge_sendMessage(ctx().scintillaView2, SCI_ZOOMOUT, 0, 0);
-					if (ctx().scintillaView)
-						ctx().zoomLevel = static_cast<int>(ScintillaBridge_sendMessage(ctx().scintillaView, SCI_GETZOOM, 0, 0));
+					void* sci = ctx().activeScintillaView();
+					if (sci)
+					{
+						ScintillaBridge_sendMessage(sci, SCI_ZOOMOUT, 0, 0);
+						auto& docs = ctx().activeDocuments();
+						int tabIdx = ctx().activeTabIndex();
+						if (tabIdx >= 0 && tabIdx < static_cast<int>(docs.size()))
+							docs[tabIdx].zoomLevel = static_cast<int>(ScintillaBridge_sendMessage(sci, SCI_GETZOOM, 0, 0));
+					}
 					refreshLineNumberMargins();
 					return 0;
 				}
 				case IDM_VIEW_ZOOMRESTORE:
 				{
-					ctx().zoomLevel = 0;
-					if (ctx().scintillaView)
-						ScintillaBridge_sendMessage(ctx().scintillaView, SCI_SETZOOM, 0, 0);
-					if (ctx().isSplit && ctx().scintillaView2)
-						ScintillaBridge_sendMessage(ctx().scintillaView2, SCI_SETZOOM, 0, 0);
+					void* sci = ctx().activeScintillaView();
+					if (sci)
+					{
+						ScintillaBridge_sendMessage(sci, SCI_SETZOOM, 0, 0);
+						auto& docs = ctx().activeDocuments();
+						int tabIdx = ctx().activeTabIndex();
+						if (tabIdx >= 0 && tabIdx < static_cast<int>(docs.size()))
+							docs[tabIdx].zoomLevel = 0;
+					}
 					refreshLineNumberMargins();
 					return 0;
 				}


### PR DESCRIPTION
## Summary

- **Per-file zoom level (#71):** Zoom stored per document instead of globally, restored on tab switch, persisted in session. Global zoom removed from settings/app state.
- **Case conversions & sort variants (#29):** 4 new case conversions (sentence, invert, camelCase, snake_case) and 5 new line operations (case-insensitive sort, reverse, numeric, random, remove duplicates).
- **Hash tools (#27):** New Tools > Hash menu with MD5/SHA-1/SHA-256/SHA-512 using CommonCrypto. NSPanel result dialog with Copy/Insert at Cursor.
- **Macro recording & playback (#24):** Record/stop/playback via Scintilla's native SCI_STARTRECORD/STOPRECORD/SCN_MACRORECORD. Save/load named macros to ~/.npp-macos/macros.json. Repeat-count prompt.

## Review fixes applied

- Reset Scintilla zoom when closing last tab
- Expanded macro `isStringMessage()` to cover SCI_REPLACETARGET and other string-carrying messages
- Corrected Scintilla message IDs (SCI_ADDTEXT=2001, SCI_SEARCHNEXT=2367, SCI_SEARCHPREV=2368)
- Sort/line helpers now use document EOL mode instead of hardcoded LF
- Session restore applies SCI_SETZOOM immediately to prevent overwrite on next tab open
- Move/Clone to Other View now copies zoomLevel

## New files

- `macro_manager.h/.mm` — MacroManager singleton
- `hash_tools.h/.mm` — CommonCrypto hash pipeline + result dialog

## Test plan

- [ ] Open multiple files, set different zoom per tab, switch tabs — zoom follows each file
- [ ] Save session, restart app — per-file zoom restored correctly
- [ ] Select text, apply each new case conversion — verify output
- [ ] Select lines, run each sort variant — verify ordering and EOL preservation
- [ ] Run Remove Duplicate Lines — verify first-occurrence order preserved
- [ ] Hash selection and whole document with each algorithm — compare against known values
- [ ] Copy and Insert at Cursor buttons work in hash dialog
- [ ] Record a macro (type text, find/replace), stop, play back — reproduces steps
- [ ] Save macro, restart, load — playback still works
- [ ] Run Multiple Times with count prompt — repeats correctly
- [ ] Move/Clone tab to other view — zoom level preserved

Closes #71, closes #29, closes #27, closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)