### PR TITLE
Feature/1.1 panel layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ PowerEditor/src/MISC/md5/RCa06792
 *.db
 *.sln
 *.opendb
+.superpowers/

--- a/docs/superpowers/plans/2026-03-30-1.1-sprint-panels.md
+++ b/docs/superpowers/plans/2026-03-30-1.1-sprint-panels.md
@@ -12,6 +12,8 @@
 
 **Build command:** `cd macos/build && cmake --build . --target MacOSNotePP`
 
+**Review feedback addressed:** Concurrency guards for FSEvents, async icon caching, split-view behavior rules, inline rename validation, File Switcher unified-list semantics, path-display edge cases, cross-view switching helper, minimum panel width.
+
 ---
 
 ## File Map
@@ -46,6 +48,56 @@
 | `document_map.mm` | Replace `relayoutFunctionListPanel()` call with `relayoutPanels()` |
 | `split_view.mm` | Replace `relayoutFunctionListPanel()` calls with `relayoutPanels()` |
 | `CMakeLists.txt` | Add 6 new .mm source files to `add_executable()` |
+
+---
+
+## Cross-Cutting Design Rules
+
+These rules apply across multiple tasks. They were identified during code review of the initial plan.
+
+### Split-View Behavior
+
+- **File Switcher** shows a **unified list** from both views (`ctx().documents` + `ctx().documents2`). View 2 documents are appended below view 1 documents with a subtle section divider row.
+- **File Browser** opens files into the **active editor view** (`ctx().activeView`). The workspace root is **window-global** (not per-view).
+- **Cross-view switching** uses a dedicated helper `switchToDocumentInSwitcher(row)` that sets both `ctx().activeView` and the tab index atomically via `switchToTabInView(viewIndex, tabIndex)`.
+
+### Concurrency: FSEvents + Lazy Loading
+
+- All FSEvents callbacks and tree mutations must run on a **serial dispatch queue** (`dispatch_queue_create("com.macnotepp.filebrowser", DISPATCH_QUEUE_SERIAL)`).
+- The debounced refresh dispatches the reload to the **main queue** for UI updates.
+- `loadChildren()` must guard against re-entrant calls by checking `childrenLoaded` before any mutation.
+
+### File Icon Caching
+
+- Use a static `NSCache<NSString*, NSImage*>` keyed by file extension (not full path).
+- Cache lookup on main thread. On cache miss, use a generic icon immediately and schedule async icon load via `dispatch_async` to a background queue.
+- After async load completes, dispatch back to main queue to update the cell if still visible.
+
+### Inline Rename/Create Validation
+
+- **Empty names:** Reject with `NSBeep()`, keep the field editor active.
+- **Illegal characters** (`:`, `/`): Reject with an inline error tooltip.
+- **Permission errors:** Show `NSAlert` with the POSIX error description.
+- **Cancel:** Pressing Escape ends editing, removes the placeholder row (for new file/folder), or reverts the name (for rename).
+- **Confirm:** Pressing Enter commits. For new file: `[[NSFileManager defaultManager] createFileAtPath:...]`. For new folder: `createDirectoryAtPath:...`.
+
+### File Switcher: Path Display Edge Cases
+
+- **File outside workspace root:** Show the full parent directory path (no stripping).
+- **No folder set in File Browser:** Show the file's parent directory name only (last path component of parent).
+- **Workspace root changes:** `reloadFileSwitcherData()` is called when `openFolderInFileBrowser()` sets a new root, which refreshes all displayed paths.
+- **Untitled/unsaved files:** Show "(unsaved)" as the path.
+
+### File Switcher: Scope Change from Original Issue
+
+The original issue (#35) specified a multi-column sortable table. This v1 implementation uses a **single-column compact list** with tab-order sorting. Sortable columns are deferred to a future iteration. This is an intentional simplification to keep the panel narrow and consistent with the left-zone layout.
+
+### Minimum Panel Widths
+
+- Left zone minimum practical width: **120px** (below this, filenames truncate badly)
+- Right zone minimum practical width: **120px**
+- Collapse threshold remains **60px** — between 60-120px the panel is usable but cramped
+- Filename truncation uses `NSLineBreakByTruncatingMiddle` for the File Switcher and `NSLineBreakByTruncatingTail` for the File Browser
 
 ---
 
@@ -831,9 +883,33 @@ Follow the pattern from `clipboard_history_panel.mm`. Key components:
 
 - (NSInteger)numberOfRowsInTableView:(NSTableView*)tableView
 {
+    // Unified list: view 1 docs + separator row (if split) + view 2 docs
     auto& docs = ctx().documents;
-    auto& docs2 = ctx().documents2;
-    return static_cast<NSInteger>(docs.size() + (ctx().isSplit ? docs2.size() : 0));
+    NSInteger count = static_cast<NSInteger>(docs.size());
+    if (ctx().isSplit) {
+        count += 1;  // separator row
+        count += static_cast<NSInteger>(ctx().documents2.size());
+    }
+    return count;
+}
+
+// Helper: resolve row index to (viewIndex, docIndex). Returns false for separator rows.
+static bool resolveRow(NSInteger row, int& viewIndex, size_t& docIndex)
+{
+    size_t view1Count = ctx().documents.size();
+    if (static_cast<size_t>(row) < view1Count) {
+        viewIndex = 0;
+        docIndex = static_cast<size_t>(row);
+        return true;
+    }
+    if (ctx().isSplit) {
+        size_t separatorRow = view1Count;
+        if (static_cast<size_t>(row) == separatorRow) return false;  // separator
+        viewIndex = 1;
+        docIndex = static_cast<size_t>(row) - separatorRow - 1;
+        return docIndex < ctx().documents2.size();
+    }
+    return false;
 }
 
 - (NSView*)tableView:(NSTableView*)tableView viewForTableColumn:(NSTableColumn*)column row:(NSInteger)row
@@ -874,16 +950,26 @@ Follow the pattern from `clipboard_history_panel.mm`. Key components:
         [cell addSubview:pathLabel];
     }
 
-    // Get document data for this row
-    auto& docs = ctx().documents;
-    size_t docIndex = static_cast<size_t>(row);
-    bool isView2 = false;
-    if (ctx().isSplit && docIndex >= docs.size()) {
-        docIndex -= docs.size();
-        isView2 = true;
+    // Handle separator row between view 1 and view 2
+    int viewIndex = 0;
+    size_t docIndex = 0;
+    if (!resolveRow(row, viewIndex, docIndex)) {
+        // This is the separator row — return a simple divider cell
+        NSTableCellView* sepCell = [tableView makeViewWithIdentifier:@"SeparatorCell" owner:self];
+        if (!sepCell) {
+            sepCell = [[NSTableCellView alloc] initWithFrame:NSMakeRect(0, 0, 200, 18)];
+            sepCell.identifier = @"SeparatorCell";
+            NSTextField* label = [NSTextField labelWithString:@"— Split View —"];
+            label.frame = NSMakeRect(8, 0, 184, 18);
+            label.font = [NSFont systemFontOfSize:9 weight:NSFontWeightMedium];
+            label.textColor = [NSColor tertiaryLabelColor];
+            label.alignment = NSTextAlignmentCenter;
+            [sepCell addSubview:label];
+        }
+        return sepCell;
     }
 
-    auto& docList = isView2 ? ctx().documents2 : docs;
+    auto& docList = (viewIndex == 1) ? ctx().documents2 : ctx().documents;
     if (docIndex < docList.size()) {
         auto& doc = docList[docIndex];
 
@@ -897,20 +983,33 @@ Follow the pattern from `clipboard_history_panel.mm`. Key components:
         nameLabel.stringValue = @(filename.c_str());
 
         // Bold for active document
-        bool isActive = (!isView2 && static_cast<int>(docIndex) == ctx().activeTab)
-                     || (isView2 && static_cast<int>(docIndex) == ctx().activeTab2);
+        bool isActive = (viewIndex == 0 && static_cast<int>(docIndex) == ctx().activeTab && ctx().activeView == 0)
+                     || (viewIndex == 1 && static_cast<int>(docIndex) == ctx().activeTab2 && ctx().activeView == 1);
         nameLabel.font = isActive
             ? [NSFont systemFontOfSize:12 weight:NSFontWeightBold]
             : [NSFont systemFontOfSize:12 weight:NSFontWeightRegular];
 
-        // Relative path
+        // Relative path — handle edge cases
         NSTextField* pathLabel = (NSTextField*)[cell viewWithTag:102];
-        std::string displayPath = doc.filePath;
-        if (!ctx().fileBrowserRootPath.empty() &&
-            displayPath.find(ctx().fileBrowserRootPath) == 0) {
-            displayPath = displayPath.substr(ctx().fileBrowserRootPath.size());
+        std::string displayPath;
+        if (doc.filePath.empty()) {
+            // Untitled/unsaved file
+            displayPath = "(unsaved)";
+        } else if (!ctx().fileBrowserRootPath.empty() &&
+                   doc.filePath.find(ctx().fileBrowserRootPath) == 0) {
+            // File inside workspace — show relative path
+            displayPath = doc.filePath.substr(ctx().fileBrowserRootPath.size());
             if (!displayPath.empty() && displayPath[0] == '/')
                 displayPath = displayPath.substr(1);
+        } else {
+            // File outside workspace or no workspace set — show parent directory name
+            size_t lastSlash = doc.filePath.rfind('/');
+            if (lastSlash != std::string::npos && lastSlash > 0) {
+                size_t prevSlash = doc.filePath.rfind('/', lastSlash - 1);
+                displayPath = (prevSlash != std::string::npos)
+                    ? doc.filePath.substr(prevSlash + 1, lastSlash - prevSlash - 1)
+                    : doc.filePath.substr(0, lastSlash);
+            }
         }
         pathLabel.stringValue = @(displayPath.c_str());
     }
@@ -935,18 +1034,15 @@ static NSView* sContainer = nil;
 static FileSwitcherTableView* sTableView = nil;
 static FileSwitcherController* sController = nil;
 
+// Cross-view switching helper: resolves row to (view, tab) and switches atomically
 static void switchToDocumentAtRow(NSInteger row)
 {
-    auto& docs = ctx().documents;
-    size_t docIndex = static_cast<size_t>(row);
-    bool isView2 = false;
-    if (ctx().isSplit && docIndex >= docs.size()) {
-        docIndex -= docs.size();
-        isView2 = true;
-    }
-    // Call switchToTabInView(viewIndex, tabIndex)
+    int viewIndex = 0;
+    size_t docIndex = 0;
+    if (!resolveRow(row, viewIndex, docIndex)) return;  // separator row — no-op
+
     extern void switchToTabInView(int viewIndex, int tabIndex);
-    switchToTabInView(isView2 ? 1 : 0, static_cast<int>(docIndex));
+    switchToTabInView(viewIndex, static_cast<int>(docIndex));
 }
 
 // --- Context menu ---
@@ -1068,13 +1164,20 @@ And remove the local stub function.
 "${CMAKE_CURRENT_SOURCE_DIR}/platform/file_switcher_panel.mm"
 ```
 
-- [ ] **Step 5: Wire into document_manager.mm**
+- [ ] **Step 5: Wire into document_manager.mm — explicit rebind points**
 
-Add `#include "file_switcher_panel.h"` and call `bindFileSwitcherToActiveView()` in:
+Add `#include "file_switcher_panel.h"` and wire these notification points:
 
-- `switchToTabInView()` — after `bindFunctionListToActiveView()` (line ~131)
-- `addNewTabToView()` — after `bindFunctionListToActiveView()` (line ~197), also call `reloadFileSwitcherData()`
-- `closeTabFromView()` — after `bindFunctionListToActiveView()` (line ~272), also call `reloadFileSwitcherData()`
+| Event | Function | Line | Call |
+|-------|----------|------|------|
+| Tab switched | `switchToTabInView()` | ~131 | `bindFileSwitcherToActiveView()` — updates active row highlight |
+| Tab opened | `addNewTabToView()` | ~197 | `reloadFileSwitcherData()` — adds row to list |
+| Tab closed | `closeTabFromView()` | ~272 | `reloadFileSwitcherData()` — removes row from list |
+| Active view changed (split) | `switchToTabInView()` | ~131 | `bindFileSwitcherToActiveView()` — already covered, handles view switch |
+| Save point left/reached | Scintilla notify callback in `app_delegate.mm` | varies | `reloadFileSwitcherData()` — updates modified dot |
+| File renamed | wherever rename updates DocumentData | varies | `reloadFileSwitcherData()` — updates displayed filename |
+
+The `SCN_SAVEPOINTLEFT` / `SCN_SAVEPOINTREACHED` notification wiring should be added where the existing Scintilla notification callback handles these events (search for `SCN_SAVEPOINTLEFT` in `app_delegate.mm`).
 
 - [ ] **Step 6: Build and verify**
 
@@ -1085,7 +1188,14 @@ Launch and manually test:
 - Open multiple files — verify they appear in the list
 - Click a row — verify it switches to that tab
 - Modify a file — verify the orange dot appears
+- Save the file — verify the orange dot disappears
 - Close a file — verify it disappears from the list
+- Enable split view → verify "— Split View —" separator row appears between the two view sections
+- Click a file in the view 2 section → verify it switches to view 2 and selects that tab
+- Open a workspace folder → verify relative paths update in the File Switcher
+- Open a file outside the workspace → verify it shows parent directory name, not relative path
+- Create a new untitled file → verify it shows "(unsaved)" as path
+- Resize left panel narrow (~120px) → verify filename truncation is readable
 
 - [ ] **Step 7: Commit**
 
@@ -1132,6 +1242,48 @@ void* fileBrowserContainerView();
 #include <string>
 #include <algorithm>
 
+// --- Serial queue for thread-safe tree mutations ---
+static dispatch_queue_t sFileBrowserQueue = nil;
+
+static dispatch_queue_t fileBrowserQueue()
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sFileBrowserQueue = dispatch_queue_create("com.macnotepp.filebrowser",
+                                                   DISPATCH_QUEUE_SERIAL);
+    });
+    return sFileBrowserQueue;
+}
+
+// --- Icon Cache ---
+static NSCache<NSString*, NSImage*>* sIconCache = nil;
+
+static NSCache* iconCache()
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sIconCache = [[NSCache alloc] init];
+        sIconCache.countLimit = 200;
+    });
+    return sIconCache;
+}
+
+static NSImage* cachedIconForPath(NSString* path, bool isDirectory)
+{
+    // Cache by extension (or "folder" for directories)
+    NSString* cacheKey = isDirectory ? @"__folder__" : [path pathExtension];
+    if (cacheKey.length == 0) cacheKey = @"__noext__";
+
+    NSImage* cached = [iconCache() objectForKey:cacheKey];
+    if (cached) return cached;
+
+    // Synchronous load for first occurrence of each extension
+    NSImage* icon = [[NSWorkspace sharedWorkspace] iconForFile:path];
+    [icon setSize:NSMakeSize(16, 16)];
+    [iconCache() setObject:icon forKey:cacheKey];
+    return icon;
+}
+
 // --- Data Model ---
 
 struct FileBrowserNode {
@@ -1151,6 +1303,7 @@ static bool shouldIgnore(const std::string& name)
     return false;
 }
 
+// Must be called on fileBrowserQueue() or with guarantee of no concurrent access
 static void loadChildren(FileBrowserNode& node)
 {
     if (node.childrenLoaded || !node.isDirectory) return;
@@ -1288,9 +1441,7 @@ Then implement the full data source:
     }
 
     cell.textField.stringValue = @(node->filename.c_str());
-    cell.imageView.image = [[NSWorkspace sharedWorkspace]
-        iconForFile:@(node->path.c_str())];
-    [cell.imageView.image setSize:NSMakeSize(16, 16)];
+    cell.imageView.image = cachedIconForPath(@(node->path.c_str()), node->isDirectory);
 
     return cell;
 }
@@ -1316,23 +1467,33 @@ static void fsEventsCallback(ConstFSEventStreamRef streamRef,
                              const FSEventStreamEventFlags eventFlags[],
                              const FSEventStreamEventId eventIds[])
 {
-    // Debounce: cancel pending timer, schedule new one at 500ms
-    if (sDebounceTimer) {
-        dispatch_source_cancel(sDebounceTimer);
-    }
-    sDebounceTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0,
-                                            dispatch_get_main_queue());
-    dispatch_source_set_timer(sDebounceTimer,
-                              dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
-                              DISPATCH_TIME_FOREVER, 100 * NSEC_PER_MSEC);
-    dispatch_source_set_event_handler(sDebounceTimer, ^{
-        // Reload the changed subtree
-        // For simplicity in v1: mark children as unloaded and reload outline view
-        sRootNode.childrenLoaded = false;
-        extern NSOutlineView* sOutlineView;
-        [sOutlineView reloadData];
+    // Debounce on the serial queue to avoid racing with loadChildren()
+    dispatch_async(fileBrowserQueue(), ^{
+        if (sDebounceTimer) {
+            dispatch_source_cancel(sDebounceTimer);
+        }
+        sDebounceTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0,
+                                                fileBrowserQueue());
+        dispatch_source_set_timer(sDebounceTimer,
+                                  dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
+                                  DISPATCH_TIME_FOREVER, 100 * NSEC_PER_MSEC);
+        dispatch_source_set_event_handler(sDebounceTimer, ^{
+            // Invalidate loaded children so next access reloads from disk
+            // Walk the tree and mark all nodes as unloaded
+            std::function<void(FileBrowserNode&)> invalidate = [&](FileBrowserNode& node) {
+                node.childrenLoaded = false;
+                for (auto& child : node.children) invalidate(child);
+            };
+            invalidate(sRootNode);
+
+            // Dispatch UI reload to main queue
+            dispatch_async(dispatch_get_main_queue(), ^{
+                extern NSOutlineView* sOutlineView;
+                [sOutlineView reloadData];
+            });
+        });
+        dispatch_resume(sDebounceTimer);
     });
-    dispatch_resume(sDebounceTimer);
 }
 
 static void startFSEventsMonitoring(const std::string& path)
@@ -1393,7 +1554,39 @@ Implement action methods on `FileBrowserController`:
 - `deleteAction:` — show confirmation alert, then `[[NSWorkspace sharedWorkspace] recycleURLs:@[url] completionHandler:nil]`
 - `revealInFinderAction:` — `[[NSWorkspace sharedWorkspace] selectFile:path inFileViewerRootedAtPath:@""]`
 - `copyPathAction:` — `[[NSPasteboard generalPasteboard] setString:path forType:NSPasteboardTypeString]`
-- `newFileAction:` / `newFolderAction:` / `renameAction:` — begin inline editing on the outline view row
+- `newFileAction:` / `newFolderAction:` — insert a temporary placeholder row, begin inline editing via `[sOutlineView editColumn:0 row:newRow withEvent:nil select:YES]`
+- `renameAction:` — begin inline editing on the selected row
+
+**Inline editing validation** (implement in `NSOutlineViewDelegate` method `outlineView:shouldEdit:item:`
+and the text field delegate `controlTextDidEndEditing:`):
+
+```objc
+// Validate the proposed name
+static bool validateFilename(NSString* name, NSString* parentPath, NSString** errorOut)
+{
+    if (name.length == 0) {
+        *errorOut = @"Name cannot be empty";
+        return false;
+    }
+    if ([name containsString:@"/"] || [name containsString:@":"]) {
+        *errorOut = @"Name cannot contain / or :";
+        return false;
+    }
+    NSString* fullPath = [parentPath stringByAppendingPathComponent:name];
+    if ([[NSFileManager defaultManager] fileExistsAtPath:fullPath]) {
+        *errorOut = @"An item with this name already exists";
+        return false;
+    }
+    return true;
+}
+
+// On confirm (Enter / end editing):
+// - Validate name. On failure: NSBeep(), show tooltip, keep field editor active.
+// - On success for new file: [[NSFileManager defaultManager] createFileAtPath:fullPath contents:nil attributes:nil]
+// - On success for new folder: [[NSFileManager defaultManager] createDirectoryAtPath:fullPath withIntermediateDirectories:NO attributes:nil error:&err]
+// - On permission error: show NSAlert with [err localizedDescription]
+// - On cancel (Escape): remove placeholder row (new) or revert name (rename)
+```
 
 - [ ] **Step 7: Implement panel init/destroy/set and Open Folder**
 
@@ -1464,7 +1657,9 @@ void initializeFileBrowserPanel()
     sOutlineView.dataSource = sController;
     sOutlineView.delegate = sController;
 
-    // Single-click to open file
+    // Single-click to open file in the active editor view (ctx().activeView)
+    // The click handler should check if the file is already open in any view.
+    // If open: switch to that tab. If not: open in the active view.
     sOutlineView.target = sController;
     sOutlineView.action = @selector(outlineViewClicked:);
 
@@ -1502,6 +1697,10 @@ void openFolderInFileBrowser(const std::string& path)
 
     [sOutlineView reloadData];
     startFSEventsMonitoring(path);
+
+    // Refresh File Switcher — path display changes when workspace root changes
+    extern void reloadFileSwitcherData();
+    reloadFileSwitcherData();
 }
 
 void openFolderWithDialog()
@@ -1568,9 +1767,15 @@ Launch and test:
 - Toggle File Browser panel from View menu → shows placeholder
 - File > Open Folder → select a folder → tree populates
 - Expand directories → children load lazily
-- Click a file → opens in editor
-- Right-click → context menu appears with all items
-- Create/delete a file externally → tree refreshes after ~500ms
+- Click a file → opens in the active editor view
+- Click a file already open → switches to its tab (no duplicate)
+- In split view: click a file → opens in whichever view is active
+- Right-click → context menu: New File, New Folder, Rename, Delete, Reveal in Finder, Copy Path
+- New File → inline edit field appears, Enter creates the file, Escape cancels
+- Rename → inline edit, enter "/" → rejected with beep, empty name → rejected
+- Delete → confirmation alert, file moves to Trash
+- Create/delete a file externally (e.g., `touch test.txt` in terminal) → tree refreshes after ~500ms
+- Rapidly expand/collapse while external changes happen → no crash (serial queue test)
 - Quit and relaunch → folder is remembered from settings
 
 - [ ] **Step 11: Commit**

--- a/docs/superpowers/plans/2026-03-30-1.1-sprint-panels.md
+++ b/docs/superpowers/plans/2026-03-30-1.1-sprint-panels.md
@@ -1,0 +1,1713 @@
+# 1.1 Sprint: Panels Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add File Browser and File Switcher panels to a new left zone, introduce resizable dividers across all panels, and restructure right-side panels to stack vertically.
+
+**Architecture:** Extend the existing manual frame layout with left-zone support and custom PanelDividerView drag handles. The layout orchestrator moves from `function_list_panel.mm` to a dedicated `panel_layout.mm`. Right-side panels (Function List, Clipboard History) switch from side-by-side columns to vertical stacking. Document Map stays glued to the editor.
+
+**Tech Stack:** C++20, Objective-C (AppKit: NSOutlineView, NSTableView, NSView), FSEvents API, CMake + Xcode generator
+
+**Spec:** `docs/superpowers/specs/2026-03-30-1.1-sprint-panels-design.md`
+
+**Build command:** `cd macos/build && cmake --build . --target MacOSNotePP`
+
+---
+
+## File Map
+
+### New Files (all under `macos/platform/`)
+
+| File | Responsibility |
+|------|---------------|
+| `panel_divider.h` | PanelDividerView @interface, orientation enum, creation helper |
+| `panel_divider.mm` | Drag tracking, cursor changes, collapse logic, double-click reset |
+| `panel_layout.h` | `relayoutPanels()` declaration, `layoutSplitTopTabBars()` forward decl |
+| `panel_layout.mm` | Central layout orchestrator — left zone, center block, right zone, dividers |
+| `file_switcher_panel.h` | init/destroy/set/bind declarations for File Switcher |
+| `file_switcher_panel.mm` | NSTableView, FileSwitcherController, tab-list UI |
+| `file_browser_panel.h` | init/destroy/set/bind declarations for File Browser |
+| `file_browser_panel.mm` | NSOutlineView, FileBrowserController, FSEvents, context menu |
+
+### Modified Files
+
+| File | What Changes |
+|------|-------------|
+| `app_state.h` | Add left/right zone fields to AppContext |
+| `npp_constants.h` | Add IDM_VIEW_FILEBROWSER (42088), IDM_VIEW_FILESWITCHER (42089), IDM_FILE_OPENFOLDER (42090) |
+| `settings_manager.mm` | Load/save new panel widths, ratios, root path |
+| `menu_builder.mm` | Add View menu items + File > Open Folder |
+| `wndproc.mm` | Add switch cases for new IDM commands + WM_INITMENUPOPUP updates |
+| `document_manager.mm` | Call `bindFileSwitcherToActiveView()` on tab switch/open/close |
+| `app_delegate.mm` | Initialize new panels at startup, replace `relayoutFunctionListPanel()` calls |
+| `function_list_panel.mm` | Remove `relayoutFunctionListPanel()`, call `relayoutPanels()` in setter |
+| `function_list_panel.h` | Remove `relayoutFunctionListPanel()` declaration |
+| `clipboard_history_panel.mm` | Replace `relayoutFunctionListPanel()` call with `relayoutPanels()` |
+| `document_map.mm` | Replace `relayoutFunctionListPanel()` call with `relayoutPanels()` |
+| `split_view.mm` | Replace `relayoutFunctionListPanel()` calls with `relayoutPanels()` |
+| `CMakeLists.txt` | Add 6 new .mm source files to `add_executable()` |
+
+---
+
+### Task 1: AppContext Fields and IDM Constants
+
+**Files:**
+- Modify: `macos/platform/app_state.h:89-94`
+- Modify: `macos/platform/npp_constants.h:113-116`
+
+- [ ] **Step 1: Add left zone and right zone fields to AppContext**
+
+In `app_state.h`, after the existing clipboard history fields (around line 94), add:
+
+```cpp
+// Left zone — File Browser + File Switcher
+bool fileBrowserEnabled = false;
+bool fileSwitcherEnabled = false;
+int leftPanelWidth = 200;
+CGFloat fileBrowserHeightRatio = 0.6;
+std::string fileBrowserRootPath;
+std::vector<std::string> fileBrowserIgnorePatterns = {
+    ".git", ".DS_Store", "node_modules", "__pycache__", ".build", "build"
+};
+
+// Right zone — replaces per-panel widths for Function List + Clipboard History
+int rightPanelWidth = 220;
+CGFloat functionListHeightRatio = 0.5;
+```
+
+- [ ] **Step 2: Add IDM constants for new menu commands**
+
+In `npp_constants.h`, after `IDM_VIEW_CLIPBOARD_HISTORY 42087` (line 116), add:
+
+```cpp
+#define IDM_VIEW_FILEBROWSER         42088
+#define IDM_VIEW_FILESWITCHER        42089
+#define IDM_FILE_OPENFOLDER          42090
+```
+
+- [ ] **Step 3: Build to verify no compilation errors**
+
+Run: `cd macos/build && cmake --build . --target MacOSNotePP 2>&1 | tail -5`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add macos/platform/app_state.h macos/platform/npp_constants.h
+git commit -m "feat: add AppContext fields and IDM constants for File Browser, File Switcher, and zone layout"
+```
+
+---
+
+### Task 2: Settings Persistence
+
+**Files:**
+- Modify: `macos/platform/settings_manager.mm:84-90,156-162`
+
+- [ ] **Step 1: Add new fields to the settings struct**
+
+Find the settings struct (or the JSON load section around line 84) and add load entries following the existing pattern:
+
+```objc
+if ([json[@"fileBrowser"] isKindOfClass:[NSNumber class]])      settings.fileBrowser = [json[@"fileBrowser"] boolValue];
+if ([json[@"fileSwitcher"] isKindOfClass:[NSNumber class]])     settings.fileSwitcher = [json[@"fileSwitcher"] boolValue];
+if ([json[@"leftPanelWidth"] isKindOfClass:[NSNumber class]])   settings.leftPanelWidth = [json[@"leftPanelWidth"] intValue];
+if ([json[@"fileBrowserHeightRatio"] isKindOfClass:[NSNumber class]]) settings.fileBrowserHeightRatio = [json[@"fileBrowserHeightRatio"] doubleValue];
+if ([json[@"fileBrowserRootPath"] isKindOfClass:[NSString class]]) settings.fileBrowserRootPath = [json[@"fileBrowserRootPath"] UTF8String];
+if ([json[@"rightPanelWidth"] isKindOfClass:[NSNumber class]])  settings.rightPanelWidth = [json[@"rightPanelWidth"] intValue];
+if ([json[@"functionListHeightRatio"] isKindOfClass:[NSNumber class]]) settings.functionListHeightRatio = [json[@"functionListHeightRatio"] doubleValue];
+```
+
+- [ ] **Step 2: Add save entries**
+
+In the save section (around line 156), add to the NSDictionary literal:
+
+```objc
+@"fileBrowser": @(settings.fileBrowser),
+@"fileSwitcher": @(settings.fileSwitcher),
+@"leftPanelWidth": @(settings.leftPanelWidth),
+@"fileBrowserHeightRatio": @(settings.fileBrowserHeightRatio),
+@"fileBrowserRootPath": settings.fileBrowserRootPath.empty() ? @"" : @(settings.fileBrowserRootPath.c_str()),
+@"rightPanelWidth": @(settings.rightPanelWidth),
+@"functionListHeightRatio": @(settings.functionListHeightRatio),
+```
+
+- [ ] **Step 3: Wire settings to AppContext in app_delegate.mm**
+
+Find where existing settings are applied to `ctx()` (e.g., `ctx().documentMapEnabled = settings.documentMap`) and add:
+
+```cpp
+ctx().fileBrowserEnabled = settings.fileBrowser;
+ctx().fileSwitcherEnabled = settings.fileSwitcher;
+ctx().leftPanelWidth = settings.leftPanelWidth;
+ctx().fileBrowserHeightRatio = settings.fileBrowserHeightRatio;
+ctx().fileBrowserRootPath = settings.fileBrowserRootPath;
+ctx().rightPanelWidth = settings.rightPanelWidth;
+ctx().functionListHeightRatio = settings.functionListHeightRatio;
+```
+
+And in the save path, populate settings from `ctx()` before saving.
+
+- [ ] **Step 4: Build to verify**
+
+Run: `cd macos/build && cmake --build . --target MacOSNotePP 2>&1 | tail -5`
+Expected: Build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add macos/platform/settings_manager.mm macos/platform/app_delegate.mm
+git commit -m "feat: persist File Browser, File Switcher, and zone layout settings"
+```
+
+---
+
+### Task 3: PanelDividerView
+
+**Files:**
+- Create: `macos/platform/panel_divider.h`
+- Create: `macos/platform/panel_divider.mm`
+- Modify: `macos/CMakeLists.txt:368`
+
+- [ ] **Step 1: Create panel_divider.h**
+
+```objc
+#pragma once
+#import <Cocoa/Cocoa.h>
+#include <functional>
+
+enum class DividerOrientation {
+    Vertical,    // between left/right zones (drag changes width)
+    Horizontal   // between stacked panels (drag changes height)
+};
+
+@interface PanelDividerView : NSView
+
+@property (nonatomic, assign) DividerOrientation orientation;
+@property (nonatomic, copy) void (^onDrag)(CGFloat delta);
+@property (nonatomic, copy) void (^onDoubleClick)(void);
+
+- (instancetype)initWithOrientation:(DividerOrientation)orientation;
+
+@end
+
+// C++ helper to create and add a divider between two views
+PanelDividerView* createPanelDivider(
+    DividerOrientation orientation,
+    NSView* parentView,
+    void (^onDrag)(CGFloat delta),
+    void (^onDoubleClick)(void)
+);
+```
+
+- [ ] **Step 2: Create panel_divider.mm**
+
+```objc
+#import "panel_divider.h"
+
+static const CGFloat kDividerThickness = 3.0;
+static const CGFloat kCollapseThreshold = 60.0;
+
+@implementation PanelDividerView
+{
+    NSPoint _dragStart;
+    BOOL _isDragging;
+}
+
+- (instancetype)initWithOrientation:(DividerOrientation)orientation
+{
+    self = [super initWithFrame:NSZeroRect];
+    if (self) {
+        _orientation = orientation;
+        _isDragging = NO;
+        self.wantsLayer = YES;
+        self.layer.backgroundColor = [[NSColor separatorColor] CGColor];
+    }
+    return self;
+}
+
+- (void)resetCursorRects
+{
+    if (_orientation == DividerOrientation::Vertical) {
+        [self addCursorRect:self.bounds cursor:[NSCursor resizeLeftRightCursor]];
+    } else {
+        [self addCursorRect:self.bounds cursor:[NSCursor resizeUpDownCursor]];
+    }
+}
+
+- (void)mouseDown:(NSEvent*)event
+{
+    _dragStart = [event locationInWindow];
+    _isDragging = YES;
+
+    if (event.clickCount == 2 && self.onDoubleClick) {
+        self.onDoubleClick();
+        _isDragging = NO;
+        return;
+    }
+}
+
+- (void)mouseDragged:(NSEvent*)event
+{
+    if (!_isDragging) return;
+
+    NSPoint current = [event locationInWindow];
+    CGFloat delta;
+
+    if (_orientation == DividerOrientation::Vertical) {
+        delta = current.x - _dragStart.x;
+    } else {
+        delta = current.y - _dragStart.y;
+    }
+
+    _dragStart = current;
+
+    if (self.onDrag) {
+        self.onDrag(delta);
+    }
+}
+
+- (void)mouseUp:(NSEvent*)event
+{
+    _isDragging = NO;
+}
+
+- (BOOL)acceptsFirstMouse:(NSEvent*)event
+{
+    return YES;
+}
+
+@end
+
+PanelDividerView* createPanelDivider(
+    DividerOrientation orientation,
+    NSView* parentView,
+    void (^onDrag)(CGFloat delta),
+    void (^onDoubleClick)(void))
+{
+    PanelDividerView* divider = [[PanelDividerView alloc] initWithOrientation:orientation];
+    divider.onDrag = onDrag;
+    divider.onDoubleClick = onDoubleClick;
+    divider.autoresizingMask = (orientation == DividerOrientation::Vertical)
+        ? NSViewHeightSizable
+        : NSViewWidthSizable;
+    [parentView addSubview:divider];
+    return divider;
+}
+```
+
+- [ ] **Step 3: Add to CMakeLists.txt**
+
+In `macos/CMakeLists.txt`, after the `clipboard_history_panel.mm` line (around line 368), add:
+
+```cmake
+"${CMAKE_CURRENT_SOURCE_DIR}/platform/panel_divider.mm"
+```
+
+- [ ] **Step 4: Build to verify**
+
+Run: `cd macos/build && cmake -G Xcode .. && cmake --build . --target MacOSNotePP 2>&1 | tail -5`
+Expected: Build succeeds. (cmake regeneration needed for new source file)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add macos/platform/panel_divider.h macos/platform/panel_divider.mm macos/CMakeLists.txt
+git commit -m "feat: add PanelDividerView — draggable resize handles with auto-collapse"
+```
+
+---
+
+### Task 4: Layout Orchestrator (`relayoutPanels`)
+
+**Files:**
+- Create: `macos/platform/panel_layout.h`
+- Create: `macos/platform/panel_layout.mm`
+- Modify: `macos/platform/function_list_panel.mm:559-647` (remove `relayoutFunctionListPanel()`)
+- Modify: `macos/platform/function_list_panel.h` (remove declaration)
+- Modify: `macos/platform/clipboard_history_panel.mm:326` (update call)
+- Modify: `macos/platform/document_map.mm:172` (update call)
+- Modify: `macos/platform/split_view.mm:280,353` (update calls)
+- Modify: `macos/platform/app_delegate.mm:649,657` (update calls)
+- Modify: `macos/CMakeLists.txt`
+
+- [ ] **Step 1: Create panel_layout.h**
+
+```objc
+#pragma once
+
+// Central layout orchestrator — positions all panels, dividers, and editor
+void relayoutPanels();
+
+// Collapse threshold for panel drag-to-hide
+static const CGFloat kPanelCollapseThreshold = 60.0;
+static const CGFloat kMinEditorWidth = 120.0;
+static const CGFloat kDividerThickness = 3.0;
+
+// Default widths for double-click reset
+static const int kDefaultLeftPanelWidth = 200;
+static const int kDefaultRightPanelWidth = 220;
+static const int kDefaultDocumentMapWidth = 140;
+```
+
+- [ ] **Step 2: Create panel_layout.mm — scaffold**
+
+Start with a function that reproduces the current behavior of `relayoutFunctionListPanel()`. Read the existing function at `function_list_panel.mm:559-647` carefully. The new version must:
+
+1. Calculate base content frame (window height minus tab bar minus status bar)
+2. Calculate left zone width (0 if no left panels enabled)
+3. Calculate document map width (existing logic)
+4. Calculate right zone width (0 if no right panels enabled)
+5. Add divider widths (3px each) for enabled zone boundaries
+6. Clamp total to preserve minimum editor width of 120px
+7. Position frames left-to-right: left zone → left divider → editor → doc map → right divider → right zone
+8. Within left zone: position File Browser (top) and File Switcher (bottom) with horizontal divider
+9. Within right zone: position Function List (top) and Clipboard History (bottom) with horizontal divider
+10. Call `ScintillaBridge_resizeToFit()` on Scintilla views
+11. Call `layoutSplitTopTabBars()` if split
+
+```objc
+#import "panel_layout.h"
+#import "panel_divider.h"
+#import "app_state.h"
+#import <Cocoa/Cocoa.h>
+
+// Forward declarations for panel container accessors
+extern void* functionListContainerView();
+extern void* clipboardHistoryContainerView();
+extern void* fileBrowserContainerView();
+extern void* fileSwitcherContainerView();
+extern void layoutSplitTopTabBars();
+
+// Static divider references — created once, repositioned on each relayout
+static PanelDividerView* sLeftDivider = nil;
+static PanelDividerView* sRightDivider = nil;
+static PanelDividerView* sLeftHorizontalDivider = nil;
+static PanelDividerView* sRightHorizontalDivider = nil;
+
+static void ensureDividersCreated()
+{
+    NSView* contentView = [ctx().mainWindow contentView];
+    if (!contentView) return;
+
+    if (!sLeftDivider) {
+        sLeftDivider = createPanelDivider(
+            DividerOrientation::Vertical, contentView,
+            ^(CGFloat delta) {
+                int newWidth = ctx().leftPanelWidth + static_cast<int>(delta);
+                if (newWidth < kPanelCollapseThreshold) {
+                    ctx().fileBrowserEnabled = false;
+                    ctx().fileSwitcherEnabled = false;
+                    ctx().leftPanelWidth = kDefaultLeftPanelWidth;
+                } else {
+                    ctx().leftPanelWidth = newWidth;
+                }
+                relayoutPanels();
+            },
+            ^{
+                ctx().leftPanelWidth = kDefaultLeftPanelWidth;
+                relayoutPanels();
+            }
+        );
+    }
+
+    if (!sRightDivider) {
+        sRightDivider = createPanelDivider(
+            DividerOrientation::Vertical, contentView,
+            ^(CGFloat delta) {
+                int newWidth = ctx().rightPanelWidth - static_cast<int>(delta);
+                if (newWidth < kPanelCollapseThreshold) {
+                    ctx().functionListEnabled = false;
+                    ctx().clipboardHistoryEnabled = false;
+                    ctx().rightPanelWidth = kDefaultRightPanelWidth;
+                } else {
+                    ctx().rightPanelWidth = newWidth;
+                }
+                relayoutPanels();
+            },
+            ^{
+                ctx().rightPanelWidth = kDefaultRightPanelWidth;
+                relayoutPanels();
+            }
+        );
+    }
+
+    if (!sLeftHorizontalDivider) {
+        sLeftHorizontalDivider = createPanelDivider(
+            DividerOrientation::Horizontal, contentView,
+            ^(CGFloat delta) {
+                NSView* contentView = [ctx().mainWindow contentView];
+                CGFloat totalHeight = contentView.frame.size.height;
+                CGFloat ratio = ctx().fileBrowserHeightRatio + (delta / totalHeight);
+                ctx().fileBrowserHeightRatio = fmax(0.15, fmin(0.85, ratio));
+                relayoutPanels();
+            },
+            ^{
+                ctx().fileBrowserHeightRatio = 0.6;
+                relayoutPanels();
+            }
+        );
+    }
+
+    if (!sRightHorizontalDivider) {
+        sRightHorizontalDivider = createPanelDivider(
+            DividerOrientation::Horizontal, contentView,
+            ^(CGFloat delta) {
+                NSView* contentView = [ctx().mainWindow contentView];
+                CGFloat totalHeight = contentView.frame.size.height;
+                CGFloat ratio = ctx().functionListHeightRatio + (delta / totalHeight);
+                ctx().functionListHeightRatio = fmax(0.15, fmin(0.85, ratio));
+                relayoutPanels();
+            },
+            ^{
+                ctx().functionListHeightRatio = 0.5;
+                relayoutPanels();
+            }
+        );
+    }
+}
+
+void relayoutPanels()
+{
+    if (!ctx().mainWindow || !ctx().editorContainer)
+        return;
+
+    NSView* contentView = [ctx().mainWindow contentView];
+    CGFloat windowWidth = contentView.frame.size.width;
+    CGFloat windowHeight = contentView.frame.size.height;
+
+    // Calculate vertical bounds (tab bar at top, status bar at bottom)
+    // Copy the existing tab bar / status bar offset logic from relayoutFunctionListPanel()
+    CGFloat tabBarHeight = /* existing value from relayoutFunctionListPanel */ 0;
+    CGFloat statusBarHeight = /* existing value */ 0;
+    CGFloat contentTop = windowHeight - tabBarHeight;
+    CGFloat contentHeight = contentTop - statusBarHeight;
+
+    ensureDividersCreated();
+
+    // --- Calculate zone widths ---
+    bool leftVisible = ctx().fileBrowserEnabled || ctx().fileSwitcherEnabled;
+    bool rightVisible = ctx().functionListEnabled || ctx().clipboardHistoryEnabled;
+    bool docMapVisible = ctx().documentMapEnabled;
+
+    CGFloat leftWidth = leftVisible ? static_cast<CGFloat>(ctx().leftPanelWidth) : 0;
+    CGFloat rightWidth = rightVisible ? static_cast<CGFloat>(ctx().rightPanelWidth) : 0;
+    CGFloat docMapWidth = docMapVisible ? static_cast<CGFloat>(ctx().documentMapWidth) : 0;
+
+    CGFloat leftDivW = leftVisible ? kDividerThickness : 0;
+    CGFloat rightDivW = rightVisible ? kDividerThickness : 0;
+
+    // Clamp to enforce minimum editor width
+    CGFloat totalPanels = leftWidth + leftDivW + docMapWidth + rightDivW + rightWidth;
+    CGFloat editorWidth = windowWidth - totalPanels;
+    if (editorWidth < kMinEditorWidth) {
+        CGFloat overflow = kMinEditorWidth - editorWidth;
+        // Proportionally reduce panel widths
+        CGFloat totalReducible = leftWidth + rightWidth;
+        if (totalReducible > 0) {
+            leftWidth = fmax(0, leftWidth - overflow * (leftWidth / totalReducible));
+            rightWidth = fmax(0, rightWidth - overflow * (rightWidth / totalReducible));
+        }
+        editorWidth = kMinEditorWidth;
+    }
+
+    // --- Position zones left-to-right ---
+    CGFloat x = 0;
+
+    // Left zone
+    if (leftVisible) {
+        // Position left zone panels within the zone
+        bool fbEnabled = ctx().fileBrowserEnabled;
+        bool fsEnabled = ctx().fileSwitcherEnabled;
+
+        NSView* fbContainer = (__bridge NSView*)fileBrowserContainerView();
+        NSView* fsContainer = (__bridge NSView*)fileSwitcherContainerView();
+
+        if (fbEnabled && fsEnabled) {
+            // Both visible — split vertically with horizontal divider
+            CGFloat fbHeight = contentHeight * ctx().fileBrowserHeightRatio;
+            CGFloat divH = kDividerThickness;
+            CGFloat fsHeight = contentHeight - fbHeight - divH;
+
+            if (fbContainer) {
+                fbContainer.frame = NSMakeRect(x, statusBarHeight + fsHeight + divH, leftWidth, fbHeight);
+                fbContainer.hidden = NO;
+            }
+            sLeftHorizontalDivider.frame = NSMakeRect(x, statusBarHeight + fsHeight, leftWidth, divH);
+            sLeftHorizontalDivider.hidden = NO;
+            if (fsContainer) {
+                fsContainer.frame = NSMakeRect(x, statusBarHeight, leftWidth, fsHeight);
+                fsContainer.hidden = NO;
+            }
+        } else if (fbEnabled) {
+            if (fbContainer) {
+                fbContainer.frame = NSMakeRect(x, statusBarHeight, leftWidth, contentHeight);
+                fbContainer.hidden = NO;
+            }
+            if (fsContainer) fsContainer.hidden = YES;
+            sLeftHorizontalDivider.hidden = YES;
+        } else if (fsEnabled) {
+            if (fsContainer) {
+                fsContainer.frame = NSMakeRect(x, statusBarHeight, leftWidth, contentHeight);
+                fsContainer.hidden = NO;
+            }
+            if (fbContainer) fbContainer.hidden = YES;
+            sLeftHorizontalDivider.hidden = YES;
+        }
+
+        x += leftWidth;
+        sLeftDivider.frame = NSMakeRect(x, statusBarHeight, kDividerThickness, contentHeight);
+        sLeftDivider.hidden = NO;
+        x += kDividerThickness;
+    } else {
+        sLeftDivider.hidden = YES;
+        sLeftHorizontalDivider.hidden = YES;
+        NSView* fbContainer = (__bridge NSView*)fileBrowserContainerView();
+        NSView* fsContainer = (__bridge NSView*)fileSwitcherContainerView();
+        if (fbContainer) fbContainer.hidden = YES;
+        if (fsContainer) fsContainer.hidden = YES;
+    }
+
+    // Center block (editor + document map)
+    CGFloat centerWidth = windowWidth - x - rightDivW - rightWidth;
+    CGFloat editorActualWidth = centerWidth - docMapWidth;
+
+    // Position editor container
+    NSView* editorContainer = (__bridge NSView*)ctx().editorContainer;
+    if (editorContainer) {
+        editorContainer.frame = NSMakeRect(x, statusBarHeight, editorActualWidth, contentHeight);
+    }
+    x += editorActualWidth;
+
+    // Position document map (glued to editor right edge)
+    if (docMapVisible) {
+        NSView* docMapContainer = ctx().documentMapContainer;
+        if (docMapContainer) {
+            docMapContainer.frame = NSMakeRect(x, statusBarHeight, docMapWidth, contentHeight);
+            docMapContainer.hidden = NO;
+        }
+        x += docMapWidth;
+    } else {
+        if (ctx().documentMapContainer) ctx().documentMapContainer.hidden = YES;
+    }
+
+    // Right zone
+    if (rightVisible) {
+        sRightDivider.frame = NSMakeRect(x, statusBarHeight, kDividerThickness, contentHeight);
+        sRightDivider.hidden = NO;
+        x += kDividerThickness;
+
+        bool flEnabled = ctx().functionListEnabled;
+        bool chEnabled = ctx().clipboardHistoryEnabled;
+
+        NSView* flContainer = (__bridge NSView*)functionListContainerView();
+        NSView* chContainer = (__bridge NSView*)clipboardHistoryContainerView();
+
+        if (flEnabled && chEnabled) {
+            CGFloat flHeight = contentHeight * ctx().functionListHeightRatio;
+            CGFloat divH = kDividerThickness;
+            CGFloat chHeight = contentHeight - flHeight - divH;
+
+            if (flContainer) {
+                flContainer.frame = NSMakeRect(x, statusBarHeight + chHeight + divH, rightWidth, flHeight);
+                flContainer.hidden = NO;
+            }
+            sRightHorizontalDivider.frame = NSMakeRect(x, statusBarHeight + chHeight, rightWidth, divH);
+            sRightHorizontalDivider.hidden = NO;
+            if (chContainer) {
+                chContainer.frame = NSMakeRect(x, statusBarHeight, rightWidth, chHeight);
+                chContainer.hidden = NO;
+            }
+        } else if (flEnabled) {
+            if (flContainer) {
+                flContainer.frame = NSMakeRect(x, statusBarHeight, rightWidth, contentHeight);
+                flContainer.hidden = NO;
+            }
+            if (chContainer) chContainer.hidden = YES;
+            sRightHorizontalDivider.hidden = YES;
+        } else if (chEnabled) {
+            if (chContainer) {
+                chContainer.frame = NSMakeRect(x, statusBarHeight, rightWidth, contentHeight);
+                chContainer.hidden = NO;
+            }
+            if (flContainer) flContainer.hidden = YES;
+            sRightHorizontalDivider.hidden = YES;
+        }
+    } else {
+        sRightDivider.hidden = YES;
+        sRightHorizontalDivider.hidden = YES;
+        NSView* flContainer = (__bridge NSView*)functionListContainerView();
+        NSView* chContainer = (__bridge NSView*)clipboardHistoryContainerView();
+        if (flContainer) flContainer.hidden = YES;
+        if (chContainer) chContainer.hidden = YES;
+    }
+
+    // Resize Scintilla views to fill editor container
+    // Copy ScintillaBridge_resizeToFit() calls from old relayoutFunctionListPanel()
+
+    // Handle split view tab bars
+    if (ctx().isSplit) {
+        layoutSplitTopTabBars();
+    }
+}
+```
+
+**Important:** This is a scaffold. The implementing engineer must read the existing `relayoutFunctionListPanel()` at `function_list_panel.mm:559-647` to copy the exact tab bar height, status bar height, Scintilla resize, and split view logic. The scaffold shows the zone positioning algorithm.
+
+- [ ] **Step 3: Add panel_layout.mm to CMakeLists.txt**
+
+After the panel_divider.mm entry, add:
+
+```cmake
+"${CMAKE_CURRENT_SOURCE_DIR}/platform/panel_layout.mm"
+```
+
+- [ ] **Step 4: Remove relayoutFunctionListPanel() from function_list_panel.mm**
+
+Delete the function body at lines 559-647 of `function_list_panel.mm`. Remove its declaration from `function_list_panel.h`.
+
+- [ ] **Step 5: Update all callers to use relayoutPanels()**
+
+Replace `relayoutFunctionListPanel()` with `relayoutPanels()` and add `#include "panel_layout.h"` in each of these files:
+
+- `function_list_panel.mm:654` — in `setFunctionListEnabled()`
+- `clipboard_history_panel.mm:326` — in `setClipboardHistoryEnabled()`
+- `document_map.mm:172` — in `setDocumentMapEnabled()`
+- `split_view.mm:280` — after split view creation
+- `split_view.mm:353` — after unsplit operation
+- `app_delegate.mm:649` — view sizing handler
+- `app_delegate.mm:657` — layout context
+
+- [ ] **Step 6: Add container view accessor functions**
+
+Each existing panel needs a function returning its container NSView*. Check if these already exist; if not, add them:
+
+In `function_list_panel.mm`, add or verify:
+```objc
+void* functionListContainerView() { return (__bridge void*)sContainer; }
+```
+
+In `clipboard_history_panel.mm`, add or verify:
+```objc
+void* clipboardHistoryContainerView() { return (__bridge void*)sContainer; }
+```
+
+Declare these in their respective headers.
+
+For the new panels (not yet created), add stub functions in `panel_layout.mm`:
+```objc
+// Stubs until panels are created — return nullptr
+void* fileBrowserContainerView() { return nullptr; }
+void* fileSwitcherContainerView() { return nullptr; }
+```
+
+- [ ] **Step 7: Build and manually verify**
+
+Run: `cd macos/build && cmake -G Xcode .. && cmake --build . --target MacOSNotePP 2>&1 | tail -10`
+
+Then launch the app and verify:
+- Existing panels (Function List, Clipboard History, Document Map) still toggle and display correctly
+- Window resizing still repositions panels properly
+- Split view still works
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add macos/platform/panel_layout.h macos/platform/panel_layout.mm \
+        macos/platform/function_list_panel.mm macos/platform/function_list_panel.h \
+        macos/platform/clipboard_history_panel.mm macos/platform/document_map.mm \
+        macos/platform/split_view.mm macos/platform/app_delegate.mm \
+        macos/CMakeLists.txt
+git commit -m "refactor: extract relayoutPanels() into panel_layout.mm with left/right zone support"
+```
+
+---
+
+### Task 5: Adapt Existing Right Panels to Vertical Stacking
+
+**Files:**
+- Modify: `macos/platform/function_list_panel.mm`
+- Modify: `macos/platform/clipboard_history_panel.mm`
+- Modify: `macos/platform/app_state.h`
+
+- [ ] **Step 1: Remove per-panel width fields from AppContext**
+
+In `app_state.h`, remove the individual width fields for Function List and Clipboard History:
+
+```cpp
+// Remove these:
+// int functionListWidth = 200;
+// int clipboardHistoryWidth = 220;
+```
+
+These are replaced by `rightPanelWidth` (already added in Task 1).
+
+- [ ] **Step 2: Update Function List to use rightPanelWidth**
+
+In `function_list_panel.mm`, find any references to `ctx().functionListWidth` and replace with `ctx().rightPanelWidth`. The actual frame positioning is now handled by `relayoutPanels()`, so these may only appear in initialization or container creation code.
+
+- [ ] **Step 3: Update Clipboard History to use rightPanelWidth**
+
+In `clipboard_history_panel.mm`, find any references to `ctx().clipboardHistoryWidth` and replace with `ctx().rightPanelWidth`.
+
+- [ ] **Step 4: Update settings_manager.mm**
+
+Remove the old `functionListWidth` and `clipboardHistoryWidth` load/save entries. They are replaced by `rightPanelWidth` (added in Task 2).
+
+- [ ] **Step 5: Update autoresizing masks**
+
+Both panels currently use `NSViewMinXMargin | NSViewHeightSizable` (stick to right, grow with height). Now that they're stacked vertically in a zone, they should use `NSViewWidthSizable` (fill zone width) instead. Update the autoresizing mask in the container creation code for both panels.
+
+- [ ] **Step 6: Build and verify**
+
+Run: `cd macos/build && cmake --build . --target MacOSNotePP 2>&1 | tail -5`
+
+Launch and verify:
+- Function List and Clipboard History both enabled → they stack vertically in the right zone
+- Only one enabled → it fills the full right zone height
+- Right zone divider drag resizes both panels
+- Horizontal divider between them adjusts the split ratio
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add macos/platform/function_list_panel.mm macos/platform/clipboard_history_panel.mm \
+        macos/platform/app_state.h macos/platform/settings_manager.mm
+git commit -m "refactor: stack Function List and Clipboard History vertically in right zone"
+```
+
+---
+
+### Task 6: File Switcher Panel
+
+**Files:**
+- Create: `macos/platform/file_switcher_panel.h`
+- Create: `macos/platform/file_switcher_panel.mm`
+- Modify: `macos/platform/document_manager.mm`
+- Modify: `macos/CMakeLists.txt`
+
+- [ ] **Step 1: Create file_switcher_panel.h**
+
+```objc
+#pragma once
+
+void initializeFileSwitcherPanel();
+void destroyFileSwitcherPanel();
+void setFileSwitcherEnabled(bool enabled);
+void bindFileSwitcherToActiveView();
+void reloadFileSwitcherData();
+void* fileSwitcherContainerView();
+```
+
+- [ ] **Step 2: Create file_switcher_panel.mm — controller and table view**
+
+Follow the pattern from `clipboard_history_panel.mm`. Key components:
+
+```objc
+#import "file_switcher_panel.h"
+#import "panel_layout.h"
+#import "app_state.h"
+#import <Cocoa/Cocoa.h>
+
+// Custom table view for Enter key handling
+@interface FileSwitcherTableView : NSTableView
+@end
+
+@implementation FileSwitcherTableView
+- (void)keyDown:(NSEvent*)event {
+    if (event.keyCode == 36) {  // Return key
+        [self.target performSelector:self.doubleAction withObject:self];
+        return;
+    }
+    [super keyDown:event];
+}
+@end
+
+// Data source and delegate
+@interface FileSwitcherController : NSObject <NSTableViewDataSource, NSTableViewDelegate>
+@end
+
+@implementation FileSwitcherController
+
+- (NSInteger)numberOfRowsInTableView:(NSTableView*)tableView
+{
+    auto& docs = ctx().documents;
+    auto& docs2 = ctx().documents2;
+    return static_cast<NSInteger>(docs.size() + (ctx().isSplit ? docs2.size() : 0));
+}
+
+- (NSView*)tableView:(NSTableView*)tableView viewForTableColumn:(NSTableColumn*)column row:(NSInteger)row
+{
+    // Create a two-line cell: bold filename + dimmer relative path
+    // Show modified dot (small colored circle) on left if document is modified
+    // Highlight active document row with subtle background
+
+    NSTableCellView* cell = [tableView makeViewWithIdentifier:@"FileSwitcherCell" owner:self];
+    if (!cell) {
+        cell = [[NSTableCellView alloc] initWithFrame:NSMakeRect(0, 0, 200, 36)];
+        cell.identifier = @"FileSwitcherCell";
+
+        // Modified dot (6px circle, left edge)
+        NSView* dot = [[NSView alloc] initWithFrame:NSMakeRect(4, 14, 6, 6)];
+        dot.wantsLayer = YES;
+        dot.layer.cornerRadius = 3;
+        dot.layer.backgroundColor = [[NSColor systemOrangeColor] CGColor];
+        dot.tag = 100;
+        [cell addSubview:dot];
+
+        // Filename label (bold)
+        NSTextField* nameLabel = [NSTextField labelWithString:@""];
+        nameLabel.frame = NSMakeRect(16, 18, 180, 16);
+        nameLabel.font = [NSFont systemFontOfSize:12 weight:NSFontWeightMedium];
+        nameLabel.textColor = [NSColor labelColor];
+        nameLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
+        nameLabel.tag = 101;
+        [cell addSubview:nameLabel];
+
+        // Path label (dimmer, smaller)
+        NSTextField* pathLabel = [NSTextField labelWithString:@""];
+        pathLabel.frame = NSMakeRect(16, 2, 180, 14);
+        pathLabel.font = [NSFont systemFontOfSize:10];
+        pathLabel.textColor = [NSColor secondaryLabelColor];
+        pathLabel.lineBreakMode = NSLineBreakByTruncatingHead;
+        pathLabel.tag = 102;
+        [cell addSubview:pathLabel];
+    }
+
+    // Get document data for this row
+    auto& docs = ctx().documents;
+    size_t docIndex = static_cast<size_t>(row);
+    bool isView2 = false;
+    if (ctx().isSplit && docIndex >= docs.size()) {
+        docIndex -= docs.size();
+        isView2 = true;
+    }
+
+    auto& docList = isView2 ? ctx().documents2 : docs;
+    if (docIndex < docList.size()) {
+        auto& doc = docList[docIndex];
+
+        // Modified dot visibility
+        NSView* dot = [cell viewWithTag:100];
+        dot.hidden = !doc.isModified;
+
+        // Filename
+        NSTextField* nameLabel = (NSTextField*)[cell viewWithTag:101];
+        std::string filename = doc.filename;
+        nameLabel.stringValue = @(filename.c_str());
+
+        // Bold for active document
+        bool isActive = (!isView2 && static_cast<int>(docIndex) == ctx().activeTab)
+                     || (isView2 && static_cast<int>(docIndex) == ctx().activeTab2);
+        nameLabel.font = isActive
+            ? [NSFont systemFontOfSize:12 weight:NSFontWeightBold]
+            : [NSFont systemFontOfSize:12 weight:NSFontWeightRegular];
+
+        // Relative path
+        NSTextField* pathLabel = (NSTextField*)[cell viewWithTag:102];
+        std::string displayPath = doc.filePath;
+        if (!ctx().fileBrowserRootPath.empty() &&
+            displayPath.find(ctx().fileBrowserRootPath) == 0) {
+            displayPath = displayPath.substr(ctx().fileBrowserRootPath.size());
+            if (!displayPath.empty() && displayPath[0] == '/')
+                displayPath = displayPath.substr(1);
+        }
+        pathLabel.stringValue = @(displayPath.c_str());
+    }
+
+    return cell;
+}
+
+- (CGFloat)tableView:(NSTableView*)tableView heightOfRow:(NSInteger)row
+{
+    return 36.0;
+}
+
+- (BOOL)tableView:(NSTableView*)tableView shouldSelectRow:(NSInteger)row
+{
+    return YES;
+}
+
+@end
+
+// --- Static state ---
+static NSView* sContainer = nil;
+static FileSwitcherTableView* sTableView = nil;
+static FileSwitcherController* sController = nil;
+
+static void switchToDocumentAtRow(NSInteger row)
+{
+    auto& docs = ctx().documents;
+    size_t docIndex = static_cast<size_t>(row);
+    bool isView2 = false;
+    if (ctx().isSplit && docIndex >= docs.size()) {
+        docIndex -= docs.size();
+        isView2 = true;
+    }
+    // Call switchToTabInView(viewIndex, tabIndex)
+    extern void switchToTabInView(int viewIndex, int tabIndex);
+    switchToTabInView(isView2 ? 1 : 0, static_cast<int>(docIndex));
+}
+
+// --- Context menu ---
+static void setupContextMenu()
+{
+    NSMenu* menu = [[NSMenu alloc] initWithTitle:@"File Switcher"];
+    [menu addItemWithTitle:@"Close" action:@selector(closeSelectedDocument:) keyEquivalent:@""];
+    [menu addItemWithTitle:@"Save" action:@selector(saveSelectedDocument:) keyEquivalent:@""];
+    [menu addItem:[NSMenuItem separatorItem]];
+    [menu addItemWithTitle:@"Copy Path" action:@selector(copySelectedPath:) keyEquivalent:@""];
+    [menu addItemWithTitle:@"Reveal in Finder" action:@selector(revealSelectedInFinder:) keyEquivalent:@""];
+    sTableView.menu = menu;
+}
+
+void initializeFileSwitcherPanel()
+{
+    if (sContainer) return;
+
+    NSView* contentView = [ctx().mainWindow contentView];
+    sContainer = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 200, 300)];
+    sContainer.autoresizingMask = NSViewWidthSizable;
+    sContainer.wantsLayer = YES;
+
+    // Title label
+    NSTextField* title = [NSTextField labelWithString:@"Open Files"];
+    title.frame = NSMakeRect(8, sContainer.frame.size.height - 24, 184, 20);
+    title.font = [NSFont systemFontOfSize:11 weight:NSFontWeightSemibold];
+    title.textColor = [NSColor secondaryLabelColor];
+    title.autoresizingMask = NSViewMinYMargin | NSViewWidthSizable;
+    [sContainer addSubview:title];
+
+    // Scroll view + table
+    NSScrollView* scrollView = [[NSScrollView alloc] initWithFrame:
+        NSMakeRect(0, 0, 200, sContainer.frame.size.height - 28)];
+    scrollView.hasVerticalScroller = YES;
+    scrollView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+
+    sTableView = [[FileSwitcherTableView alloc] initWithFrame:scrollView.bounds];
+    sTableView.headerView = nil;  // No column header
+    sTableView.rowHeight = 36;
+
+    NSTableColumn* col = [[NSTableColumn alloc] initWithIdentifier:@"main"];
+    col.resizingMask = NSTableColumnAutoresizingMask;
+    [sTableView addTableColumn:col];
+
+    sController = [[FileSwitcherController alloc] init];
+    sTableView.dataSource = sController;
+    sTableView.delegate = sController;
+
+    sTableView.target = sController;
+    sTableView.action = @selector(tableViewClicked:);
+
+    scrollView.documentView = sTableView;
+    [sContainer addSubview:scrollView];
+
+    setupContextMenu();
+    [contentView addSubview:sContainer];
+    sContainer.hidden = YES;
+}
+
+void destroyFileSwitcherPanel()
+{
+    if (sContainer) {
+        [sContainer removeFromSuperview];
+        sContainer = nil;
+        sTableView = nil;
+        sController = nil;
+    }
+}
+
+void setFileSwitcherEnabled(bool enabled)
+{
+    ctx().fileSwitcherEnabled = enabled;
+    if (enabled && !sContainer)
+        initializeFileSwitcherPanel();
+    relayoutPanels();
+    if (enabled)
+        reloadFileSwitcherData();
+}
+
+void bindFileSwitcherToActiveView()
+{
+    if (!ctx().fileSwitcherEnabled || !sTableView) return;
+    [sTableView reloadData];
+
+    // Select the active document row
+    NSInteger activeRow = ctx().activeTab;
+    if (activeRow >= 0 && activeRow < [sTableView numberOfRows]) {
+        [sTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:activeRow]
+                byExtendingSelection:NO];
+    }
+}
+
+void reloadFileSwitcherData()
+{
+    if (!sTableView) return;
+    [sTableView reloadData];
+}
+
+void* fileSwitcherContainerView()
+{
+    return (__bridge void*)sContainer;
+}
+```
+
+**Note:** The implementing engineer must adapt the `DocumentData` field names (`filename`, `filePath`, `isModified`) to match the actual struct in `app_state.h`. Also wire up the context menu actions as Obj-C methods on the controller class (follow the pattern in `clipboard_history_panel.mm`).
+
+- [ ] **Step 3: Remove the stub `fileSwitcherContainerView()` from panel_layout.mm**
+
+Replace the stub with:
+```cpp
+#include "file_switcher_panel.h"
+```
+And remove the local stub function.
+
+- [ ] **Step 4: Add to CMakeLists.txt**
+
+```cmake
+"${CMAKE_CURRENT_SOURCE_DIR}/platform/file_switcher_panel.mm"
+```
+
+- [ ] **Step 5: Wire into document_manager.mm**
+
+Add `#include "file_switcher_panel.h"` and call `bindFileSwitcherToActiveView()` in:
+
+- `switchToTabInView()` — after `bindFunctionListToActiveView()` (line ~131)
+- `addNewTabToView()` — after `bindFunctionListToActiveView()` (line ~197), also call `reloadFileSwitcherData()`
+- `closeTabFromView()` — after `bindFunctionListToActiveView()` (line ~272), also call `reloadFileSwitcherData()`
+
+- [ ] **Step 6: Build and verify**
+
+Run: `cd macos/build && cmake -G Xcode .. && cmake --build . --target MacOSNotePP 2>&1 | tail -10`
+
+Launch and manually test:
+- Toggle File Switcher from View menu
+- Open multiple files — verify they appear in the list
+- Click a row — verify it switches to that tab
+- Modify a file — verify the orange dot appears
+- Close a file — verify it disappears from the list
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add macos/platform/file_switcher_panel.h macos/platform/file_switcher_panel.mm \
+        macos/platform/panel_layout.mm macos/platform/document_manager.mm \
+        macos/CMakeLists.txt
+git commit -m "feat: add File Switcher panel — compact open-documents list in left zone"
+```
+
+---
+
+### Task 7: File Browser Panel
+
+**Files:**
+- Create: `macos/platform/file_browser_panel.h`
+- Create: `macos/platform/file_browser_panel.mm`
+- Modify: `macos/platform/panel_layout.mm` (remove stub)
+- Modify: `macos/CMakeLists.txt`
+
+- [ ] **Step 1: Create file_browser_panel.h**
+
+```objc
+#pragma once
+#include <string>
+
+void initializeFileBrowserPanel();
+void destroyFileBrowserPanel();
+void setFileBrowserEnabled(bool enabled);
+void openFolderInFileBrowser(const std::string& path);
+void openFolderWithDialog();  // Shows NSOpenPanel
+void* fileBrowserContainerView();
+```
+
+- [ ] **Step 2: Create file_browser_panel.mm — data model**
+
+```objc
+#import "file_browser_panel.h"
+#import "panel_layout.h"
+#import "app_state.h"
+#import <Cocoa/Cocoa.h>
+#include <CoreServices/CoreServices.h>
+#include <vector>
+#include <string>
+#include <algorithm>
+
+// --- Data Model ---
+
+struct FileBrowserNode {
+    std::string path;
+    std::string filename;
+    bool isDirectory = false;
+    bool isExpanded = false;
+    bool childrenLoaded = false;
+    std::vector<FileBrowserNode> children;
+};
+
+static bool shouldIgnore(const std::string& name)
+{
+    for (auto& pattern : ctx().fileBrowserIgnorePatterns) {
+        if (name == pattern) return true;
+    }
+    return false;
+}
+
+static void loadChildren(FileBrowserNode& node)
+{
+    if (node.childrenLoaded || !node.isDirectory) return;
+    node.childrenLoaded = true;
+    node.children.clear();
+
+    NSString* dirPath = @(node.path.c_str());
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSArray<NSString*>* contents = [fm contentsOfDirectoryAtPath:dirPath error:nil];
+    if (!contents) return;
+
+    for (NSString* name in contents) {
+        std::string nameStr = [name UTF8String];
+        if (shouldIgnore(nameStr)) continue;
+
+        std::string fullPath = node.path + "/" + nameStr;
+        BOOL isDir = NO;
+        [fm fileExistsAtPath:@(fullPath.c_str()) isDirectory:&isDir];
+
+        FileBrowserNode child;
+        child.path = fullPath;
+        child.filename = nameStr;
+        child.isDirectory = isDir;
+        node.children.push_back(std::move(child));
+    }
+
+    // Sort: directories first, then alphabetical (case-insensitive)
+    std::sort(node.children.begin(), node.children.end(),
+        [](const FileBrowserNode& a, const FileBrowserNode& b) {
+            if (a.isDirectory != b.isDirectory) return a.isDirectory > b.isDirectory;
+            return strcasecmp(a.filename.c_str(), b.filename.c_str()) < 0;
+        });
+}
+```
+
+- [ ] **Step 3: Add NSOutlineView controller to file_browser_panel.mm**
+
+```objc
+// --- Outline View Controller ---
+
+@interface FileBrowserController : NSObject <NSOutlineViewDataSource, NSOutlineViewDelegate>
+@end
+
+static FileBrowserNode sRootNode;
+
+@implementation FileBrowserController
+
+- (NSInteger)outlineView:(NSOutlineView*)outlineView numberOfChildrenOfItem:(id)item
+{
+    if (!item) {
+        loadChildren(sRootNode);
+        return static_cast<NSInteger>(sRootNode.children.size());
+    }
+    FileBrowserNode* node = (__bridge FileBrowserNode*)((__bridge void*)item);
+    // Use NSValue wrapper for node pointer — see step 4 for the wrapper approach
+    return 0; // placeholder
+}
+
+// ... (see step 4 for full implementation using NSValue wrappers)
+@end
+```
+
+**Important implementation detail:** Since `FileBrowserNode` is a C++ struct, it cannot be directly used as an `id` in NSOutlineView. The implementing engineer must use an Objective-C wrapper object (`@interface FileBrowserNodeWrapper : NSObject`) holding a pointer to the C++ node, following the same pattern used in `function_list_panel.mm` with `FunctionListItem`.
+
+- [ ] **Step 4: Implement the full controller with node wrapper**
+
+Follow the `FunctionListItem` pattern from `function_list_panel.mm`. Create:
+
+```objc
+@interface FileBrowserNodeWrapper : NSObject
+@property (nonatomic, assign) FileBrowserNode* node;
++ (instancetype)wrapperForNode:(FileBrowserNode*)node;
+@end
+
+@implementation FileBrowserNodeWrapper
++ (instancetype)wrapperForNode:(FileBrowserNode*)node {
+    FileBrowserNodeWrapper* w = [[FileBrowserNodeWrapper alloc] init];
+    w.node = node;
+    return w;
+}
+@end
+```
+
+Then implement the full data source:
+
+```objc
+@implementation FileBrowserController
+
+- (NSInteger)outlineView:(NSOutlineView*)outlineView numberOfChildrenOfItem:(id)item
+{
+    if (!item) {
+        if (sRootNode.path.empty()) return 0;
+        loadChildren(sRootNode);
+        return static_cast<NSInteger>(sRootNode.children.size());
+    }
+    FileBrowserNodeWrapper* wrapper = (FileBrowserNodeWrapper*)item;
+    loadChildren(*wrapper.node);
+    return static_cast<NSInteger>(wrapper.node->children.size());
+}
+
+- (id)outlineView:(NSOutlineView*)outlineView child:(NSInteger)index ofItem:(id)item
+{
+    FileBrowserNode* parent = item ? ((FileBrowserNodeWrapper*)item).node : &sRootNode;
+    loadChildren(*parent);
+    if (index < 0 || static_cast<size_t>(index) >= parent->children.size()) return nil;
+    return [FileBrowserNodeWrapper wrapperForNode:&parent->children[index]];
+}
+
+- (BOOL)outlineView:(NSOutlineView*)outlineView isItemExpandable:(id)item
+{
+    if (!item) return YES;
+    return ((FileBrowserNodeWrapper*)item).node->isDirectory;
+}
+
+- (NSView*)outlineView:(NSOutlineView*)outlineView viewForTableColumn:(NSTableColumn*)column item:(id)item
+{
+    FileBrowserNodeWrapper* wrapper = (FileBrowserNodeWrapper*)item;
+    FileBrowserNode* node = wrapper.node;
+
+    NSTableCellView* cell = [outlineView makeViewWithIdentifier:@"FileBrowserCell" owner:self];
+    if (!cell) {
+        cell = [[NSTableCellView alloc] initWithFrame:NSMakeRect(0, 0, 200, 20)];
+        cell.identifier = @"FileBrowserCell";
+
+        NSImageView* iconView = [[NSImageView alloc] initWithFrame:NSMakeRect(0, 0, 16, 16)];
+        [cell addSubview:iconView];
+        cell.imageView = iconView;
+
+        NSTextField* textField = [NSTextField labelWithString:@""];
+        textField.frame = NSMakeRect(20, 0, 176, 20);
+        textField.font = [NSFont systemFontOfSize:12];
+        textField.lineBreakMode = NSLineBreakByTruncatingTail;
+        [cell addSubview:textField];
+        cell.textField = textField;
+    }
+
+    cell.textField.stringValue = @(node->filename.c_str());
+    cell.imageView.image = [[NSWorkspace sharedWorkspace]
+        iconForFile:@(node->path.c_str())];
+    [cell.imageView.image setSize:NSMakeSize(16, 16)];
+
+    return cell;
+}
+
+- (CGFloat)outlineView:(NSOutlineView*)outlineView heightOfRowByItem:(id)item
+{
+    return 22.0;
+}
+
+@end
+```
+
+- [ ] **Step 5: Implement FSEvents monitoring**
+
+```objc
+static FSEventStreamRef sEventStream = NULL;
+static dispatch_source_t sDebounceTimer = nil;
+
+static void fsEventsCallback(ConstFSEventStreamRef streamRef,
+                             void* clientCallBackInfo,
+                             size_t numEvents,
+                             void* eventPaths,
+                             const FSEventStreamEventFlags eventFlags[],
+                             const FSEventStreamEventId eventIds[])
+{
+    // Debounce: cancel pending timer, schedule new one at 500ms
+    if (sDebounceTimer) {
+        dispatch_source_cancel(sDebounceTimer);
+    }
+    sDebounceTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0,
+                                            dispatch_get_main_queue());
+    dispatch_source_set_timer(sDebounceTimer,
+                              dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
+                              DISPATCH_TIME_FOREVER, 100 * NSEC_PER_MSEC);
+    dispatch_source_set_event_handler(sDebounceTimer, ^{
+        // Reload the changed subtree
+        // For simplicity in v1: mark children as unloaded and reload outline view
+        sRootNode.childrenLoaded = false;
+        extern NSOutlineView* sOutlineView;
+        [sOutlineView reloadData];
+    });
+    dispatch_resume(sDebounceTimer);
+}
+
+static void startFSEventsMonitoring(const std::string& path)
+{
+    stopFSEventsMonitoring();
+
+    NSString* nsPath = @(path.c_str());
+    CFArrayRef pathsToWatch = (__bridge CFArrayRef)@[nsPath];
+
+    FSEventStreamContext callbackCtx = {0, NULL, NULL, NULL, NULL};
+    sEventStream = FSEventStreamCreate(NULL,
+        &fsEventsCallback,
+        &callbackCtx,
+        pathsToWatch,
+        kFSEventStreamEventIdSinceNow,
+        0.5,  // latency
+        kFSEventStreamCreateFlagUseCFTypes |
+        kFSEventStreamCreateFlagFileEvents);
+
+    FSEventStreamScheduleWithRunLoop(sEventStream, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+    FSEventStreamStart(sEventStream);
+}
+
+static void stopFSEventsMonitoring()
+{
+    if (sEventStream) {
+        FSEventStreamStop(sEventStream);
+        FSEventStreamInvalidate(sEventStream);
+        FSEventStreamRelease(sEventStream);
+        sEventStream = NULL;
+    }
+    if (sDebounceTimer) {
+        dispatch_source_cancel(sDebounceTimer);
+        sDebounceTimer = nil;
+    }
+}
+```
+
+- [ ] **Step 6: Implement context menu**
+
+```objc
+static void setupFileBrowserContextMenu(NSOutlineView* outlineView)
+{
+    NSMenu* menu = [[NSMenu alloc] initWithTitle:@"File Browser"];
+    [menu addItemWithTitle:@"New File" action:@selector(newFileAction:) keyEquivalent:@""];
+    [menu addItemWithTitle:@"New Folder" action:@selector(newFolderAction:) keyEquivalent:@""];
+    [menu addItem:[NSMenuItem separatorItem]];
+    [menu addItemWithTitle:@"Rename" action:@selector(renameAction:) keyEquivalent:@""];
+    [menu addItemWithTitle:@"Delete" action:@selector(deleteAction:) keyEquivalent:@""];
+    [menu addItem:[NSMenuItem separatorItem]];
+    [menu addItemWithTitle:@"Reveal in Finder" action:@selector(revealInFinderAction:) keyEquivalent:@""];
+    [menu addItemWithTitle:@"Copy Path" action:@selector(copyPathAction:) keyEquivalent:@""];
+    outlineView.menu = menu;
+}
+```
+
+Implement action methods on `FileBrowserController`:
+- `deleteAction:` — show confirmation alert, then `[[NSWorkspace sharedWorkspace] recycleURLs:@[url] completionHandler:nil]`
+- `revealInFinderAction:` — `[[NSWorkspace sharedWorkspace] selectFile:path inFileViewerRootedAtPath:@""]`
+- `copyPathAction:` — `[[NSPasteboard generalPasteboard] setString:path forType:NSPasteboardTypeString]`
+- `newFileAction:` / `newFolderAction:` / `renameAction:` — begin inline editing on the outline view row
+
+- [ ] **Step 7: Implement panel init/destroy/set and Open Folder**
+
+```objc
+static NSView* sContainer = nil;
+static NSOutlineView* sOutlineView = nil;
+static FileBrowserController* sController = nil;
+static NSTextField* sTitleLabel = nil;
+static NSView* sPlaceholderView = nil;
+
+void initializeFileBrowserPanel()
+{
+    if (sContainer) return;
+
+    NSView* contentView = [ctx().mainWindow contentView];
+    sContainer = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 200, 400)];
+    sContainer.autoresizingMask = NSViewWidthSizable;
+    sContainer.wantsLayer = YES;
+
+    // Title label
+    sTitleLabel = [NSTextField labelWithString:@"File Browser"];
+    sTitleLabel.frame = NSMakeRect(8, sContainer.frame.size.height - 24, 184, 20);
+    sTitleLabel.font = [NSFont systemFontOfSize:11 weight:NSFontWeightSemibold];
+    sTitleLabel.textColor = [NSColor secondaryLabelColor];
+    sTitleLabel.autoresizingMask = NSViewMinYMargin | NSViewWidthSizable;
+    [sContainer addSubview:sTitleLabel];
+
+    // Placeholder view (shown when no folder is open)
+    sPlaceholderView = [[NSView alloc] initWithFrame:
+        NSMakeRect(0, 0, 200, sContainer.frame.size.height - 28)];
+    sPlaceholderView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+
+    NSTextField* placeholderText = [NSTextField labelWithString:@"Open a folder to get started"];
+    placeholderText.frame = NSMakeRect(20, sPlaceholderView.frame.size.height / 2 + 10, 160, 30);
+    placeholderText.alignment = NSTextAlignmentCenter;
+    placeholderText.textColor = [NSColor tertiaryLabelColor];
+    placeholderText.autoresizingMask = NSViewMinYMargin | NSViewWidthSizable;
+    [sPlaceholderView addSubview:placeholderText];
+
+    NSButton* openButton = [[NSButton alloc] initWithFrame:
+        NSMakeRect(50, sPlaceholderView.frame.size.height / 2 - 20, 100, 28)];
+    openButton.title = @"Open Folder";
+    openButton.bezelStyle = NSBezelStyleRounded;
+    openButton.target = nil;
+    openButton.action = @selector(openFolderButtonClicked:);
+    openButton.autoresizingMask = NSViewMinYMargin | NSViewMinXMargin | NSViewMaxXMargin;
+    [sPlaceholderView addSubview:openButton];
+    [sContainer addSubview:sPlaceholderView];
+
+    // Scroll view + outline view
+    NSScrollView* scrollView = [[NSScrollView alloc] initWithFrame:
+        NSMakeRect(0, 0, 200, sContainer.frame.size.height - 28)];
+    scrollView.hasVerticalScroller = YES;
+    scrollView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+    scrollView.tag = 200;
+
+    sOutlineView = [[NSOutlineView alloc] initWithFrame:scrollView.bounds];
+    sOutlineView.headerView = nil;
+    sOutlineView.rowHeight = 22;
+    sOutlineView.indentationPerLevel = 16;
+
+    NSTableColumn* col = [[NSTableColumn alloc] initWithIdentifier:@"main"];
+    col.resizingMask = NSTableColumnAutoresizingMask;
+    [sOutlineView addTableColumn:col];
+    sOutlineView.outlineTableColumn = col;
+
+    sController = [[FileBrowserController alloc] init];
+    sOutlineView.dataSource = sController;
+    sOutlineView.delegate = sController;
+
+    // Single-click to open file
+    sOutlineView.target = sController;
+    sOutlineView.action = @selector(outlineViewClicked:);
+
+    setupFileBrowserContextMenu(sOutlineView);
+
+    scrollView.documentView = sOutlineView;
+    scrollView.hidden = YES;  // Hidden until a folder is opened
+    [sContainer addSubview:scrollView];
+
+    [contentView addSubview:sContainer];
+    sContainer.hidden = YES;
+
+    // If a root path was restored from settings, open it
+    if (!ctx().fileBrowserRootPath.empty()) {
+        openFolderInFileBrowser(ctx().fileBrowserRootPath);
+    }
+}
+
+void openFolderInFileBrowser(const std::string& path)
+{
+    ctx().fileBrowserRootPath = path;
+    sRootNode = FileBrowserNode{};
+    sRootNode.path = path;
+    sRootNode.isDirectory = true;
+
+    // Extract folder name for title
+    NSString* nsPath = @(path.c_str());
+    NSString* folderName = [nsPath lastPathComponent];
+    sTitleLabel.stringValue = folderName;
+
+    // Show outline view, hide placeholder
+    sPlaceholderView.hidden = YES;
+    NSView* scrollView = [sContainer viewWithTag:200];
+    scrollView.hidden = NO;
+
+    [sOutlineView reloadData];
+    startFSEventsMonitoring(path);
+}
+
+void openFolderWithDialog()
+{
+    NSOpenPanel* panel = [NSOpenPanel openPanel];
+    panel.canChooseFiles = NO;
+    panel.canChooseDirectories = YES;
+    panel.allowsMultipleSelection = NO;
+    panel.message = @"Choose a folder to open in the File Browser";
+
+    [panel beginSheetModalForWindow:ctx().mainWindow completionHandler:^(NSModalResponse result) {
+        if (result == NSModalResponseOK && panel.URL) {
+            std::string path = [panel.URL.path UTF8String];
+            openFolderInFileBrowser(path);
+
+            // Auto-enable File Browser if not already
+            if (!ctx().fileBrowserEnabled) {
+                setFileBrowserEnabled(true);
+            }
+        }
+    }];
+}
+
+void setFileBrowserEnabled(bool enabled)
+{
+    ctx().fileBrowserEnabled = enabled;
+    if (enabled && !sContainer)
+        initializeFileBrowserPanel();
+    relayoutPanels();
+}
+
+void destroyFileBrowserPanel()
+{
+    stopFSEventsMonitoring();
+    if (sContainer) {
+        [sContainer removeFromSuperview];
+        sContainer = nil;
+        sOutlineView = nil;
+        sController = nil;
+    }
+}
+
+void* fileBrowserContainerView()
+{
+    return (__bridge void*)sContainer;
+}
+```
+
+- [ ] **Step 8: Remove the stub `fileBrowserContainerView()` from panel_layout.mm**
+
+Replace the stub with `#include "file_browser_panel.h"`.
+
+- [ ] **Step 9: Add to CMakeLists.txt**
+
+```cmake
+"${CMAKE_CURRENT_SOURCE_DIR}/platform/file_browser_panel.mm"
+```
+
+- [ ] **Step 10: Build and verify**
+
+Run: `cd macos/build && cmake -G Xcode .. && cmake --build . --target MacOSNotePP 2>&1 | tail -10`
+
+Launch and test:
+- Toggle File Browser panel from View menu → shows placeholder
+- File > Open Folder → select a folder → tree populates
+- Expand directories → children load lazily
+- Click a file → opens in editor
+- Right-click → context menu appears with all items
+- Create/delete a file externally → tree refreshes after ~500ms
+- Quit and relaunch → folder is remembered from settings
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add macos/platform/file_browser_panel.h macos/platform/file_browser_panel.mm \
+        macos/platform/panel_layout.mm macos/CMakeLists.txt
+git commit -m "feat: add File Browser panel — tree view with FSEvents monitoring and context menu"
+```
+
+---
+
+### Task 8: Menu Integration and Wiring
+
+**Files:**
+- Modify: `macos/platform/menu_builder.mm:117-141`
+- Modify: `macos/platform/wndproc.mm:507-533,671-676`
+- Modify: `macos/platform/app_delegate.mm`
+
+- [ ] **Step 1: Add View menu items in menu_builder.mm**
+
+After the existing clipboard history menu item (around line 141), add:
+
+```objc
+AppendMenuW(hViewMenu, MF_STRING | (ctx().fileBrowserEnabled ? MF_CHECKED : MF_UNCHECKED),
+            IDM_VIEW_FILEBROWSER, L"File &Browser\tCtrl+Shift+E");
+AppendMenuW(hViewMenu, MF_STRING | (ctx().fileSwitcherEnabled ? MF_CHECKED : MF_UNCHECKED),
+            IDM_VIEW_FILESWITCHER, L"File &Switcher\tCtrl+Shift+O");
+```
+
+- [ ] **Step 2: Add File > Open Folder menu item**
+
+In the File menu section (around line 15-38), add after existing items:
+
+```objc
+AppendMenuW(hFileMenu, MF_SEPARATOR, 0, NULL);
+AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_OPENFOLDER, L"Open Fol&der...\tCtrl+Shift+K");
+```
+
+- [ ] **Step 3: Add wndproc.mm switch cases**
+
+After the `IDM_VIEW_CLIPBOARD_HISTORY` case (around line 533), add:
+
+```cpp
+case IDM_VIEW_FILEBROWSER:
+{
+    setFileBrowserEnabled(!ctx().fileBrowserEnabled);
+    HMENU hMenu = GetMenu(hWnd);
+    if (hMenu)
+        CheckMenuItem(hMenu, IDM_VIEW_FILEBROWSER,
+                      MF_BYCOMMAND | (ctx().fileBrowserEnabled ? MF_CHECKED : MF_UNCHECKED));
+    return 0;
+}
+
+case IDM_VIEW_FILESWITCHER:
+{
+    setFileSwitcherEnabled(!ctx().fileSwitcherEnabled);
+    HMENU hMenu = GetMenu(hWnd);
+    if (hMenu)
+        CheckMenuItem(hMenu, IDM_VIEW_FILESWITCHER,
+                      MF_BYCOMMAND | (ctx().fileSwitcherEnabled ? MF_CHECKED : MF_UNCHECKED));
+    return 0;
+}
+
+case IDM_FILE_OPENFOLDER:
+{
+    openFolderWithDialog();
+    return 0;
+}
+```
+
+- [ ] **Step 4: Add WM_INITMENUPOPUP checks**
+
+In the `WM_INITMENUPOPUP` handler (around line 671-676), add:
+
+```cpp
+CheckMenuItem(hMenu, IDM_VIEW_FILEBROWSER,
+              MF_BYCOMMAND | (ctx().fileBrowserEnabled ? MF_CHECKED : MF_UNCHECKED));
+CheckMenuItem(hMenu, IDM_VIEW_FILESWITCHER,
+              MF_BYCOMMAND | (ctx().fileSwitcherEnabled ? MF_CHECKED : MF_UNCHECKED));
+```
+
+- [ ] **Step 5: Wire keyboard shortcuts in app_delegate.mm**
+
+Find where existing keyboard shortcuts are registered (the macOS key equivalent system) and add:
+- Cmd+Shift+E → `IDM_VIEW_FILEBROWSER`
+- Cmd+Shift+O → `IDM_VIEW_FILESWITCHER`
+- Cmd+Shift+K → `IDM_FILE_OPENFOLDER`
+
+Follow the existing pattern for how shortcuts like Ctrl+Shift+H (Clipboard History) are mapped.
+
+- [ ] **Step 6: Initialize new panels at startup**
+
+In `app_delegate.mm`, in `applicationDidFinishLaunching:`, after existing panel initialization, add:
+
+```objc
+if (ctx().fileBrowserEnabled)
+    initializeFileBrowserPanel();
+if (ctx().fileSwitcherEnabled)
+    initializeFileSwitcherPanel();
+```
+
+- [ ] **Step 7: Add includes**
+
+Add to `wndproc.mm`:
+```cpp
+#include "file_browser_panel.h"
+#include "file_switcher_panel.h"
+```
+
+Add to `app_delegate.mm`:
+```cpp
+#include "file_browser_panel.h"
+#include "file_switcher_panel.h"
+```
+
+- [ ] **Step 8: Build and full integration test**
+
+Run: `cd macos/build && cmake --build . --target MacOSNotePP 2>&1 | tail -5`
+
+Full manual test:
+- View > File Browser (Cmd+Shift+E) → toggles panel
+- View > File Switcher (Cmd+Shift+O) → toggles panel
+- File > Open Folder (Cmd+Shift+K) → opens folder dialog
+- Menu checkmarks update correctly
+- Both panels appear in left zone
+- Drag left divider to resize → both panels resize
+- Drag left divider below 60px → left zone collapses
+- Drag right divider → right zone resizes
+- Drag horizontal dividers → panel height ratios change
+- Double-click any divider → resets to default width
+- Settings persist across app restart
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add macos/platform/menu_builder.mm macos/platform/wndproc.mm \
+        macos/platform/app_delegate.mm
+git commit -m "feat: wire File Browser and File Switcher into menus with keyboard shortcuts"
+```

--- a/docs/superpowers/plans/2026-03-30-1.1-sprint-panels.md
+++ b/docs/superpowers/plans/2026-03-30-1.1-sprint-panels.md
@@ -36,7 +36,7 @@
 | File | What Changes |
 |------|-------------|
 | `app_state.h` | Add left/right zone fields to AppContext |
-| `npp_constants.h` | Add IDM_VIEW_FILEBROWSER (42088), IDM_VIEW_FILESWITCHER (42089), IDM_FILE_OPENFOLDER (42090) |
+| `npp_constants.h` | Add IDM_VIEW_FILEBROWSER (42088), IDM_VIEW_FILESWITCHER (42089), IDM_FILE_OPENFOLDER (42094) |
 | `settings_manager.mm` | Load/save new panel widths, ratios, root path |
 | `menu_builder.mm` | Add View menu items + File > Open Folder |
 | `wndproc.mm` | Add switch cases for new IDM commands + WM_INITMENUPOPUP updates |
@@ -134,7 +134,7 @@ In `npp_constants.h`, after `IDM_VIEW_CLIPBOARD_HISTORY 42087` (line 116), add:
 ```cpp
 #define IDM_VIEW_FILEBROWSER         42088
 #define IDM_VIEW_FILESWITCHER        42089
-#define IDM_FILE_OPENFOLDER          42090
+#define IDM_FILE_OPENFOLDER          42094
 ```
 
 - [ ] **Step 3: Build to verify no compilation errors**

--- a/docs/superpowers/specs/2026-03-30-1.1-sprint-panels-design.md
+++ b/docs/superpowers/specs/2026-03-30-1.1-sprint-panels-design.md
@@ -1,0 +1,256 @@
+# 1.1 Sprint: File Browser, File Switcher, and Resizable Panel Layout
+
+**Date:** 2026-03-30
+**Issues:** #23 (File Browser panel), #35 (Vertical File Switcher panel)
+**Milestone:** 1.1-advanced (P2)
+
+## Summary
+
+Add two new side panels to the left zone of the editor (File Browser + File Switcher), introduce resizable dividers across all panels, and restructure the right-side panels (Function List + Clipboard History) to stack vertically in a single column. The Document Map retains its current position glued to the right edge of the editor.
+
+## Architecture: Approach A — Manual Frame Layout + Custom Divider Views
+
+Extend the existing manual frame layout system rather than introducing NSSplitView. This preserves consistency with the codebase's proven pattern (used by 4 existing panels) and gives full control over collapse behavior.
+
+## Window Layout
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                          Tab Bar(s)                          │
+├────────┬─┬────────────────────┬──────────┬─┬────────────────┤
+│ File   │║│                    │ Document │║│  Right Zone    │
+│Browser │║│      Editor        │   Map    │║│  ┌───────────┐│
+│        │║│   (Scintilla)      │ (minimap)│║│  │Func List  ││
+│--------│║│                    │          │║│  │───────────│││
+│ File   │║│                    │          │║│  │Clipboard  ││
+│Switcher│║│                    │          │║│  │  History  ││
+│        │║│                    │          │║│  └───────────┘│
+├────────┴─┴────────────────────┴──────────┴─┴────────────────┤
+│                         Status Bar                           │
+└──────────────────────────────────────────────────────────────┘
+  ║ = draggable divider (3px, col-resize cursor)
+```
+
+**Layout zones:**
+- **Left zone:** File Browser (top) + File Switcher (bottom), stacked vertically
+- **Center block:** Editor (Scintilla views + tab bar) + Document Map (glued to editor right edge)
+- **Right zone:** Function List (top) + Clipboard History (bottom), stacked vertically
+
+The editor+DocMap behave as a logical unit. `relayoutPanels()` treats them as one center block.
+
+## Resizable Divider System
+
+### PanelDividerView (NSView subclass)
+
+New file: `panel_divider.mm/.h`
+
+**Properties:**
+- `orientation`: vertical (between zones) or horizontal (between stacked panels)
+- `leftOrTopView`: the view on the leading side
+- `rightOrBottomView`: the view on the trailing side
+- `onResize`: C++ callback block invoked during drag
+- `collapseThreshold`: 60px (constant)
+
+**Behavior:**
+- 3px wide (vertical) or 3px tall (horizontal)
+- Hover: cursor changes to `resizeLeftRightCursor` / `resizeUpDownCursor`
+- Drag: calls `onResize` callback with delta, updates width/height in AppContext, calls `relayoutPanels()`
+- Collapse: if drag brings a panel below 60px, set its enabled flag to `false`, width to 0, call `relayoutPanels()`. View menu checkmark updates.
+- Double-click: reset panel to default width
+- Minimum editor width enforced at 120px during drag
+
+### Divider instances (when all panels visible)
+
+1. Left zone ↔ Editor (vertical)
+2. Editor+DocMap ↔ Right zone (vertical)
+3. File Browser ↔ File Switcher within left zone (horizontal)
+4. Function List ↔ Clipboard History within right zone (horizontal)
+
+Dividers for hidden panels are not rendered. `relayoutPanels()` builds the divider list dynamically.
+
+### Single-panel zone behavior
+
+When only one panel in a zone is enabled (e.g., File Browser without File Switcher), that panel fills the full zone height. No horizontal divider is rendered. The zone's vertical divider still works for resizing/collapsing the entire zone. Collapsing the last visible panel in a zone collapses the entire zone.
+
+## Layout Orchestrator
+
+### Rename and extract: `relayoutFunctionListPanel()` → `relayoutPanels()`
+
+New file: `panel_layout.mm/.h`
+
+Central layout function that:
+1. Calculates base frame (window height - tab bar - status bar)
+2. Gets enabled panel states and widths from AppContext
+3. Clamps all widths to prevent exceeding window minus 120px editor minimum
+4. Positions left zone panels, left divider, center block (editor + DocMap), right divider, right zone panels
+5. Positions horizontal dividers within left and right zones
+6. Calls `layoutSplitTopTabBars()` to position tab bars
+
+All existing callers of `relayoutFunctionListPanel()` are updated to call `relayoutPanels()`.
+
+## File Browser Panel
+
+New file: `file_browser_panel.mm/.h`
+
+### Data Model
+
+`FileBrowserNode` struct:
+- `path` (std::string) — full filesystem path
+- `filename` (std::string) — display name
+- `isDirectory` (bool)
+- `children` (std::vector<FileBrowserNode>) — lazy-loaded on first expand
+- `isExpanded` (bool)
+
+Sorted: directories first, then alphabetical (case-insensitive).
+
+### UI
+
+- `NSOutlineView` with `FileBrowserController` as data source/delegate
+- Single column: file/folder icon (`NSWorkspace.iconForFile:`) + filename
+- Disclosure triangles for directories (built into NSOutlineView)
+- Title bar at top showing workspace folder name
+
+### Opening a workspace
+
+- **File > Open Folder...** menu item opens `NSOpenPanel` in directory mode
+- Sets workspace root path and populates the tree
+- If File Browser is toggled on before a folder is opened, show placeholder: "Open a folder to get started" with a button triggering the Open Folder action
+
+### Interactions
+
+- **Single-click file** → open in editor (or switch to tab if already open)
+- **Single-click directory** → expand/collapse
+- **Context menu** (right-click):
+  - New File → inline rename field in the tree
+  - New Folder → inline rename field
+  - Rename → inline rename field on selected item
+  - Delete → Move to Trash via `NSWorkspace.recycleURLs` (confirmation alert)
+  - Reveal in Finder → `NSWorkspace.selectFile:inFileViewerRootedAtPath:`
+  - Copy Path → full path on pasteboard
+
+### FSEvents Monitoring
+
+- `FSEventStreamCreate` on workspace root
+- Flags: `kFSEventStreamEventFlagItemCreated | Modified | Removed | Renamed`
+- On event: compare affected paths against loaded nodes, refresh only changed subtree
+- 500ms debounce (FSEvents can fire rapidly)
+
+### Filter Patterns
+
+Default ignore list (hardcoded, not user-configurable in v1):
+`.git`, `.DS_Store`, `node_modules`, `__pycache__`, `.build`, `build`
+
+Stored as `std::vector<std::string>` in AppContext.
+
+### State
+
+- `ctx().fileBrowserEnabled` (default false)
+- `ctx().fileBrowserRootPath` — persisted via SettingsManager
+- Expanded directory state not persisted (start collapsed on launch)
+
+## File Switcher Panel
+
+New file: `file_switcher_panel.mm/.h`
+
+### Data Model
+
+No separate model. Reads directly from `ctx().documents` (and `ctx().documents2` if split view active). Each entry maps 1:1 to an open tab.
+
+### UI
+
+- `NSTableView` with `FileSwitcherController` as data source/delegate (single column, view-based)
+- Each row:
+  - **Modified dot** — small colored dot (left edge), visible only when document has unsaved changes
+  - **Filename** — primary text, bold for the active document
+  - **Relative path** — secondary text below filename, smaller/dimmer font. Relative to File Browser root if set, otherwise the file's parent directory
+- Active document row has subtle highlight background
+- Custom `FileSwitcherTableView` subclass for Enter key → switch to tab
+
+### Interactions
+
+- **Single-click** → switch to that document's tab (handles cross-view switching in split mode)
+- **Context menu** (right-click):
+  - Close → triggers save prompt if modified
+  - Save
+  - Copy Path
+  - Reveal in Finder
+
+### Sort
+
+Default: tab order (matches tab bar sequence). No user-sortable columns in v1.
+
+### Auto-updates
+
+- Tab opened/closed → reload table data
+- Document modified/saved → update modified dot for that row
+- Tab switched → update active highlight
+- File renamed → update displayed name
+
+### Communication
+
+- `bindFileSwitcherToActiveView()` called on tab switch — refreshes list, updates active row
+- Listens to `SCN_SAVEPOINTLEFT` / `SCN_SAVEPOINTREACHED` for modified dot updates
+
+### State
+
+- `ctx().fileSwitcherEnabled` (default false)
+- Width shared with left zone: `ctx().leftPanelWidth`
+
+## Menu Integration
+
+### View menu additions
+
+| Menu Item | Shortcut | Action |
+|-----------|----------|--------|
+| Show File Browser | Cmd+Shift+E | Toggle `fileBrowserEnabled` |
+| Show File Switcher | Cmd+Shift+O | Toggle `fileSwitcherEnabled` |
+
+### File menu addition
+
+| Menu Item | Shortcut | Action |
+|-----------|----------|--------|
+| Open Folder... | Cmd+Shift+K | NSOpenPanel directory mode → set File Browser root |
+
+## AppContext Changes
+
+```cpp
+// Left zone
+bool fileBrowserEnabled = false;
+bool fileSwitcherEnabled = false;
+int leftPanelWidth = 200;
+CGFloat fileBrowserHeightRatio = 0.6;  // top portion of left zone
+std::string fileBrowserRootPath;
+std::vector<std::string> fileBrowserIgnorePatterns = {
+    ".git", ".DS_Store", "node_modules", "__pycache__", ".build", "build"
+};
+
+// Right zone (replaces per-panel widths for Function List + Clipboard History)
+int rightPanelWidth = 220;
+CGFloat functionListHeightRatio = 0.5;  // split within right zone
+
+// Document Map width stays as-is (ctx().documentMapWidth)
+```
+
+## New Files
+
+| File | Purpose |
+|------|---------|
+| `file_browser_panel.mm/.h` | File Browser — NSOutlineView, FSEvents, context menu |
+| `file_switcher_panel.mm/.h` | File Switcher — NSTableView, open docs list |
+| `panel_divider.mm/.h` | PanelDividerView — drag resize, auto-collapse |
+| `panel_layout.mm/.h` | `relayoutPanels()` — central layout orchestrator |
+
+## Modified Files
+
+| File | Changes |
+|------|---------|
+| `app_state.h` | Add left zone + right zone state fields |
+| `wndproc.mm` | Add menu command cases for new panels + Open Folder |
+| `menu_builder.mm` | Add View menu items + File > Open Folder |
+| `npp_constants.h` | Add IDM constants for new panels and Open Folder |
+| `app_delegate.mm` | Initialize new panels at startup, wire up settings |
+| `document_manager.mm` | Call bind functions on tab switch |
+| `settings_manager.mm` | Persist new width/ratio/path settings |
+| `function_list_panel.mm` | Remove `relayoutFunctionListPanel()` (moved to panel_layout.mm), adapt to vertical stacking |
+| `clipboard_history_panel.mm` | Adapt to vertical stacking in right zone |
+| `document_map.mm` | No internal changes — layout handled by panel_layout.mm |

--- a/docs/superpowers/specs/2026-03-30-1.1-sprint-panels-design.md
+++ b/docs/superpowers/specs/2026-03-30-1.1-sprint-panels-design.md
@@ -209,7 +209,7 @@ Default: tab order (matches tab bar sequence). No user-sortable columns in v1.
 
 | Menu Item | Shortcut | Action |
 |-----------|----------|--------|
-| Open Folder... | Cmd+Shift+K | NSOpenPanel directory mode → set File Browser root |
+| Open Folder... | Cmd+Shift+J | NSOpenPanel directory mode → set File Browser root |
 
 ## AppContext Changes
 

--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -367,6 +367,7 @@ add_executable(MacOSNotePP
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/function_list_panel.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/clipboard_history_panel.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/panel_divider.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/panel_layout.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/file_path_ops.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/tab_bar_view.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/tab_context_menu.mm"

--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -369,6 +369,7 @@ add_executable(MacOSNotePP
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/panel_divider.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/panel_layout.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/file_switcher_panel.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/file_browser_panel.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/file_path_ops.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/tab_bar_view.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/tab_context_menu.mm"

--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -366,6 +366,7 @@ add_executable(MacOSNotePP
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/function_list_parser.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/function_list_panel.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/clipboard_history_panel.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/panel_divider.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/file_path_ops.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/tab_bar_view.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/tab_context_menu.mm"

--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -368,6 +368,7 @@ add_executable(MacOSNotePP
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/clipboard_history_panel.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/panel_divider.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/panel_layout.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/file_switcher_panel.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/file_path_ops.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/tab_bar_view.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/tab_context_menu.mm"

--- a/macos/platform/app_delegate.mm
+++ b/macos/platform/app_delegate.mm
@@ -138,8 +138,6 @@ static void setDockIconFromLogo()
 	ctx().rightPanelWidth = s.rightPanelWidth;
 	ctx().functionListHeightRatio = s.functionListHeightRatio;
 	ctx().documentMapWidth = s.documentMapWidth;
-	ctx().functionListWidth = s.functionListWidth;
-	ctx().clipboardHistoryWidth = s.clipboardHistoryWidth;
 	setDockIconFromLogo();
 
 	ctx().recentFiles.clear();
@@ -618,8 +616,6 @@ static void setDockIconFromLogo()
 	s.rightPanelWidth = ctx().rightPanelWidth;
 	s.functionListHeightRatio = ctx().functionListHeightRatio;
 	s.documentMapWidth = ctx().documentMapWidth;
-	s.functionListWidth = ctx().functionListWidth;
-	s.clipboardHistoryWidth = ctx().clipboardHistoryWidth;
 	s.wordWrap = ctx().scintillaView ?
 		(ScintillaBridge_sendMessage(ctx().scintillaView, SCI_GETWRAPMODE, 0, 0) != 0) : false;
 

--- a/macos/platform/app_delegate.mm
+++ b/macos/platform/app_delegate.mm
@@ -29,6 +29,7 @@
 #include "document_map.h"
 #include "function_list_panel.h"
 #include "clipboard_history_panel.h"
+#include "panel_layout.h"
 #include "toolbar.h"
 #include "scintilla_notify.h"
 #include "macro_manager.h"
@@ -660,7 +661,7 @@ static void setDockIconFromLogo()
 		ScintillaBridge_resizeToFit(ctx().scintillaView2);
 
 	layoutSplitTopTabBars();
-	relayoutFunctionListPanel();
+	relayoutPanels();
 	updateDocumentMapViewport();
 	scheduleFunctionListRefresh();
 }
@@ -668,7 +669,7 @@ static void setDockIconFromLogo()
 - (void)splitViewDidResizeSubviews:(NSNotification*)notification
 {
 	layoutSplitTopTabBars();
-	relayoutFunctionListPanel();
+	relayoutPanels();
 	updateDocumentMapViewport();
 	scheduleFunctionListRefresh();
 }

--- a/macos/platform/app_delegate.mm
+++ b/macos/platform/app_delegate.mm
@@ -29,6 +29,8 @@
 #include "document_map.h"
 #include "function_list_panel.h"
 #include "clipboard_history_panel.h"
+#include "file_browser_panel.h"
+#include "file_switcher_panel.h"
 #include "panel_layout.h"
 #include "toolbar.h"
 #include "scintilla_notify.h"
@@ -503,6 +505,10 @@ static void setDockIconFromLogo()
 	setDocumentMapEnabled(ctx().documentMapEnabled);
 	setFunctionListEnabled(ctx().functionListEnabled);
 	setClipboardHistoryEnabled(ctx().clipboardHistoryEnabled);
+	if (ctx().fileBrowserEnabled)
+		setFileBrowserEnabled(ctx().fileBrowserEnabled);
+	if (ctx().fileSwitcherEnabled)
+		setFileSwitcherEnabled(ctx().fileSwitcherEnabled);
 	bindDocumentMapToActiveView();
 	updateDocumentMapViewport();
 
@@ -647,6 +653,8 @@ static void setDockIconFromLogo()
 	destroyDocumentMap();
 	destroyFunctionListPanel();
 	destroyClipboardHistoryPanel();
+	destroyFileBrowserPanel();
+	destroyFileSwitcherPanel();
 }
 
 - (void)windowDidResize:(NSNotification*)notification

--- a/macos/platform/app_delegate.mm
+++ b/macos/platform/app_delegate.mm
@@ -283,6 +283,7 @@ static void setDockIconFromLogo()
 							ctx().documents[tabIdx].modified = true;
 							updateTabModifiedIndicator(0, tabIdx);
 							updateWindowDocumentEdited();
+							reloadFileSwitcherData();
 						}
 					}
 				}
@@ -297,6 +298,7 @@ static void setDockIconFromLogo()
 							ctx().documents[tabIdx].modified = false;
 							updateTabModifiedIndicator(0, tabIdx);
 							updateWindowDocumentEdited();
+							reloadFileSwitcherData();
 						}
 					}
 				}

--- a/macos/platform/app_delegate.mm
+++ b/macos/platform/app_delegate.mm
@@ -129,6 +129,13 @@ static void setDockIconFromLogo()
 	ctx().functionListEnabled = s.functionList;
 	ctx().clipboardHistoryEnabled = s.clipboardHistory;
 	ctx().showChangeHistory = s.showChangeHistory;
+	ctx().fileBrowserEnabled = s.fileBrowser;
+	ctx().fileSwitcherEnabled = s.fileSwitcher;
+	ctx().leftPanelWidth = s.leftPanelWidth;
+	ctx().fileBrowserHeightRatio = s.fileBrowserHeightRatio;
+	ctx().fileBrowserRootPath = s.fileBrowserRootPath;
+	ctx().rightPanelWidth = s.rightPanelWidth;
+	ctx().functionListHeightRatio = s.functionListHeightRatio;
 	ctx().documentMapWidth = s.documentMapWidth;
 	ctx().functionListWidth = s.functionListWidth;
 	ctx().clipboardHistoryWidth = s.clipboardHistoryWidth;
@@ -602,6 +609,13 @@ static void setDockIconFromLogo()
 	s.functionList = ctx().functionListEnabled;
 	s.clipboardHistory = ctx().clipboardHistoryEnabled;
 	s.showChangeHistory = ctx().showChangeHistory;
+	s.fileBrowser = ctx().fileBrowserEnabled;
+	s.fileSwitcher = ctx().fileSwitcherEnabled;
+	s.leftPanelWidth = ctx().leftPanelWidth;
+	s.fileBrowserHeightRatio = ctx().fileBrowserHeightRatio;
+	s.fileBrowserRootPath = ctx().fileBrowserRootPath;
+	s.rightPanelWidth = ctx().rightPanelWidth;
+	s.functionListHeightRatio = ctx().functionListHeightRatio;
 	s.documentMapWidth = ctx().documentMapWidth;
 	s.functionListWidth = ctx().functionListWidth;
 	s.clipboardHistoryWidth = ctx().clipboardHistoryWidth;

--- a/macos/platform/app_delegate.mm
+++ b/macos/platform/app_delegate.mm
@@ -272,6 +272,7 @@ static void setDockIconFromLogo()
 					ctx().activeView = 0;
 					bindDocumentMapToActiveView();
 					bindFunctionListToActiveView();
+					bindFileSwitcherToActiveView();
 				}
 				else if (scn->nmhdr.code == SCN_SAVEPOINTLEFT)
 				{

--- a/macos/platform/app_state.h
+++ b/macos/platform/app_state.h
@@ -87,11 +87,9 @@ struct AppContext
 
 	// Function list state
 	bool functionListEnabled = false;
-	int functionListWidth = 200;
 
 	// Clipboard history state
 	bool clipboardHistoryEnabled = false;
-	int clipboardHistoryWidth = 220;
 
 	// Left zone — File Browser + File Switcher
 	bool fileBrowserEnabled = false;

--- a/macos/platform/app_state.h
+++ b/macos/platform/app_state.h
@@ -93,6 +93,20 @@ struct AppContext
 	bool clipboardHistoryEnabled = false;
 	int clipboardHistoryWidth = 220;
 
+	// Left zone — File Browser + File Switcher
+	bool fileBrowserEnabled = false;
+	bool fileSwitcherEnabled = false;
+	int leftPanelWidth = 200;
+	CGFloat fileBrowserHeightRatio = 0.6;
+	std::string fileBrowserRootPath;
+	std::vector<std::string> fileBrowserIgnorePatterns = {
+		".git", ".DS_Store", "node_modules", "__pycache__", ".build", "build"
+	};
+
+	// Right zone — replaces per-panel widths for Function List + Clipboard History
+	int rightPanelWidth = 220;
+	CGFloat functionListHeightRatio = 0.5;
+
 	// Notification suppression (prevents false dirty indicators during tab switches)
 	bool suppressSavePointNotifications = false;
 

--- a/macos/platform/clipboard_history_panel.h
+++ b/macos/platform/clipboard_history_panel.h
@@ -12,5 +12,5 @@ void captureClipboardEntry();
 
 // Returns opaque pointer to the panel's container view (NSView*),
 // or nullptr if the panel has not been initialized.
-// Used by relayoutFunctionListPanel() for geometry positioning.
+// Used by relayoutPanels() for geometry positioning.
 void* clipboardHistoryContainerView();

--- a/macos/platform/clipboard_history_panel.mm
+++ b/macos/platform/clipboard_history_panel.mm
@@ -228,13 +228,13 @@ void initializeClipboardHistoryPanel()
 
 	sController = [[ClipboardHistoryController alloc] init];
 
-	CGFloat width = static_cast<CGFloat>(ctx().clipboardHistoryWidth);
+	CGFloat width = static_cast<CGFloat>(ctx().rightPanelWidth);
 	if (width < 120) width = 120;
 	if (width > 360) width = 360;
-	ctx().clipboardHistoryWidth = static_cast<int>(width);
+	ctx().rightPanelWidth = static_cast<int>(width);
 
 	sContainer = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, width, 100)];
-	sContainer.autoresizingMask = NSViewMinXMargin | NSViewHeightSizable;
+	sContainer.autoresizingMask = NSViewWidthSizable;
 	[contentView addSubview:sContainer];
 
 	// Scroll view

--- a/macos/platform/clipboard_history_panel.mm
+++ b/macos/platform/clipboard_history_panel.mm
@@ -8,7 +8,7 @@
 #include <utility>
 
 #include "clipboard_history_panel.h"
-#include "function_list_panel.h"
+#include "panel_layout.h"
 #include "app_state.h"
 #include "scintilla_bridge.h"
 #include "npp_constants.h"
@@ -323,7 +323,7 @@ void setClipboardHistoryEnabled(bool enabled)
 		if (sTableView)
 			[sTableView reloadData];
 	}
-	relayoutFunctionListPanel();
+	relayoutPanels();
 }
 
 bool isClipboardHistoryEnabled()

--- a/macos/platform/document_manager.mm
+++ b/macos/platform/document_manager.mm
@@ -12,6 +12,7 @@
 #include "incremental_search.h"
 #include "document_map.h"
 #include "function_list_panel.h"
+#include "file_switcher_panel.h"
 #include "sync_scroll.h"
 #include "windows.h"
 #include "commctrl.h"
@@ -129,6 +130,7 @@ void switchToTabInView(int viewIndex, int tabIndex)
 	bindDocumentMapToActiveView();
 	updateDocumentMapViewport();
 	bindFunctionListToActiveView();
+	bindFileSwitcherToActiveView();
 	refreshSyncScrollAnchor();
 
 	if (isIncrementalSearchVisible())
@@ -195,6 +197,7 @@ int addNewTabToView(int viewIndex, const std::wstring& title, const std::string&
 		bindDocumentMapToActiveView();
 		updateDocumentMapViewport();
 		bindFunctionListToActiveView();
+		reloadFileSwitcherData();
 	}
 	refreshSyncScrollAnchor();
 
@@ -270,6 +273,7 @@ void closeTabFromView(int viewIndex, int tabIndex)
 		bindDocumentMapToActiveView();
 		updateDocumentMapViewport();
 		bindFunctionListToActiveView();
+		reloadFileSwitcherData();
 	}
 	refreshSyncScrollAnchor();
 

--- a/macos/platform/document_map.mm
+++ b/macos/platform/document_map.mm
@@ -8,7 +8,7 @@
 #include "npp_constants.h"
 #include "scintilla_bridge.h"
 #include "split_view.h"
-#include "function_list_panel.h"
+#include "panel_layout.h"
 #include <algorithm>
 
 @interface DocumentMapOverlayView : NSView
@@ -169,7 +169,7 @@ void destroyDocumentMap()
 
 void relayoutDocumentMap()
 {
-	relayoutFunctionListPanel();
+	relayoutPanels();
 }
 
 void setDocumentMapEnabled(bool enabled)

--- a/macos/platform/file_browser_panel.h
+++ b/macos/platform/file_browser_panel.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <string>
+
+void initializeFileBrowserPanel();
+void destroyFileBrowserPanel();
+void setFileBrowserEnabled(bool enabled);
+void openFolderInFileBrowser(const std::string& path);
+void openFolderWithDialog();
+void* fileBrowserContainerView();

--- a/macos/platform/file_browser_panel.mm
+++ b/macos/platform/file_browser_panel.mm
@@ -284,11 +284,13 @@ static void startFSEventsMonitoring(const std::string& path)
 
 static void stopFSEventsMonitoring()
 {
-	if (sDebounceTimer)
-	{
-		dispatch_source_cancel(sDebounceTimer);
-		sDebounceTimer = nil;
-	}
+	dispatch_sync(fileBrowserQueue(), ^{
+		if (sDebounceTimer)
+		{
+			dispatch_source_cancel(sDebounceTimer);
+			sDebounceTimer = nil;
+		}
+	});
 
 	if (sEventStream)
 	{

--- a/macos/platform/file_browser_panel.mm
+++ b/macos/platform/file_browser_panel.mm
@@ -511,7 +511,12 @@ static void stopFSEventsMonitoring()
 		err.messageText = @"Error";
 		err.informativeText = [NSString stringWithFormat:@"Could not create file '%@'.", name];
 		[err runModal];
+		return;
 	}
+
+	// Immediately refresh so the new file appears without waiting for FSEvents
+	if (sOutlineView)
+		[sOutlineView reloadItem:nil reloadChildren:YES];
 }
 
 - (void)newFolder:(id)sender
@@ -591,7 +596,12 @@ static void stopFSEventsMonitoring()
 			err.informativeText = [NSString stringWithFormat:@"Could not create folder '%@'.", name];
 		}
 		[err runModal];
+		return;
 	}
+
+	// Immediately refresh so the new folder appears without waiting for FSEvents
+	if (sOutlineView)
+		[sOutlineView reloadItem:nil reloadChildren:YES];
 }
 
 - (void)renameItem:(id)sender
@@ -653,7 +663,14 @@ static void stopFSEventsMonitoring()
 	{
 		NSAlert* err = [NSAlert alertWithError:error];
 		[err runModal];
+		return;
 	}
+
+	// Update in-memory model and refresh outline view immediately
+	node->filename = [newName UTF8String];
+	node->path = [newPath UTF8String];
+	if (sOutlineView)
+		[sOutlineView reloadItem:wrapper];
 }
 
 - (void)deleteItem:(id)sender
@@ -681,7 +698,13 @@ static void stopFSEventsMonitoring()
 		return;
 
 	NSURL* url = [NSURL fileURLWithPath:path];
-	[[NSWorkspace sharedWorkspace] recycleURLs:@[url] completionHandler:nil];
+	[[NSWorkspace sharedWorkspace] recycleURLs:@[url]
+	                        completionHandler:^(NSDictionary<NSURL*, NSURL*>* _Nonnull newURLs, NSError* _Nullable error) {
+		dispatch_async(dispatch_get_main_queue(), ^{
+			if (sOutlineView)
+				[sOutlineView reloadData];
+		});
+	}];
 }
 
 - (void)revealInFinder:(id)sender

--- a/macos/platform/file_browser_panel.mm
+++ b/macos/platform/file_browser_panel.mm
@@ -5,6 +5,7 @@
 #import <Cocoa/Cocoa.h>
 #include <CoreServices/CoreServices.h>
 #include <algorithm>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -235,11 +236,9 @@ static void fsEventsCallback(ConstFSEventStreamRef streamRef,
 			dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
 			DISPATCH_TIME_FOREVER, 100 * NSEC_PER_MSEC);
 		dispatch_source_set_event_handler(sDebounceTimer, ^{
-			// Invalidate all childrenLoaded flags
-			invalidateChildrenRecursive(sRootNode);
-
-			// Reload UI on main queue
+			// Perform model invalidation and UI reload on the main queue to avoid data races
 			dispatch_async(dispatch_get_main_queue(), ^{
+				invalidateChildrenRecursive(sRootNode);
 				if (sOutlineView)
 					[sOutlineView reloadData];
 			});
@@ -417,6 +416,8 @@ static void stopFSEventsMonitoring()
 - (void)outlineViewClicked:(id)sender
 {
 	NSInteger row = sOutlineView ? sOutlineView.clickedRow : -1;
+	if (row < 0 && sOutlineView)
+		row = sOutlineView.selectedRow;
 	if (row < 0)
 		return;
 
@@ -503,7 +504,14 @@ static void stopFSEventsMonitoring()
 		return;
 	}
 
-	[[NSFileManager defaultManager] createFileAtPath:fullPath contents:[NSData data] attributes:nil];
+	BOOL created = [[NSFileManager defaultManager] createFileAtPath:fullPath contents:[NSData data] attributes:nil];
+	if (!created)
+	{
+		NSAlert* err = [[NSAlert alloc] init];
+		err.messageText = @"Error";
+		err.informativeText = [NSString stringWithFormat:@"Could not create file '%@'.", name];
+		[err runModal];
+	}
 }
 
 - (void)newFolder:(id)sender
@@ -569,10 +577,21 @@ static void stopFSEventsMonitoring()
 		return;
 	}
 
-	[[NSFileManager defaultManager] createDirectoryAtPath:fullPath
-	                          withIntermediateDirectories:NO
-	                                          attributes:nil
-	                                               error:nil];
+	NSError* error = nil;
+	BOOL created = [[NSFileManager defaultManager] createDirectoryAtPath:fullPath
+	                                        withIntermediateDirectories:NO
+	                                                        attributes:nil
+	                                                             error:&error];
+	if (!created)
+	{
+		NSAlert* err = error ? [NSAlert alertWithError:error] : [[NSAlert alloc] init];
+		if (!error)
+		{
+			err.messageText = @"Error";
+			err.informativeText = [NSString stringWithFormat:@"Could not create folder '%@'.", name];
+		}
+		[err runModal];
+	}
 }
 
 - (void)renameItem:(id)sender

--- a/macos/platform/file_browser_panel.mm
+++ b/macos/platform/file_browser_panel.mm
@@ -1031,11 +1031,12 @@ void openFolderWithDialog()
 		return;
 
 	std::string path = [url.path UTF8String];
-	openFolderInFileBrowser(path);
 
 	// Auto-enable the file browser if it is not already enabled
 	if (!ctx().fileBrowserEnabled)
 		setFileBrowserEnabled(true);
+
+	openFolderInFileBrowser(path);
 }
 
 void* fileBrowserContainerView()

--- a/macos/platform/file_browser_panel.mm
+++ b/macos/platform/file_browser_panel.mm
@@ -50,8 +50,26 @@ static NSImage* cachedIconForPath(NSString* path, bool isDirectory)
 	if (cacheKey.length == 0) cacheKey = @"__noext__";
 	NSImage* cached = [iconCache() objectForKey:cacheKey];
 	if (cached) return cached;
-	NSImage* icon = [[NSWorkspace sharedWorkspace] iconForFile:path];
-	[icon setSize:NSMakeSize(16, 16)];
+
+	NSImage* icon = nil;
+	if (isDirectory)
+	{
+		icon = [[NSWorkspace sharedWorkspace] iconForFileType:NSFileTypeForHFSTypeCode(kGenericFolderIcon)];
+	}
+	else
+	{
+		NSString* ext = [path pathExtension];
+		if (ext.length > 0)
+			icon = [[NSWorkspace sharedWorkspace] iconForFileType:ext];
+		else
+			icon = [[NSWorkspace sharedWorkspace] iconForFileType:NSFileTypeForHFSTypeCode(kGenericDocumentIcon)];
+	}
+
+	if (icon)
+		[icon setSize:NSMakeSize(16, 16)];
+	else
+		icon = [[NSWorkspace sharedWorkspace] iconForFile:path]; // fallback
+
 	[iconCache() setObject:icon forKey:cacheKey];
 	return icon;
 }

--- a/macos/platform/file_browser_panel.mm
+++ b/macos/platform/file_browser_panel.mm
@@ -711,6 +711,13 @@ static void stopFSEventsMonitoring()
 	[[NSWorkspace sharedWorkspace] recycleURLs:@[url]
 	                        completionHandler:^(NSDictionary<NSURL*, NSURL*>* _Nonnull newURLs, NSError* _Nullable error) {
 		dispatch_async(dispatch_get_main_queue(), ^{
+			if (error)
+			{
+				NSAlert* errAlert = [NSAlert alertWithError:error];
+				[errAlert runModal];
+				return;
+			}
+			invalidateChildrenRecursive(sRootNode);
 			if (sOutlineView)
 				[sOutlineView reloadData];
 		});

--- a/macos/platform/file_browser_panel.mm
+++ b/macos/platform/file_browser_panel.mm
@@ -515,6 +515,7 @@ static void stopFSEventsMonitoring()
 	}
 
 	// Immediately refresh so the new file appears without waiting for FSEvents
+	invalidateChildrenRecursive(sRootNode);
 	if (sOutlineView)
 		[sOutlineView reloadItem:nil reloadChildren:YES];
 }
@@ -600,6 +601,7 @@ static void stopFSEventsMonitoring()
 	}
 
 	// Immediately refresh so the new folder appears without waiting for FSEvents
+	invalidateChildrenRecursive(sRootNode);
 	if (sOutlineView)
 		[sOutlineView reloadItem:nil reloadChildren:YES];
 }

--- a/macos/platform/file_browser_panel.mm
+++ b/macos/platform/file_browser_panel.mm
@@ -1,0 +1,994 @@
+// file_browser_panel.mm — File browser panel with tree view, FSEvents, and context menu
+// Shows a folder tree in the left zone (top, above File Switcher).
+// Uses NSOutlineView with lazy-loaded children and icon caching.
+
+#import <Cocoa/Cocoa.h>
+#include <CoreServices/CoreServices.h>
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "file_browser_panel.h"
+#include "panel_layout.h"
+#include "app_state.h"
+#include "string_utils.h"
+#include "file_switcher_panel.h"
+#include "file_operations.h"
+#include "npp_constants.h"
+
+// ---------------------------------------------------------------------------
+// Serial dispatch queue for thread safety
+// ---------------------------------------------------------------------------
+static dispatch_queue_t sFileBrowserQueue = nil;
+static dispatch_queue_t fileBrowserQueue()
+{
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		sFileBrowserQueue = dispatch_queue_create("com.macnotepp.filebrowser", DISPATCH_QUEUE_SERIAL);
+	});
+	return sFileBrowserQueue;
+}
+
+// ---------------------------------------------------------------------------
+// Icon cache (by extension, not full path)
+// ---------------------------------------------------------------------------
+static NSCache<NSString*, NSImage*>* sIconCache = nil;
+static NSCache* iconCache()
+{
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		sIconCache = [[NSCache alloc] init];
+		sIconCache.countLimit = 200;
+	});
+	return sIconCache;
+}
+
+static NSImage* cachedIconForPath(NSString* path, bool isDirectory)
+{
+	NSString* cacheKey = isDirectory ? @"__folder__" : [path pathExtension];
+	if (cacheKey.length == 0) cacheKey = @"__noext__";
+	NSImage* cached = [iconCache() objectForKey:cacheKey];
+	if (cached) return cached;
+	NSImage* icon = [[NSWorkspace sharedWorkspace] iconForFile:path];
+	[icon setSize:NSMakeSize(16, 16)];
+	[iconCache() setObject:icon forKey:cacheKey];
+	return icon;
+}
+
+// ---------------------------------------------------------------------------
+// Data Model
+// ---------------------------------------------------------------------------
+struct FileBrowserNode
+{
+	std::string path;
+	std::string filename;
+	bool isDirectory = false;
+	bool isExpanded = false;
+	bool childrenLoaded = false;
+	std::vector<FileBrowserNode> children;
+};
+
+static FileBrowserNode sRootNode;
+
+static bool shouldIgnore(const std::string& name)
+{
+	for (const auto& pattern : ctx().fileBrowserIgnorePatterns)
+	{
+		if (name == pattern)
+			return true;
+	}
+	return false;
+}
+
+static void loadChildren(FileBrowserNode& node)
+{
+	if (node.childrenLoaded || !node.isDirectory)
+		return;
+
+	node.childrenLoaded = true;
+	node.children.clear();
+
+	NSString* dirPath = [NSString stringWithUTF8String:node.path.c_str()];
+	NSFileManager* fm = [NSFileManager defaultManager];
+	NSArray<NSString*>* contents = [fm contentsOfDirectoryAtPath:dirPath error:nil];
+	if (!contents)
+		return;
+
+	std::vector<FileBrowserNode> dirs;
+	std::vector<FileBrowserNode> files;
+
+	for (NSString* name in contents)
+	{
+		std::string nameStr = [name UTF8String];
+		if (shouldIgnore(nameStr))
+			continue;
+		// Skip hidden files (starting with '.')
+		if ([name hasPrefix:@"."])
+			continue;
+
+		NSString* fullPath = [dirPath stringByAppendingPathComponent:name];
+		BOOL isDir = NO;
+		[fm fileExistsAtPath:fullPath isDirectory:&isDir];
+
+		FileBrowserNode child;
+		child.path = [fullPath UTF8String];
+		child.filename = nameStr;
+		child.isDirectory = isDir ? true : false;
+
+		if (child.isDirectory)
+			dirs.push_back(std::move(child));
+		else
+			files.push_back(std::move(child));
+	}
+
+	// Sort directories and files alphabetically (case-insensitive)
+	auto cmpFunc = [](const FileBrowserNode& a, const FileBrowserNode& b) {
+		NSString* sa = [NSString stringWithUTF8String:a.filename.c_str()];
+		NSString* sb = [NSString stringWithUTF8String:b.filename.c_str()];
+		return [sa caseInsensitiveCompare:sb] == NSOrderedAscending;
+	};
+
+	std::sort(dirs.begin(), dirs.end(), cmpFunc);
+	std::sort(files.begin(), files.end(), cmpFunc);
+
+	// Directories first, then files
+	node.children.reserve(dirs.size() + files.size());
+	for (auto& d : dirs)
+		node.children.push_back(std::move(d));
+	for (auto& f : files)
+		node.children.push_back(std::move(f));
+}
+
+static void invalidateChildrenRecursive(FileBrowserNode& node)
+{
+	node.childrenLoaded = false;
+	for (auto& child : node.children)
+		invalidateChildrenRecursive(child);
+}
+
+// ---------------------------------------------------------------------------
+// Obj-C wrapper for NSOutlineView (following FunctionListItem pattern)
+// ---------------------------------------------------------------------------
+@interface FileBrowserNodeWrapper : NSObject
+@property (nonatomic, assign) FileBrowserNode* node;
++ (instancetype)wrapperForNode:(FileBrowserNode*)node;
+@end
+
+@implementation FileBrowserNodeWrapper
++ (instancetype)wrapperForNode:(FileBrowserNode*)node
+{
+	FileBrowserNodeWrapper* wrapper = [[FileBrowserNodeWrapper alloc] init];
+	wrapper.node = node;
+	return wrapper;
+}
+@end
+
+// ---------------------------------------------------------------------------
+// Custom NSOutlineView subclass for Enter-key activation
+// (Matches FunctionListOutlineView pattern)
+// ---------------------------------------------------------------------------
+@interface FileBrowserOutlineView : NSOutlineView
+@end
+
+@implementation FileBrowserOutlineView
+- (void)keyDown:(NSEvent*)event
+{
+	if (event.keyCode == 36) // Return key
+	{
+		id target = self.target;
+		SEL action = self.action;
+		if (target && action)
+		{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+			[target performSelector:action withObject:self];
+#pragma clang diagnostic pop
+			return;
+		}
+	}
+	[super keyDown:event];
+}
+@end
+
+// ---------------------------------------------------------------------------
+// Forward declarations
+// ---------------------------------------------------------------------------
+@class FileBrowserController;
+static FileBrowserController* sController = nil;
+static NSView* sContainer = nil;
+static NSScrollView* sScrollView = nil;
+static NSOutlineView* sOutlineView = nil;
+static NSView* sPlaceholderView = nil;
+static NSTextField* sTitleLabel = nil;
+
+// ---------------------------------------------------------------------------
+// FSEvents monitoring
+// ---------------------------------------------------------------------------
+static FSEventStreamRef sEventStream = NULL;
+static dispatch_source_t sDebounceTimer = nil;
+
+static void fsEventsCallback(ConstFSEventStreamRef streamRef,
+                             void* clientCallBackInfo,
+                             size_t numEvents,
+                             void* eventPaths,
+                             const FSEventStreamEventFlags eventFlags[],
+                             const FSEventStreamEventId eventIds[])
+{
+	dispatch_async(fileBrowserQueue(), ^{
+		// Cancel any existing debounce timer
+		if (sDebounceTimer)
+		{
+			dispatch_source_cancel(sDebounceTimer);
+			sDebounceTimer = nil;
+		}
+
+		sDebounceTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, fileBrowserQueue());
+		dispatch_source_set_timer(sDebounceTimer,
+			dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
+			DISPATCH_TIME_FOREVER, 100 * NSEC_PER_MSEC);
+		dispatch_source_set_event_handler(sDebounceTimer, ^{
+			// Invalidate all childrenLoaded flags
+			invalidateChildrenRecursive(sRootNode);
+
+			// Reload UI on main queue
+			dispatch_async(dispatch_get_main_queue(), ^{
+				if (sOutlineView)
+					[sOutlineView reloadData];
+			});
+
+			if (sDebounceTimer)
+			{
+				dispatch_source_cancel(sDebounceTimer);
+				sDebounceTimer = nil;
+			}
+		});
+		dispatch_resume(sDebounceTimer);
+	});
+}
+
+static void startFSEventsMonitoring(const std::string& path)
+{
+	if (sEventStream)
+		return;
+
+	NSString* nsPath = [NSString stringWithUTF8String:path.c_str()];
+	if (!nsPath)
+		return;
+
+	CFArrayRef pathsToWatch = (__bridge CFArrayRef)@[nsPath];
+	FSEventStreamContext context = {0, NULL, NULL, NULL, NULL};
+
+	sEventStream = FSEventStreamCreate(
+		kCFAllocatorDefault,
+		&fsEventsCallback,
+		&context,
+		pathsToWatch,
+		kFSEventStreamEventIdSinceNow,
+		1.0, // 1 second latency
+		kFSEventStreamCreateFlagUseCFTypes | kFSEventStreamCreateFlagFileEvents
+	);
+
+	if (sEventStream)
+	{
+		FSEventStreamScheduleWithRunLoop(sEventStream, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+		FSEventStreamStart(sEventStream);
+	}
+}
+
+static void stopFSEventsMonitoring()
+{
+	if (sDebounceTimer)
+	{
+		dispatch_source_cancel(sDebounceTimer);
+		sDebounceTimer = nil;
+	}
+
+	if (sEventStream)
+	{
+		FSEventStreamStop(sEventStream);
+		FSEventStreamInvalidate(sEventStream);
+		FSEventStreamRelease(sEventStream);
+		sEventStream = NULL;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FileBrowserController — NSOutlineViewDataSource + NSOutlineViewDelegate
+// ---------------------------------------------------------------------------
+@interface FileBrowserController : NSObject <NSOutlineViewDataSource, NSOutlineViewDelegate, NSMenuDelegate>
+- (void)outlineViewClicked:(id)sender;
+- (void)newFile:(id)sender;
+- (void)newFolder:(id)sender;
+- (void)renameItem:(id)sender;
+- (void)deleteItem:(id)sender;
+- (void)revealInFinder:(id)sender;
+- (void)copyPath:(id)sender;
+@end
+
+@implementation FileBrowserController
+
+// ---------------------------------------------------------------------------
+// NSOutlineViewDataSource
+// ---------------------------------------------------------------------------
+- (NSInteger)outlineView:(NSOutlineView*)outlineView numberOfChildrenOfItem:(id)item
+{
+	if (!item)
+	{
+		loadChildren(sRootNode);
+		return static_cast<NSInteger>(sRootNode.children.size());
+	}
+
+	FileBrowserNodeWrapper* wrapper = (FileBrowserNodeWrapper*)item;
+	FileBrowserNode* node = wrapper.node;
+	if (!node)
+		return 0;
+
+	loadChildren(*node);
+	return static_cast<NSInteger>(node->children.size());
+}
+
+- (id)outlineView:(NSOutlineView*)outlineView child:(NSInteger)index ofItem:(id)item
+{
+	FileBrowserNode* parent = nullptr;
+	if (!item)
+		parent = &sRootNode;
+	else
+		parent = ((FileBrowserNodeWrapper*)item).node;
+
+	if (!parent || index < 0 || index >= static_cast<NSInteger>(parent->children.size()))
+		return nil;
+
+	return [FileBrowserNodeWrapper wrapperForNode:&parent->children[static_cast<size_t>(index)]];
+}
+
+- (BOOL)outlineView:(NSOutlineView*)outlineView isItemExpandable:(id)item
+{
+	FileBrowserNodeWrapper* wrapper = (FileBrowserNodeWrapper*)item;
+	if (!wrapper || !wrapper.node)
+		return NO;
+	return wrapper.node->isDirectory ? YES : NO;
+}
+
+// ---------------------------------------------------------------------------
+// NSOutlineViewDelegate
+// ---------------------------------------------------------------------------
+- (NSView*)outlineView:(NSOutlineView*)outlineView
+	viewForTableColumn:(NSTableColumn*)tableColumn
+	              item:(id)item
+{
+	FileBrowserNodeWrapper* wrapper = (FileBrowserNodeWrapper*)item;
+	if (!wrapper || !wrapper.node)
+		return nil;
+
+	FileBrowserNode* node = wrapper.node;
+
+	NSTableCellView* cell = [outlineView makeViewWithIdentifier:@"FileBrowserCell" owner:self];
+	if (!cell)
+	{
+		cell = [[NSTableCellView alloc] initWithFrame:NSMakeRect(0, 0, 200, 20)];
+
+		NSImageView* imageView = [[NSImageView alloc] initWithFrame:NSMakeRect(0, 2, 16, 16)];
+		imageView.translatesAutoresizingMaskIntoConstraints = NO;
+		[cell addSubview:imageView];
+		cell.imageView = imageView;
+
+		NSTextField* text = [NSTextField labelWithString:@""];
+		text.translatesAutoresizingMaskIntoConstraints = NO;
+		text.lineBreakMode = NSLineBreakByTruncatingTail;
+		[text setContentHuggingPriority:NSLayoutPriorityDefaultLow
+		                 forOrientation:NSLayoutConstraintOrientationHorizontal];
+		[text setContentCompressionResistancePriority:NSLayoutPriorityDefaultLow
+		                              forOrientation:NSLayoutConstraintOrientationHorizontal];
+		[cell addSubview:text];
+		cell.textField = text;
+
+		cell.identifier = @"FileBrowserCell";
+		[NSLayoutConstraint activateConstraints:@[
+			[imageView.leadingAnchor constraintEqualToAnchor:cell.leadingAnchor constant:2],
+			[imageView.centerYAnchor constraintEqualToAnchor:cell.centerYAnchor],
+			[imageView.widthAnchor constraintEqualToConstant:16],
+			[imageView.heightAnchor constraintEqualToConstant:16],
+			[text.leadingAnchor constraintEqualToAnchor:imageView.trailingAnchor constant:4],
+			[text.trailingAnchor constraintEqualToAnchor:cell.trailingAnchor constant:-4],
+			[text.centerYAnchor constraintEqualToAnchor:cell.centerYAnchor]
+		]];
+	}
+
+	NSString* nsPath = [NSString stringWithUTF8String:node->path.c_str()];
+	cell.imageView.image = cachedIconForPath(nsPath, node->isDirectory);
+
+	cell.textField.stringValue = [NSString stringWithUTF8String:node->filename.c_str()] ?: @"";
+	cell.textField.font = [NSFont systemFontOfSize:[NSFont smallSystemFontSize]];
+
+	return cell;
+}
+
+// ---------------------------------------------------------------------------
+// Click action — open file on single click
+// ---------------------------------------------------------------------------
+- (void)outlineViewClicked:(id)sender
+{
+	NSInteger row = sOutlineView ? sOutlineView.clickedRow : -1;
+	if (row < 0)
+		return;
+
+	FileBrowserNodeWrapper* wrapper = (FileBrowserNodeWrapper*)[sOutlineView itemAtRow:row];
+	if (!wrapper || !wrapper.node)
+		return;
+
+	FileBrowserNode* node = wrapper.node;
+
+	// Directories: expand/collapse is handled natively by NSOutlineView
+	if (node->isDirectory)
+		return;
+
+	// Open the file in the editor
+	NSString* filePath = [NSString stringWithUTF8String:node->path.c_str()];
+	if (filePath)
+		openFileAtPath(filePath);
+}
+
+// ---------------------------------------------------------------------------
+// Context menu actions
+// ---------------------------------------------------------------------------
+- (void)newFile:(id)sender
+{
+	NSInteger row = sOutlineView ? sOutlineView.clickedRow : -1;
+	std::string parentDir;
+
+	if (row >= 0)
+	{
+		FileBrowserNodeWrapper* wrapper = (FileBrowserNodeWrapper*)[sOutlineView itemAtRow:row];
+		if (wrapper && wrapper.node)
+		{
+			if (wrapper.node->isDirectory)
+				parentDir = wrapper.node->path;
+			else
+			{
+				NSString* p = [NSString stringWithUTF8String:wrapper.node->path.c_str()];
+				parentDir = [[p stringByDeletingLastPathComponent] UTF8String];
+			}
+		}
+	}
+
+	if (parentDir.empty())
+		parentDir = sRootNode.path;
+
+	NSAlert* alert = [[NSAlert alloc] init];
+	alert.messageText = @"New File";
+	alert.informativeText = @"Enter a name for the new file:";
+	[alert addButtonWithTitle:@"Create"];
+	[alert addButtonWithTitle:@"Cancel"];
+
+	NSTextField* input = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 260, 24)];
+	input.stringValue = @"";
+	input.placeholderString = @"filename.txt";
+	alert.accessoryView = input;
+	[alert.window setInitialFirstResponder:input];
+
+	if ([alert runModal] != NSAlertFirstButtonReturn)
+		return;
+
+	NSString* name = input.stringValue;
+	if (name.length == 0)
+		return;
+
+	// Validate name
+	if ([name containsString:@"/"] || [name containsString:@":"])
+	{
+		NSAlert* err = [[NSAlert alloc] init];
+		err.messageText = @"Invalid Name";
+		err.informativeText = @"File name cannot contain '/' or ':' characters.";
+		[err runModal];
+		return;
+	}
+
+	NSString* dir = [NSString stringWithUTF8String:parentDir.c_str()];
+	NSString* fullPath = [dir stringByAppendingPathComponent:name];
+
+	if ([[NSFileManager defaultManager] fileExistsAtPath:fullPath])
+	{
+		NSAlert* err = [[NSAlert alloc] init];
+		err.messageText = @"Already Exists";
+		err.informativeText = [NSString stringWithFormat:@"'%@' already exists.", name];
+		[err runModal];
+		return;
+	}
+
+	[[NSFileManager defaultManager] createFileAtPath:fullPath contents:[NSData data] attributes:nil];
+}
+
+- (void)newFolder:(id)sender
+{
+	NSInteger row = sOutlineView ? sOutlineView.clickedRow : -1;
+	std::string parentDir;
+
+	if (row >= 0)
+	{
+		FileBrowserNodeWrapper* wrapper = (FileBrowserNodeWrapper*)[sOutlineView itemAtRow:row];
+		if (wrapper && wrapper.node)
+		{
+			if (wrapper.node->isDirectory)
+				parentDir = wrapper.node->path;
+			else
+			{
+				NSString* p = [NSString stringWithUTF8String:wrapper.node->path.c_str()];
+				parentDir = [[p stringByDeletingLastPathComponent] UTF8String];
+			}
+		}
+	}
+
+	if (parentDir.empty())
+		parentDir = sRootNode.path;
+
+	NSAlert* alert = [[NSAlert alloc] init];
+	alert.messageText = @"New Folder";
+	alert.informativeText = @"Enter a name for the new folder:";
+	[alert addButtonWithTitle:@"Create"];
+	[alert addButtonWithTitle:@"Cancel"];
+
+	NSTextField* input = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 260, 24)];
+	input.stringValue = @"";
+	input.placeholderString = @"folder-name";
+	alert.accessoryView = input;
+	[alert.window setInitialFirstResponder:input];
+
+	if ([alert runModal] != NSAlertFirstButtonReturn)
+		return;
+
+	NSString* name = input.stringValue;
+	if (name.length == 0)
+		return;
+
+	if ([name containsString:@"/"] || [name containsString:@":"])
+	{
+		NSAlert* err = [[NSAlert alloc] init];
+		err.messageText = @"Invalid Name";
+		err.informativeText = @"Folder name cannot contain '/' or ':' characters.";
+		[err runModal];
+		return;
+	}
+
+	NSString* dir = [NSString stringWithUTF8String:parentDir.c_str()];
+	NSString* fullPath = [dir stringByAppendingPathComponent:name];
+
+	if ([[NSFileManager defaultManager] fileExistsAtPath:fullPath])
+	{
+		NSAlert* err = [[NSAlert alloc] init];
+		err.messageText = @"Already Exists";
+		err.informativeText = [NSString stringWithFormat:@"'%@' already exists.", name];
+		[err runModal];
+		return;
+	}
+
+	[[NSFileManager defaultManager] createDirectoryAtPath:fullPath
+	                          withIntermediateDirectories:NO
+	                                          attributes:nil
+	                                               error:nil];
+}
+
+- (void)renameItem:(id)sender
+{
+	NSInteger row = sOutlineView ? sOutlineView.clickedRow : -1;
+	if (row < 0)
+		return;
+
+	FileBrowserNodeWrapper* wrapper = (FileBrowserNodeWrapper*)[sOutlineView itemAtRow:row];
+	if (!wrapper || !wrapper.node)
+		return;
+
+	FileBrowserNode* node = wrapper.node;
+	NSString* oldPath = [NSString stringWithUTF8String:node->path.c_str()];
+	NSString* oldName = [NSString stringWithUTF8String:node->filename.c_str()];
+
+	NSAlert* alert = [[NSAlert alloc] init];
+	alert.messageText = @"Rename";
+	alert.informativeText = [NSString stringWithFormat:@"Enter a new name for '%@':", oldName];
+	[alert addButtonWithTitle:@"Rename"];
+	[alert addButtonWithTitle:@"Cancel"];
+
+	NSTextField* input = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 260, 24)];
+	input.stringValue = oldName;
+	alert.accessoryView = input;
+	[alert.window setInitialFirstResponder:input];
+
+	if ([alert runModal] != NSAlertFirstButtonReturn)
+		return;
+
+	NSString* newName = input.stringValue;
+	if (newName.length == 0 || [newName isEqualToString:oldName])
+		return;
+
+	if ([newName containsString:@"/"] || [newName containsString:@":"])
+	{
+		NSAlert* err = [[NSAlert alloc] init];
+		err.messageText = @"Invalid Name";
+		err.informativeText = @"Name cannot contain '/' or ':' characters.";
+		[err runModal];
+		return;
+	}
+
+	NSString* parentDir = [oldPath stringByDeletingLastPathComponent];
+	NSString* newPath = [parentDir stringByAppendingPathComponent:newName];
+
+	if ([[NSFileManager defaultManager] fileExistsAtPath:newPath])
+	{
+		NSAlert* err = [[NSAlert alloc] init];
+		err.messageText = @"Already Exists";
+		err.informativeText = [NSString stringWithFormat:@"'%@' already exists.", newName];
+		[err runModal];
+		return;
+	}
+
+	NSError* error = nil;
+	[[NSFileManager defaultManager] moveItemAtPath:oldPath toPath:newPath error:&error];
+	if (error)
+	{
+		NSAlert* err = [NSAlert alertWithError:error];
+		[err runModal];
+	}
+}
+
+- (void)deleteItem:(id)sender
+{
+	NSInteger row = sOutlineView ? sOutlineView.clickedRow : -1;
+	if (row < 0)
+		return;
+
+	FileBrowserNodeWrapper* wrapper = (FileBrowserNodeWrapper*)[sOutlineView itemAtRow:row];
+	if (!wrapper || !wrapper.node)
+		return;
+
+	FileBrowserNode* node = wrapper.node;
+	NSString* name = [NSString stringWithUTF8String:node->filename.c_str()];
+	NSString* path = [NSString stringWithUTF8String:node->path.c_str()];
+
+	NSAlert* confirm = [[NSAlert alloc] init];
+	confirm.messageText = @"Delete";
+	confirm.informativeText = [NSString stringWithFormat:@"Move '%@' to Trash?", name];
+	[confirm addButtonWithTitle:@"Move to Trash"];
+	[confirm addButtonWithTitle:@"Cancel"];
+	confirm.alertStyle = NSAlertStyleWarning;
+
+	if ([confirm runModal] != NSAlertFirstButtonReturn)
+		return;
+
+	NSURL* url = [NSURL fileURLWithPath:path];
+	[[NSWorkspace sharedWorkspace] recycleURLs:@[url] completionHandler:nil];
+}
+
+- (void)revealInFinder:(id)sender
+{
+	NSInteger row = sOutlineView ? sOutlineView.clickedRow : -1;
+	if (row < 0)
+		return;
+
+	FileBrowserNodeWrapper* wrapper = (FileBrowserNodeWrapper*)[sOutlineView itemAtRow:row];
+	if (!wrapper || !wrapper.node)
+		return;
+
+	NSString* path = [NSString stringWithUTF8String:wrapper.node->path.c_str()];
+	[[NSWorkspace sharedWorkspace] selectFile:path inFileViewerRootedAtPath:@""];
+}
+
+- (void)copyPath:(id)sender
+{
+	NSInteger row = sOutlineView ? sOutlineView.clickedRow : -1;
+	if (row < 0)
+		return;
+
+	FileBrowserNodeWrapper* wrapper = (FileBrowserNodeWrapper*)[sOutlineView itemAtRow:row];
+	if (!wrapper || !wrapper.node)
+		return;
+
+	NSString* path = [NSString stringWithUTF8String:wrapper.node->path.c_str()];
+	NSPasteboard* pb = [NSPasteboard generalPasteboard];
+	[pb clearContents];
+	[pb setString:path forType:NSPasteboardTypeString];
+}
+
+// ---------------------------------------------------------------------------
+// Context menu delegate
+// ---------------------------------------------------------------------------
+- (void)menuNeedsUpdate:(NSMenu*)menu
+{
+	[menu removeAllItems];
+
+	NSInteger row = sOutlineView ? sOutlineView.clickedRow : -1;
+
+	// Always offer New File and New Folder
+	[menu addItemWithTitle:@"New File" action:@selector(newFile:) keyEquivalent:@""];
+	[menu addItemWithTitle:@"New Folder" action:@selector(newFolder:) keyEquivalent:@""];
+
+	if (row >= 0)
+	{
+		[menu addItem:[NSMenuItem separatorItem]];
+		[menu addItemWithTitle:@"Rename" action:@selector(renameItem:) keyEquivalent:@""];
+		[menu addItemWithTitle:@"Delete" action:@selector(deleteItem:) keyEquivalent:@""];
+		[menu addItem:[NSMenuItem separatorItem]];
+		[menu addItemWithTitle:@"Reveal in Finder" action:@selector(revealInFinder:) keyEquivalent:@""];
+		[menu addItemWithTitle:@"Copy Path" action:@selector(copyPath:) keyEquivalent:@""];
+	}
+
+	for (NSMenuItem* item in menu.itemArray)
+	{
+		if (item.action)
+			item.target = self;
+	}
+}
+
+@end
+
+// ---------------------------------------------------------------------------
+// Placeholder view (shown when no folder is open)
+// ---------------------------------------------------------------------------
+static void createPlaceholderView(NSView* container)
+{
+	sPlaceholderView = [[NSView alloc] initWithFrame:NSZeroRect];
+	sPlaceholderView.translatesAutoresizingMaskIntoConstraints = NO;
+	[container addSubview:sPlaceholderView];
+
+	NSTextField* label = [NSTextField labelWithString:@"Open a folder to get started"];
+	label.translatesAutoresizingMaskIntoConstraints = NO;
+	label.alignment = NSTextAlignmentCenter;
+	label.textColor = NSColor.secondaryLabelColor;
+	label.font = [NSFont systemFontOfSize:12];
+	label.lineBreakMode = NSLineBreakByWordWrapping;
+	label.preferredMaxLayoutWidth = 160;
+	[sPlaceholderView addSubview:label];
+
+	NSButton* openButton = [NSButton buttonWithTitle:@"Open Folder"
+	                                          target:nil
+	                                          action:@selector(openFolderButtonClicked:)];
+	openButton.translatesAutoresizingMaskIntoConstraints = NO;
+	openButton.bezelStyle = NSBezelStyleRounded;
+	[sPlaceholderView addSubview:openButton];
+
+	[NSLayoutConstraint activateConstraints:@[
+		[sPlaceholderView.topAnchor constraintEqualToAnchor:container.topAnchor],
+		[sPlaceholderView.leadingAnchor constraintEqualToAnchor:container.leadingAnchor],
+		[sPlaceholderView.trailingAnchor constraintEqualToAnchor:container.trailingAnchor],
+		[sPlaceholderView.bottomAnchor constraintEqualToAnchor:container.bottomAnchor],
+		[label.centerXAnchor constraintEqualToAnchor:sPlaceholderView.centerXAnchor],
+		[label.centerYAnchor constraintEqualToAnchor:sPlaceholderView.centerYAnchor constant:-16],
+		[openButton.centerXAnchor constraintEqualToAnchor:sPlaceholderView.centerXAnchor],
+		[openButton.topAnchor constraintEqualToAnchor:label.bottomAnchor constant:8]
+	]];
+}
+
+// ---------------------------------------------------------------------------
+// Responder for "Open Folder" button in placeholder
+// ---------------------------------------------------------------------------
+@interface FileBrowserPlaceholderResponder : NSObject
+- (void)openFolderButtonClicked:(id)sender;
+@end
+
+static FileBrowserPlaceholderResponder* sPlaceholderResponder = nil;
+
+@implementation FileBrowserPlaceholderResponder
+- (void)openFolderButtonClicked:(id)sender
+{
+	openFolderWithDialog();
+}
+@end
+
+// ---------------------------------------------------------------------------
+// showOutlineView / showPlaceholder — toggle between tree and placeholder
+// ---------------------------------------------------------------------------
+static void showOutlineView()
+{
+	if (sScrollView) sScrollView.hidden = NO;
+	if (sPlaceholderView) sPlaceholderView.hidden = YES;
+}
+
+static void showPlaceholder()
+{
+	if (sScrollView) sScrollView.hidden = YES;
+	if (sPlaceholderView) sPlaceholderView.hidden = NO;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+void initializeFileBrowserPanel()
+{
+	if (!ctx().mainWindow || !ctx().editorContainer || sContainer)
+		return;
+
+	NSView* contentView = ctx().mainWindow.contentView;
+	if (!contentView)
+		return;
+
+	sController = [[FileBrowserController alloc] init];
+	sPlaceholderResponder = [[FileBrowserPlaceholderResponder alloc] init];
+
+	CGFloat width = static_cast<CGFloat>(ctx().leftPanelWidth);
+	if (width < 120) width = 120;
+	if (width > 360) width = 360;
+	ctx().leftPanelWidth = static_cast<int>(width);
+
+	sContainer = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, width, 100)];
+	sContainer.autoresizingMask = NSViewWidthSizable;
+	[contentView addSubview:sContainer];
+
+	// Title label
+	sTitleLabel = [NSTextField labelWithString:@"File Browser"];
+	sTitleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+	sTitleLabel.font = [NSFont systemFontOfSize:11 weight:NSFontWeightSemibold];
+	sTitleLabel.textColor = NSColor.secondaryLabelColor;
+	[sContainer addSubview:sTitleLabel];
+
+	// Scroll view with outline view
+	sScrollView = [[NSScrollView alloc] initWithFrame:NSZeroRect];
+	sScrollView.translatesAutoresizingMaskIntoConstraints = NO;
+	sScrollView.hasVerticalScroller = YES;
+	sScrollView.hasHorizontalScroller = NO;
+	sScrollView.autohidesScrollers = YES;
+	sScrollView.borderType = NSBezelBorder;
+	[sContainer addSubview:sScrollView];
+
+	FileBrowserOutlineView* outline = [[FileBrowserOutlineView alloc] initWithFrame:NSZeroRect];
+	outline.headerView = nil;
+	outline.usesAlternatingRowBackgroundColors = YES;
+	NSTableColumn* column = [[NSTableColumn alloc] initWithIdentifier:@"FileBrowserColumn"];
+	column.resizingMask = NSTableColumnAutoresizingMask;
+	[outline addTableColumn:column];
+	outline.outlineTableColumn = column;
+	outline.dataSource = sController;
+	outline.delegate = sController;
+	outline.target = sController;
+	outline.action = @selector(outlineViewClicked:);
+	sOutlineView = outline;
+	sScrollView.documentView = outline;
+
+	// Context menu
+	NSMenu* contextMenu = [[NSMenu alloc] initWithTitle:@""];
+	contextMenu.delegate = sController;
+	outline.menu = contextMenu;
+
+	// Placeholder view
+	createPlaceholderView(sContainer);
+
+	// Wire up the Open Folder button in the placeholder
+	for (NSView* subview in sPlaceholderView.subviews)
+	{
+		if ([subview isKindOfClass:[NSButton class]])
+		{
+			NSButton* btn = (NSButton*)subview;
+			btn.target = sPlaceholderResponder;
+			btn.action = @selector(openFolderButtonClicked:);
+		}
+	}
+
+	// Layout constraints
+	[NSLayoutConstraint activateConstraints:@[
+		[sTitleLabel.topAnchor constraintEqualToAnchor:sContainer.topAnchor constant:6],
+		[sTitleLabel.leadingAnchor constraintEqualToAnchor:sContainer.leadingAnchor constant:6],
+		[sScrollView.topAnchor constraintEqualToAnchor:sTitleLabel.bottomAnchor constant:4],
+		[sScrollView.leadingAnchor constraintEqualToAnchor:sContainer.leadingAnchor constant:6],
+		[sScrollView.trailingAnchor constraintEqualToAnchor:sContainer.trailingAnchor constant:-6],
+		[sScrollView.bottomAnchor constraintEqualToAnchor:sContainer.bottomAnchor constant:-6]
+	]];
+
+	// Check if there's a saved root path to auto-open
+	if (!ctx().fileBrowserRootPath.empty())
+	{
+		NSString* rootPath = [NSString stringWithUTF8String:ctx().fileBrowserRootPath.c_str()];
+		if ([[NSFileManager defaultManager] fileExistsAtPath:rootPath])
+		{
+			openFolderInFileBrowser(ctx().fileBrowserRootPath);
+			return;
+		}
+	}
+
+	// Show placeholder if no folder is open
+	showPlaceholder();
+}
+
+void destroyFileBrowserPanel()
+{
+	stopFSEventsMonitoring();
+
+	if (sScrollView)
+	{
+		[sScrollView removeFromSuperview];
+		sScrollView = nil;
+	}
+	sOutlineView = nil;
+	if (sPlaceholderView)
+	{
+		[sPlaceholderView removeFromSuperview];
+		sPlaceholderView = nil;
+	}
+	if (sTitleLabel)
+	{
+		[sTitleLabel removeFromSuperview];
+		sTitleLabel = nil;
+	}
+	if (sContainer)
+	{
+		[sContainer removeFromSuperview];
+		sContainer = nil;
+	}
+	sController = nil;
+	sPlaceholderResponder = nil;
+	sRootNode = FileBrowserNode();
+}
+
+void setFileBrowserEnabled(bool enabled)
+{
+	ctx().fileBrowserEnabled = enabled;
+	if (enabled)
+	{
+		if (!sContainer)
+			initializeFileBrowserPanel();
+	}
+	relayoutPanels();
+}
+
+void openFolderInFileBrowser(const std::string& path)
+{
+	if (path.empty())
+		return;
+
+	// Stop existing monitoring
+	stopFSEventsMonitoring();
+
+	// Set root node
+	sRootNode = FileBrowserNode();
+	sRootNode.path = path;
+	sRootNode.isDirectory = true;
+
+	NSString* nsPath = [NSString stringWithUTF8String:path.c_str()];
+	sRootNode.filename = [[nsPath lastPathComponent] UTF8String];
+
+	// Update title to folder name
+	if (sTitleLabel)
+		sTitleLabel.stringValue = [NSString stringWithUTF8String:sRootNode.filename.c_str()];
+
+	// Save the root path in context
+	ctx().fileBrowserRootPath = path;
+
+	// Show outline, hide placeholder
+	showOutlineView();
+
+	// Reload the outline view
+	if (sOutlineView)
+		[sOutlineView reloadData];
+
+	// Start FSEvents monitoring
+	startFSEventsMonitoring(path);
+
+	// Refresh file switcher path display
+	reloadFileSwitcherData();
+}
+
+void openFolderWithDialog()
+{
+	NSOpenPanel* panel = [NSOpenPanel openPanel];
+	panel.canChooseDirectories = YES;
+	panel.canChooseFiles = NO;
+	panel.allowsMultipleSelection = NO;
+	panel.prompt = @"Open";
+	panel.message = @"Choose a folder to browse";
+
+	if ([panel runModal] != NSModalResponseOK)
+		return;
+
+	NSURL* url = panel.URL;
+	if (!url || !url.path)
+		return;
+
+	std::string path = [url.path UTF8String];
+	openFolderInFileBrowser(path);
+
+	// Auto-enable the file browser if it is not already enabled
+	if (!ctx().fileBrowserEnabled)
+		setFileBrowserEnabled(true);
+}
+
+void* fileBrowserContainerView()
+{
+	return (__bridge void*)sContainer;
+}

--- a/macos/platform/file_browser_panel.mm
+++ b/macos/platform/file_browser_panel.mm
@@ -673,8 +673,14 @@ static void stopFSEventsMonitoring()
 	// Update in-memory model and refresh outline view immediately
 	node->filename = [newName UTF8String];
 	node->path = [newPath UTF8String];
+
+	// If a directory was renamed, descendant paths are now stale — invalidate
+	// the subtree so children are reloaded from disk on next expansion
+	if (node->isDirectory)
+		invalidateChildrenRecursive(*node);
+
 	if (sOutlineView)
-		[sOutlineView reloadItem:wrapper];
+		[sOutlineView reloadItem:nil reloadChildren:YES];
 }
 
 - (void)deleteItem:(id)sender

--- a/macos/platform/file_browser_panel.mm
+++ b/macos/platform/file_browser_panel.mm
@@ -65,7 +65,7 @@ struct FileBrowserNode
 	bool isDirectory = false;
 	bool isExpanded = false;
 	bool childrenLoaded = false;
-	std::vector<FileBrowserNode> children;
+	std::vector<std::shared_ptr<FileBrowserNode>> children;
 };
 
 static FileBrowserNode sRootNode;
@@ -94,8 +94,8 @@ static void loadChildren(FileBrowserNode& node)
 	if (!contents)
 		return;
 
-	std::vector<FileBrowserNode> dirs;
-	std::vector<FileBrowserNode> files;
+	std::vector<std::shared_ptr<FileBrowserNode>> dirs;
+	std::vector<std::shared_ptr<FileBrowserNode>> files;
 
 	for (NSString* name in contents)
 	{
@@ -110,21 +110,22 @@ static void loadChildren(FileBrowserNode& node)
 		BOOL isDir = NO;
 		[fm fileExistsAtPath:fullPath isDirectory:&isDir];
 
-		FileBrowserNode child;
-		child.path = [fullPath UTF8String];
-		child.filename = nameStr;
-		child.isDirectory = isDir ? true : false;
+		auto child = std::make_shared<FileBrowserNode>();
+		child->path = [fullPath UTF8String];
+		child->filename = nameStr;
+		child->isDirectory = isDir ? true : false;
 
-		if (child.isDirectory)
+		if (child->isDirectory)
 			dirs.push_back(std::move(child));
 		else
 			files.push_back(std::move(child));
 	}
 
 	// Sort directories and files alphabetically (case-insensitive)
-	auto cmpFunc = [](const FileBrowserNode& a, const FileBrowserNode& b) {
-		NSString* sa = [NSString stringWithUTF8String:a.filename.c_str()];
-		NSString* sb = [NSString stringWithUTF8String:b.filename.c_str()];
+	auto cmpFunc = [](const std::shared_ptr<FileBrowserNode>& a,
+	                  const std::shared_ptr<FileBrowserNode>& b) {
+		NSString* sa = [NSString stringWithUTF8String:a->filename.c_str()];
+		NSString* sb = [NSString stringWithUTF8String:b->filename.c_str()];
 		return [sa caseInsensitiveCompare:sb] == NSOrderedAscending;
 	};
 
@@ -143,23 +144,30 @@ static void invalidateChildrenRecursive(FileBrowserNode& node)
 {
 	node.childrenLoaded = false;
 	for (auto& child : node.children)
-		invalidateChildrenRecursive(child);
+		invalidateChildrenRecursive(*child);
 }
 
 // ---------------------------------------------------------------------------
 // Obj-C wrapper for NSOutlineView (following FunctionListItem pattern)
 // ---------------------------------------------------------------------------
 @interface FileBrowserNodeWrapper : NSObject
-@property (nonatomic, assign) FileBrowserNode* node;
-+ (instancetype)wrapperForNode:(FileBrowserNode*)node;
+{
+	std::shared_ptr<FileBrowserNode> _sharedNode;
+}
+@property (nonatomic, readonly) FileBrowserNode* node;
++ (instancetype)wrapperForNode:(std::shared_ptr<FileBrowserNode>)sharedNode;
 @end
 
 @implementation FileBrowserNodeWrapper
-+ (instancetype)wrapperForNode:(FileBrowserNode*)node
++ (instancetype)wrapperForNode:(std::shared_ptr<FileBrowserNode>)sharedNode
 {
 	FileBrowserNodeWrapper* wrapper = [[FileBrowserNodeWrapper alloc] init];
-	wrapper.node = node;
+	wrapper->_sharedNode = sharedNode;
 	return wrapper;
+}
+- (FileBrowserNode*)node
+{
+	return _sharedNode.get();
 }
 @end
 
@@ -338,7 +346,7 @@ static void stopFSEventsMonitoring()
 	if (!parent || index < 0 || index >= static_cast<NSInteger>(parent->children.size()))
 		return nil;
 
-	return [FileBrowserNodeWrapper wrapperForNode:&parent->children[static_cast<size_t>(index)]];
+	return [FileBrowserNodeWrapper wrapperForNode:parent->children[static_cast<size_t>(index)]];
 }
 
 - (BOOL)outlineView:(NSOutlineView*)outlineView isItemExpandable:(id)item

--- a/macos/platform/file_switcher_panel.h
+++ b/macos/platform/file_switcher_panel.h
@@ -1,0 +1,8 @@
+#pragma once
+
+void initializeFileSwitcherPanel();
+void destroyFileSwitcherPanel();
+void setFileSwitcherEnabled(bool enabled);
+void bindFileSwitcherToActiveView();
+void reloadFileSwitcherData();
+void* fileSwitcherContainerView();

--- a/macos/platform/file_switcher_panel.mm
+++ b/macos/platform/file_switcher_panel.mm
@@ -49,18 +49,20 @@ static NSString* displayPathForDocument(const DocumentData& doc)
 	if (!rootPath.empty())
 	{
 		NSString* root = [NSString stringWithUTF8String:rootPath.c_str()];
-		if (root && [fullPath hasPrefix:root])
+		if (root)
 		{
-			NSString* relative = [fullPath substringFromIndex:root.length];
-			if ([relative hasPrefix:@"/"])
-				relative = [relative substringFromIndex:1];
-			return relative;
+			NSString* normalizedRoot = [root hasSuffix:@"/"] ? root : [root stringByAppendingString:@"/"];
+			if ([fullPath hasPrefix:normalizedRoot])
+			{
+				NSString* relative = [fullPath substringFromIndex:normalizedRoot.length];
+				return relative;
+			}
 		}
 	}
 
-	// Otherwise show parent directory name
+	// Otherwise show full parent directory path
 	NSString* parent = [fullPath stringByDeletingLastPathComponent];
-	return [parent lastPathComponent];
+	return parent;
 }
 
 // ---------------------------------------------------------------------------
@@ -173,18 +175,27 @@ static void switchToDocumentAtRow(NSInteger row)
 	// Check if this is a separator row
 	if (ctx().isSplit && row == count1)
 	{
-		NSTextField* label = [NSTextField labelWithString:@"\u2014 Split View \u2014"];
-		label.alignment = NSTextAlignmentCenter;
-		label.font = [NSFont systemFontOfSize:10 weight:NSFontWeightMedium];
-		label.textColor = NSColor.tertiaryLabelColor;
+		static NSString* separatorID = @"FileSwitcherSeparator";
+		NSTableCellView* cell = [tableView makeViewWithIdentifier:separatorID owner:self];
+		if (!cell)
+		{
+			cell = [[NSTableCellView alloc] initWithFrame:NSZeroRect];
+			cell.identifier = separatorID;
 
-		NSTableCellView* cell = [[NSTableCellView alloc] initWithFrame:NSZeroRect];
-		label.translatesAutoresizingMaskIntoConstraints = NO;
-		[cell addSubview:label];
-		[NSLayoutConstraint activateConstraints:@[
-			[label.centerXAnchor constraintEqualToAnchor:cell.centerXAnchor],
-			[label.centerYAnchor constraintEqualToAnchor:cell.centerYAnchor]
-		]];
+			NSTextField* label = [NSTextField labelWithString:@""];
+			label.tag = 10;
+			label.alignment = NSTextAlignmentCenter;
+			label.font = [NSFont systemFontOfSize:10 weight:NSFontWeightMedium];
+			label.textColor = NSColor.tertiaryLabelColor;
+			label.translatesAutoresizingMaskIntoConstraints = NO;
+			[cell addSubview:label];
+			[NSLayoutConstraint activateConstraints:@[
+				[label.centerXAnchor constraintEqualToAnchor:cell.centerXAnchor],
+				[label.centerYAnchor constraintEqualToAnchor:cell.centerYAnchor]
+			]];
+		}
+		NSTextField* label = (NSTextField*)[cell viewWithTag:10];
+		label.stringValue = @"\u2014 Split View \u2014";
 		return cell;
 	}
 
@@ -203,58 +214,68 @@ static void switchToDocumentAtRow(NSInteger row)
 	int activeIdx = (resolved.viewIndex == 0) ? ctx().activeTab : ctx().activeTab2;
 	bool isActive = (resolved.docIndex == activeIdx) && (resolved.viewIndex == ctx().activeView);
 
-	// Build two-line cell
-	NSTableCellView* cell = [[NSTableCellView alloc] initWithFrame:NSZeroRect];
+	// Reuse or create document cell
+	static NSString* cellID = @"FileSwitcherDocCell";
+	NSTableCellView* cell = [tableView makeViewWithIdentifier:cellID owner:self];
+	if (!cell)
+	{
+		cell = [[NSTableCellView alloc] initWithFrame:NSZeroRect];
+		cell.identifier = cellID;
 
-	// Modified indicator dot (6px orange circle)
-	NSView* modDot = [[NSView alloc] initWithFrame:NSZeroRect];
-	modDot.translatesAutoresizingMaskIntoConstraints = NO;
-	modDot.wantsLayer = YES;
-	modDot.layer.cornerRadius = 3.0;
+		// Modified indicator dot (6px orange circle) — subview index 0
+		NSView* modDot = [[NSView alloc] initWithFrame:NSZeroRect];
+		modDot.translatesAutoresizingMaskIntoConstraints = NO;
+		modDot.wantsLayer = YES;
+		modDot.layer.cornerRadius = 3.0;
+		[cell addSubview:modDot];
+
+		// Filename label — subview index 1
+		NSTextField* titleLabel = [NSTextField labelWithString:@""];
+		titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+		titleLabel.textColor = NSColor.labelColor;
+		titleLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
+		[cell addSubview:titleLabel];
+
+		// Path label (dimmer, smaller) — subview index 2
+		NSTextField* pathLabel = [NSTextField labelWithString:@""];
+		pathLabel.translatesAutoresizingMaskIntoConstraints = NO;
+		pathLabel.font = [NSFont systemFontOfSize:10 weight:NSFontWeightRegular];
+		pathLabel.textColor = NSColor.secondaryLabelColor;
+		pathLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
+		[cell addSubview:pathLabel];
+
+		// Layout constraints
+		[NSLayoutConstraint activateConstraints:@[
+			[modDot.leadingAnchor constraintEqualToAnchor:cell.leadingAnchor constant:4],
+			[modDot.centerYAnchor constraintEqualToAnchor:cell.centerYAnchor],
+			[modDot.widthAnchor constraintEqualToConstant:6],
+			[modDot.heightAnchor constraintEqualToConstant:6],
+			[titleLabel.leadingAnchor constraintEqualToAnchor:modDot.trailingAnchor constant:4],
+			[titleLabel.trailingAnchor constraintLessThanOrEqualToAnchor:cell.trailingAnchor constant:-4],
+			[titleLabel.topAnchor constraintEqualToAnchor:cell.topAnchor constant:2],
+			[pathLabel.leadingAnchor constraintEqualToAnchor:titleLabel.leadingAnchor],
+			[pathLabel.trailingAnchor constraintLessThanOrEqualToAnchor:cell.trailingAnchor constant:-4],
+			[pathLabel.topAnchor constraintEqualToAnchor:titleLabel.bottomAnchor constant:0],
+			[pathLabel.bottomAnchor constraintLessThanOrEqualToAnchor:cell.bottomAnchor constant:-2]
+		]];
+	}
+
+	// Update cell content (subviews added in fixed order: 0=modDot, 1=title, 2=path)
+	NSView* modDot = cell.subviews[0];
+	NSTextField* titleLabel = (NSTextField*)cell.subviews[1];
+	NSTextField* pathLabel = (NSTextField*)cell.subviews[2];
+
 	modDot.layer.backgroundColor = doc.modified
 		? [NSColor orangeColor].CGColor
 		: [NSColor clearColor].CGColor;
-	[cell addSubview:modDot];
 
-	// Filename label
 	NSString* titleStr = wstringToNSString(doc.title);
-	NSTextField* titleLabel = [NSTextField labelWithString:titleStr ?: @"Untitled"];
-	titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+	titleLabel.stringValue = titleStr ?: @"Untitled";
 	titleLabel.font = isActive
 		? [NSFont systemFontOfSize:12 weight:NSFontWeightSemibold]
 		: [NSFont systemFontOfSize:12 weight:NSFontWeightRegular];
-	titleLabel.textColor = NSColor.labelColor;
-	titleLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
-	[cell addSubview:titleLabel];
 
-	// Path label (dimmer, smaller)
-	NSString* pathStr = displayPathForDocument(doc);
-	NSTextField* pathLabel = [NSTextField labelWithString:pathStr];
-	pathLabel.translatesAutoresizingMaskIntoConstraints = NO;
-	pathLabel.font = [NSFont systemFontOfSize:10 weight:NSFontWeightRegular];
-	pathLabel.textColor = NSColor.secondaryLabelColor;
-	pathLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
-	[cell addSubview:pathLabel];
-
-	// Layout constraints
-	[NSLayoutConstraint activateConstraints:@[
-		// Modified dot: 6x6, vertically centered, left edge
-		[modDot.leadingAnchor constraintEqualToAnchor:cell.leadingAnchor constant:4],
-		[modDot.centerYAnchor constraintEqualToAnchor:cell.centerYAnchor],
-		[modDot.widthAnchor constraintEqualToConstant:6],
-		[modDot.heightAnchor constraintEqualToConstant:6],
-
-		// Title: to the right of the dot
-		[titleLabel.leadingAnchor constraintEqualToAnchor:modDot.trailingAnchor constant:4],
-		[titleLabel.trailingAnchor constraintLessThanOrEqualToAnchor:cell.trailingAnchor constant:-4],
-		[titleLabel.topAnchor constraintEqualToAnchor:cell.topAnchor constant:2],
-
-		// Path: below title
-		[pathLabel.leadingAnchor constraintEqualToAnchor:titleLabel.leadingAnchor],
-		[pathLabel.trailingAnchor constraintLessThanOrEqualToAnchor:cell.trailingAnchor constant:-4],
-		[pathLabel.topAnchor constraintEqualToAnchor:titleLabel.bottomAnchor constant:0],
-		[pathLabel.bottomAnchor constraintLessThanOrEqualToAnchor:cell.bottomAnchor constant:-2]
-	]];
+	pathLabel.stringValue = displayPathForDocument(doc);
 
 	return cell;
 }
@@ -294,6 +315,8 @@ static void switchToDocumentAtRow(NSInteger row)
 - (void)tableViewClicked:(id)sender
 {
 	NSInteger row = sTableView ? sTableView.clickedRow : -1;
+	if (row < 0 && sTableView)
+		row = sTableView.selectedRow;
 	if (row < 0)
 		return;
 	switchToDocumentAtRow(row);

--- a/macos/platform/file_switcher_panel.mm
+++ b/macos/platform/file_switcher_panel.mm
@@ -1,0 +1,553 @@
+// file_switcher_panel.mm — Compact open-documents list panel
+// Shows all open documents in a table view, supports split view separator,
+// single-click switching, and context menu (Close, Save, Copy Path, Reveal).
+
+#import <Cocoa/Cocoa.h>
+#include <string>
+#include <vector>
+
+#include "file_switcher_panel.h"
+#include "panel_layout.h"
+#include "app_state.h"
+#include "string_utils.h"
+#include "document_manager.h"
+#include "file_operations.h"
+#include "npp_constants.h"
+
+// ---------------------------------------------------------------------------
+// File-scoped statics (following clipboard_history_panel.mm pattern)
+// ---------------------------------------------------------------------------
+static NSView* sContainer = nil;
+static NSScrollView* sScrollView = nil;
+static NSTableView* sTableView = nil;
+
+@class FileSwitcherController;
+static FileSwitcherController* sController = nil;
+
+// ---------------------------------------------------------------------------
+// Helper: convert wstring to NSString (uses existing WideToNSString pattern)
+// ---------------------------------------------------------------------------
+static NSString* wstringToNSString(const std::wstring& ws)
+{
+	return WideToNSString(ws.c_str());
+}
+
+// ---------------------------------------------------------------------------
+// Helper: derive display path from a document's filePath
+// ---------------------------------------------------------------------------
+static NSString* displayPathForDocument(const DocumentData& doc)
+{
+	if (doc.filePath.empty())
+		return @"(unsaved)";
+
+	NSString* fullPath = wstringToNSString(doc.filePath);
+	if (!fullPath || fullPath.length == 0)
+		return @"(unsaved)";
+
+	// If fileBrowserRootPath is set and the path starts with it, show relative path
+	const std::string& rootPath = ctx().fileBrowserRootPath;
+	if (!rootPath.empty())
+	{
+		NSString* root = [NSString stringWithUTF8String:rootPath.c_str()];
+		if (root && [fullPath hasPrefix:root])
+		{
+			NSString* relative = [fullPath substringFromIndex:root.length];
+			if ([relative hasPrefix:@"/"])
+				relative = [relative substringFromIndex:1];
+			return relative;
+		}
+	}
+
+	// Otherwise show parent directory name
+	NSString* parent = [fullPath stringByDeletingLastPathComponent];
+	return [parent lastPathComponent];
+}
+
+// ---------------------------------------------------------------------------
+// Custom NSTableView subclass for Enter-key activation
+// (Matches ClipboardHistoryTableView pattern)
+// ---------------------------------------------------------------------------
+@interface FileSwitcherTableView : NSTableView
+@end
+
+@implementation FileSwitcherTableView
+- (void)keyDown:(NSEvent*)event
+{
+	if (event.keyCode == 36) // Return key
+	{
+		id target = self.target;
+		SEL action = self.action;
+		if (target && action)
+		{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+			[target performSelector:action withObject:self];
+#pragma clang diagnostic pop
+			return;
+		}
+	}
+	[super keyDown:event];
+}
+@end
+
+// ---------------------------------------------------------------------------
+// resolveRow — maps table row to (viewIndex, docIndex)
+// Returns false for separator rows.
+// ---------------------------------------------------------------------------
+struct ResolvedRow
+{
+	int viewIndex;
+	int docIndex;
+};
+
+static bool resolveRow(NSInteger row, ResolvedRow& out)
+{
+	auto& docs = ctx().documents;
+	auto& docs2 = ctx().documents2;
+	int count1 = static_cast<int>(docs.size());
+
+	if (row < 0)
+		return false;
+
+	if (row < count1)
+	{
+		out.viewIndex = 0;
+		out.docIndex = static_cast<int>(row);
+		return true;
+	}
+
+	if (!ctx().isSplit)
+		return false;
+
+	// Separator row
+	if (row == count1)
+		return false;
+
+	int idx2 = static_cast<int>(row) - count1 - 1;
+	if (idx2 < 0 || idx2 >= static_cast<int>(docs2.size()))
+		return false;
+
+	out.viewIndex = 1;
+	out.docIndex = idx2;
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// switchToDocumentAtRow — activates the document at the given table row
+// ---------------------------------------------------------------------------
+static void switchToDocumentAtRow(NSInteger row)
+{
+	ResolvedRow resolved;
+	if (!resolveRow(row, resolved))
+		return;
+
+	switchToTabInView(resolved.viewIndex, resolved.docIndex);
+}
+
+// ---------------------------------------------------------------------------
+// FileSwitcherController — NSTableView data source + delegate
+// ---------------------------------------------------------------------------
+@interface FileSwitcherController : NSObject <NSTableViewDataSource, NSTableViewDelegate, NSMenuDelegate>
+- (void)tableViewClicked:(id)sender;
+- (void)closeDocument:(id)sender;
+- (void)saveDocument:(id)sender;
+- (void)copyPath:(id)sender;
+- (void)revealInFinder:(id)sender;
+@end
+
+@implementation FileSwitcherController
+
+- (NSInteger)numberOfRowsInTableView:(NSTableView*)tableView
+{
+	NSInteger count = static_cast<NSInteger>(ctx().documents.size());
+	if (ctx().isSplit)
+		count += 1 + static_cast<NSInteger>(ctx().documents2.size());
+	return count;
+}
+
+- (NSView*)tableView:(NSTableView*)tableView viewForTableColumn:(NSTableColumn*)tableColumn row:(NSInteger)row
+{
+	auto& docs = ctx().documents;
+	int count1 = static_cast<int>(docs.size());
+
+	// Check if this is a separator row
+	if (ctx().isSplit && row == count1)
+	{
+		NSTextField* label = [NSTextField labelWithString:@"\u2014 Split View \u2014"];
+		label.alignment = NSTextAlignmentCenter;
+		label.font = [NSFont systemFontOfSize:10 weight:NSFontWeightMedium];
+		label.textColor = NSColor.tertiaryLabelColor;
+
+		NSTableCellView* cell = [[NSTableCellView alloc] initWithFrame:NSZeroRect];
+		label.translatesAutoresizingMaskIntoConstraints = NO;
+		[cell addSubview:label];
+		[NSLayoutConstraint activateConstraints:@[
+			[label.centerXAnchor constraintEqualToAnchor:cell.centerXAnchor],
+			[label.centerYAnchor constraintEqualToAnchor:cell.centerYAnchor]
+		]];
+		return cell;
+	}
+
+	// Resolve to document
+	ResolvedRow resolved;
+	if (!resolveRow(row, resolved))
+		return nil;
+
+	auto& docList = (resolved.viewIndex == 0) ? ctx().documents : ctx().documents2;
+	if (resolved.docIndex < 0 || resolved.docIndex >= static_cast<int>(docList.size()))
+		return nil;
+
+	const auto& doc = docList[resolved.docIndex];
+
+	// Determine if this is the active document in its view
+	int activeIdx = (resolved.viewIndex == 0) ? ctx().activeTab : ctx().activeTab2;
+	bool isActive = (resolved.docIndex == activeIdx) && (resolved.viewIndex == ctx().activeView);
+
+	// Build two-line cell
+	NSTableCellView* cell = [[NSTableCellView alloc] initWithFrame:NSZeroRect];
+
+	// Modified indicator dot (6px orange circle)
+	NSView* modDot = [[NSView alloc] initWithFrame:NSZeroRect];
+	modDot.translatesAutoresizingMaskIntoConstraints = NO;
+	modDot.wantsLayer = YES;
+	modDot.layer.cornerRadius = 3.0;
+	modDot.layer.backgroundColor = doc.modified
+		? [NSColor orangeColor].CGColor
+		: [NSColor clearColor].CGColor;
+	[cell addSubview:modDot];
+
+	// Filename label
+	NSString* titleStr = wstringToNSString(doc.title);
+	NSTextField* titleLabel = [NSTextField labelWithString:titleStr ?: @"Untitled"];
+	titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+	titleLabel.font = isActive
+		? [NSFont systemFontOfSize:12 weight:NSFontWeightSemibold]
+		: [NSFont systemFontOfSize:12 weight:NSFontWeightRegular];
+	titleLabel.textColor = NSColor.labelColor;
+	titleLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
+	[cell addSubview:titleLabel];
+
+	// Path label (dimmer, smaller)
+	NSString* pathStr = displayPathForDocument(doc);
+	NSTextField* pathLabel = [NSTextField labelWithString:pathStr];
+	pathLabel.translatesAutoresizingMaskIntoConstraints = NO;
+	pathLabel.font = [NSFont systemFontOfSize:10 weight:NSFontWeightRegular];
+	pathLabel.textColor = NSColor.secondaryLabelColor;
+	pathLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
+	[cell addSubview:pathLabel];
+
+	// Layout constraints
+	[NSLayoutConstraint activateConstraints:@[
+		// Modified dot: 6x6, vertically centered, left edge
+		[modDot.leadingAnchor constraintEqualToAnchor:cell.leadingAnchor constant:4],
+		[modDot.centerYAnchor constraintEqualToAnchor:cell.centerYAnchor],
+		[modDot.widthAnchor constraintEqualToConstant:6],
+		[modDot.heightAnchor constraintEqualToConstant:6],
+
+		// Title: to the right of the dot
+		[titleLabel.leadingAnchor constraintEqualToAnchor:modDot.trailingAnchor constant:4],
+		[titleLabel.trailingAnchor constraintLessThanOrEqualToAnchor:cell.trailingAnchor constant:-4],
+		[titleLabel.topAnchor constraintEqualToAnchor:cell.topAnchor constant:2],
+
+		// Path: below title
+		[pathLabel.leadingAnchor constraintEqualToAnchor:titleLabel.leadingAnchor],
+		[pathLabel.trailingAnchor constraintLessThanOrEqualToAnchor:cell.trailingAnchor constant:-4],
+		[pathLabel.topAnchor constraintEqualToAnchor:titleLabel.bottomAnchor constant:0],
+		[pathLabel.bottomAnchor constraintLessThanOrEqualToAnchor:cell.bottomAnchor constant:-2]
+	]];
+
+	return cell;
+}
+
+- (CGFloat)tableView:(NSTableView*)tableView heightOfRow:(NSInteger)row
+{
+	auto& docs = ctx().documents;
+	int count1 = static_cast<int>(docs.size());
+
+	// Separator row is shorter
+	if (ctx().isSplit && row == count1)
+		return 20.0;
+
+	return 34.0; // Two lines (filename + path)
+}
+
+- (BOOL)tableView:(NSTableView*)tableView shouldSelectRow:(NSInteger)row
+{
+	// Don't allow selecting the separator
+	auto& docs = ctx().documents;
+	int count1 = static_cast<int>(docs.size());
+	if (ctx().isSplit && row == count1)
+		return NO;
+	return YES;
+}
+
+- (BOOL)tableView:(NSTableView*)tableView isGroupRow:(NSInteger)row
+{
+	auto& docs = ctx().documents;
+	int count1 = static_cast<int>(docs.size());
+	return ctx().isSplit && row == count1;
+}
+
+// ---------------------------------------------------------------------------
+// Single-click action
+// ---------------------------------------------------------------------------
+- (void)tableViewClicked:(id)sender
+{
+	NSInteger row = sTableView ? sTableView.clickedRow : -1;
+	if (row < 0)
+		return;
+	switchToDocumentAtRow(row);
+}
+
+// ---------------------------------------------------------------------------
+// Context menu actions
+// ---------------------------------------------------------------------------
+- (void)closeDocument:(id)sender
+{
+	NSInteger row = sTableView ? sTableView.clickedRow : -1;
+	ResolvedRow resolved;
+	if (!resolveRow(row, resolved))
+		return;
+
+	closeTabFromView(resolved.viewIndex, resolved.docIndex);
+	reloadFileSwitcherData();
+}
+
+- (void)saveDocument:(id)sender
+{
+	NSInteger row = sTableView ? sTableView.clickedRow : -1;
+	ResolvedRow resolved;
+	if (!resolveRow(row, resolved))
+		return;
+
+	// Switch to the document first, then trigger save
+	switchToTabInView(resolved.viewIndex, resolved.docIndex);
+	saveCurrentFile();
+}
+
+- (void)copyPath:(id)sender
+{
+	NSInteger row = sTableView ? sTableView.clickedRow : -1;
+	ResolvedRow resolved;
+	if (!resolveRow(row, resolved))
+		return;
+
+	auto& docList = (resolved.viewIndex == 0) ? ctx().documents : ctx().documents2;
+	if (resolved.docIndex < 0 || resolved.docIndex >= static_cast<int>(docList.size()))
+		return;
+
+	const auto& doc = docList[resolved.docIndex];
+	if (doc.filePath.empty())
+		return;
+
+	NSString* path = wstringToNSString(doc.filePath);
+	if (path)
+	{
+		NSPasteboard* pb = [NSPasteboard generalPasteboard];
+		[pb clearContents];
+		[pb setString:path forType:NSPasteboardTypeString];
+	}
+}
+
+- (void)revealInFinder:(id)sender
+{
+	NSInteger row = sTableView ? sTableView.clickedRow : -1;
+	ResolvedRow resolved;
+	if (!resolveRow(row, resolved))
+		return;
+
+	auto& docList = (resolved.viewIndex == 0) ? ctx().documents : ctx().documents2;
+	if (resolved.docIndex < 0 || resolved.docIndex >= static_cast<int>(docList.size()))
+		return;
+
+	const auto& doc = docList[resolved.docIndex];
+	if (doc.filePath.empty())
+		return;
+
+	NSString* path = wstringToNSString(doc.filePath);
+	if (path)
+		[[NSWorkspace sharedWorkspace] selectFile:path inFileViewerRootedAtPath:@""];
+}
+
+// ---------------------------------------------------------------------------
+// Context menu delegate — build menu for right-clicked row
+// ---------------------------------------------------------------------------
+- (void)menuNeedsUpdate:(NSMenu*)menu
+{
+	[menu removeAllItems];
+
+	NSInteger row = sTableView ? sTableView.clickedRow : -1;
+	ResolvedRow resolved;
+	if (!resolveRow(row, resolved))
+		return;
+
+	auto& docList = (resolved.viewIndex == 0) ? ctx().documents : ctx().documents2;
+	if (resolved.docIndex < 0 || resolved.docIndex >= static_cast<int>(docList.size()))
+		return;
+
+	const auto& doc = docList[resolved.docIndex];
+
+	[menu addItemWithTitle:@"Close" action:@selector(closeDocument:) keyEquivalent:@""];
+	[menu addItemWithTitle:@"Save" action:@selector(saveDocument:) keyEquivalent:@""];
+
+	if (!doc.filePath.empty())
+	{
+		[menu addItem:[NSMenuItem separatorItem]];
+		[menu addItemWithTitle:@"Copy Path" action:@selector(copyPath:) keyEquivalent:@""];
+		[menu addItemWithTitle:@"Reveal in Finder" action:@selector(revealInFinder:) keyEquivalent:@""];
+	}
+
+	for (NSMenuItem* item in menu.itemArray)
+	{
+		if (item.action)
+			item.target = self;
+	}
+}
+
+@end
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+void initializeFileSwitcherPanel()
+{
+	if (!ctx().mainWindow || !ctx().editorContainer || sContainer)
+		return;
+
+	NSView* contentView = ctx().mainWindow.contentView;
+	if (!contentView)
+		return;
+
+	sController = [[FileSwitcherController alloc] init];
+
+	CGFloat width = static_cast<CGFloat>(ctx().leftPanelWidth);
+	if (width < 120) width = 120;
+	if (width > 360) width = 360;
+	ctx().leftPanelWidth = static_cast<int>(width);
+
+	sContainer = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, width, 100)];
+	sContainer.autoresizingMask = NSViewWidthSizable;
+	[contentView addSubview:sContainer];
+
+	// Title label
+	NSTextField* titleLabel = [NSTextField labelWithString:@"Open Files"];
+	titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+	titleLabel.font = [NSFont systemFontOfSize:11 weight:NSFontWeightSemibold];
+	titleLabel.textColor = NSColor.secondaryLabelColor;
+	[sContainer addSubview:titleLabel];
+
+	// Scroll view
+	sScrollView = [[NSScrollView alloc] initWithFrame:NSZeroRect];
+	sScrollView.translatesAutoresizingMaskIntoConstraints = NO;
+	sScrollView.hasVerticalScroller = YES;
+	sScrollView.hasHorizontalScroller = NO;
+	sScrollView.autohidesScrollers = YES;
+	sScrollView.borderType = NSBezelBorder;
+	[sContainer addSubview:sScrollView];
+
+	// Table view
+	FileSwitcherTableView* table = [[FileSwitcherTableView alloc] initWithFrame:NSZeroRect];
+	table.headerView = nil;
+	table.usesAlternatingRowBackgroundColors = YES;
+	NSTableColumn* column = [[NSTableColumn alloc] initWithIdentifier:@"FileSwitcherColumn"];
+	column.resizingMask = NSTableColumnAutoresizingMask;
+	[table addTableColumn:column];
+	table.dataSource = sController;
+	table.delegate = sController;
+	table.target = sController;
+	table.action = @selector(tableViewClicked:);
+	sTableView = table;
+	sScrollView.documentView = table;
+
+	// Context menu
+	NSMenu* contextMenu = [[NSMenu alloc] initWithTitle:@""];
+	contextMenu.delegate = sController;
+	table.menu = contextMenu;
+
+	// Layout constraints
+	[NSLayoutConstraint activateConstraints:@[
+		[titleLabel.topAnchor constraintEqualToAnchor:sContainer.topAnchor constant:6],
+		[titleLabel.leadingAnchor constraintEqualToAnchor:sContainer.leadingAnchor constant:6],
+		[sScrollView.topAnchor constraintEqualToAnchor:titleLabel.bottomAnchor constant:4],
+		[sScrollView.leadingAnchor constraintEqualToAnchor:sContainer.leadingAnchor constant:6],
+		[sScrollView.trailingAnchor constraintEqualToAnchor:sContainer.trailingAnchor constant:-6],
+		[sScrollView.bottomAnchor constraintEqualToAnchor:sContainer.bottomAnchor constant:-6]
+	]];
+}
+
+void destroyFileSwitcherPanel()
+{
+	if (sScrollView)
+	{
+		[sScrollView removeFromSuperview];
+		sScrollView = nil;
+	}
+	sTableView = nil;
+	if (sContainer)
+	{
+		[sContainer removeFromSuperview];
+		sContainer = nil;
+	}
+	sController = nil;
+}
+
+void setFileSwitcherEnabled(bool enabled)
+{
+	ctx().fileSwitcherEnabled = enabled;
+	if (enabled)
+	{
+		if (!sContainer)
+			initializeFileSwitcherPanel();
+		reloadFileSwitcherData();
+	}
+	relayoutPanels();
+}
+
+void bindFileSwitcherToActiveView()
+{
+	if (!sTableView || !ctx().fileSwitcherEnabled)
+		return;
+
+	[sTableView reloadData];
+
+	// Select the row corresponding to the active document in the active view
+	auto& docs = ctx().documents;
+	int activeTab = ctx().activeTab;
+	int activeView = ctx().activeView;
+
+	NSInteger targetRow = -1;
+
+	if (activeView == 0)
+	{
+		if (activeTab >= 0 && activeTab < static_cast<int>(docs.size()))
+			targetRow = activeTab;
+	}
+	else if (ctx().isSplit)
+	{
+		int count1 = static_cast<int>(docs.size());
+		int activeTab2 = ctx().activeTab2;
+		if (activeTab2 >= 0 && activeTab2 < static_cast<int>(ctx().documents2.size()))
+			targetRow = count1 + 1 + activeTab2; // +1 for separator row
+	}
+
+	if (targetRow >= 0 && targetRow < sTableView.numberOfRows)
+	{
+		[sTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:targetRow]
+		        byExtendingSelection:NO];
+		[sTableView scrollRowToVisible:targetRow];
+	}
+}
+
+void reloadFileSwitcherData()
+{
+	if (!sTableView || !ctx().fileSwitcherEnabled)
+		return;
+
+	[sTableView reloadData];
+}
+
+void* fileSwitcherContainerView()
+{
+	return (__bridge void*)sContainer;
+}

--- a/macos/platform/file_switcher_panel.mm
+++ b/macos/platform/file_switcher_panel.mm
@@ -157,6 +157,19 @@ static void switchToDocumentAtRow(NSInteger row)
 - (void)revealInFinder:(id)sender;
 @end
 
+// ---------------------------------------------------------------------------
+// resolveTargetRow — returns clickedRow if valid, else selectedRow
+// ---------------------------------------------------------------------------
+static NSInteger resolveTargetRow()
+{
+	if (!sTableView)
+		return -1;
+	NSInteger row = sTableView.clickedRow;
+	if (row < 0)
+		row = sTableView.selectedRow;
+	return row;
+}
+
 @implementation FileSwitcherController
 
 - (NSInteger)numberOfRowsInTableView:(NSTableView*)tableView
@@ -334,9 +347,7 @@ static void switchToDocumentAtRow(NSInteger row)
 // ---------------------------------------------------------------------------
 - (void)tableViewClicked:(id)sender
 {
-	NSInteger row = sTableView ? sTableView.clickedRow : -1;
-	if (row < 0 && sTableView)
-		row = sTableView.selectedRow;
+	NSInteger row = resolveTargetRow();
 	if (row < 0)
 		return;
 	switchToDocumentAtRow(row);
@@ -347,7 +358,7 @@ static void switchToDocumentAtRow(NSInteger row)
 // ---------------------------------------------------------------------------
 - (void)closeDocument:(id)sender
 {
-	NSInteger row = sTableView ? sTableView.clickedRow : -1;
+	NSInteger row = resolveTargetRow();
 	ResolvedRow resolved;
 	if (!resolveRow(row, resolved))
 		return;
@@ -358,7 +369,7 @@ static void switchToDocumentAtRow(NSInteger row)
 
 - (void)saveDocument:(id)sender
 {
-	NSInteger row = sTableView ? sTableView.clickedRow : -1;
+	NSInteger row = resolveTargetRow();
 	ResolvedRow resolved;
 	if (!resolveRow(row, resolved))
 		return;
@@ -370,7 +381,7 @@ static void switchToDocumentAtRow(NSInteger row)
 
 - (void)copyPath:(id)sender
 {
-	NSInteger row = sTableView ? sTableView.clickedRow : -1;
+	NSInteger row = resolveTargetRow();
 	ResolvedRow resolved;
 	if (!resolveRow(row, resolved))
 		return;
@@ -394,7 +405,7 @@ static void switchToDocumentAtRow(NSInteger row)
 
 - (void)revealInFinder:(id)sender
 {
-	NSInteger row = sTableView ? sTableView.clickedRow : -1;
+	NSInteger row = resolveTargetRow();
 	ResolvedRow resolved;
 	if (!resolveRow(row, resolved))
 		return;
@@ -419,7 +430,7 @@ static void switchToDocumentAtRow(NSInteger row)
 {
 	[menu removeAllItems];
 
-	NSInteger row = sTableView ? sTableView.clickedRow : -1;
+	NSInteger row = resolveTargetRow();
 	ResolvedRow resolved;
 	if (!resolveRow(row, resolved))
 		return;

--- a/macos/platform/file_switcher_panel.mm
+++ b/macos/platform/file_switcher_panel.mm
@@ -217,27 +217,36 @@ static void switchToDocumentAtRow(NSInteger row)
 	// Reuse or create document cell
 	static NSString* cellID = @"FileSwitcherDocCell";
 	NSTableCellView* cell = [tableView makeViewWithIdentifier:cellID owner:self];
+
+	// Identifier constants used for both cell creation and subview lookup
+	static NSUserInterfaceItemIdentifier const modDotID = @"modDot";
+	static NSUserInterfaceItemIdentifier const titleID = @"titleLabel";
+	static NSUserInterfaceItemIdentifier const pathID = @"pathLabel";
+
 	if (!cell)
 	{
 		cell = [[NSTableCellView alloc] initWithFrame:NSZeroRect];
 		cell.identifier = cellID;
 
-		// Modified indicator dot (6px orange circle) — subview index 0
+		// Modified indicator dot (6px orange circle)
 		NSView* modDot = [[NSView alloc] initWithFrame:NSZeroRect];
+		modDot.identifier = modDotID;
 		modDot.translatesAutoresizingMaskIntoConstraints = NO;
 		modDot.wantsLayer = YES;
 		modDot.layer.cornerRadius = 3.0;
 		[cell addSubview:modDot];
 
-		// Filename label — subview index 1
+		// Filename label
 		NSTextField* titleLabel = [NSTextField labelWithString:@""];
+		titleLabel.identifier = titleID;
 		titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
 		titleLabel.textColor = NSColor.labelColor;
 		titleLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
 		[cell addSubview:titleLabel];
 
-		// Path label (dimmer, smaller) — subview index 2
+		// Path label (dimmer, smaller)
 		NSTextField* pathLabel = [NSTextField labelWithString:@""];
+		pathLabel.identifier = pathID;
 		pathLabel.translatesAutoresizingMaskIntoConstraints = NO;
 		pathLabel.font = [NSFont systemFontOfSize:10 weight:NSFontWeightRegular];
 		pathLabel.textColor = NSColor.secondaryLabelColor;
@@ -260,10 +269,21 @@ static void switchToDocumentAtRow(NSInteger row)
 		]];
 	}
 
-	// Update cell content (subviews added in fixed order: 0=modDot, 1=title, 2=path)
-	NSView* modDot = cell.subviews[0];
-	NSTextField* titleLabel = (NSTextField*)cell.subviews[1];
-	NSTextField* pathLabel = (NSTextField*)cell.subviews[2];
+	// Update cell content — use identifiers for robust subview lookup
+	auto findSubview = [](NSView* parent, NSUserInterfaceItemIdentifier ident) -> NSView* {
+		for (NSView* sv in parent.subviews)
+		{
+			if ([sv.identifier isEqualToString:ident])
+				return sv;
+		}
+		return nil;
+	};
+	NSView* modDot = findSubview(cell, modDotID);
+	NSTextField* titleLabel = (NSTextField*)findSubview(cell, titleID);
+	NSTextField* pathLabel = (NSTextField*)findSubview(cell, pathID);
+
+	if (!modDot || !titleLabel || !pathLabel)
+		return cell;
 
 	modDot.layer.backgroundColor = doc.modified
 		? [NSColor orangeColor].CGColor

--- a/macos/platform/function_list_panel.h
+++ b/macos/platform/function_list_panel.h
@@ -4,8 +4,11 @@
 
 void initializeFunctionListPanel();
 void destroyFunctionListPanel();
-void relayoutFunctionListPanel();
 void setFunctionListEnabled(bool enabled);
+
+// Returns opaque pointer to the panel's container view (NSView*),
+// or nullptr if the panel has not been initialized.
+void* functionListContainerView();
 bool isFunctionListEnabled();
 
 void bindFunctionListToActiveView();

--- a/macos/platform/function_list_panel.mm
+++ b/macos/platform/function_list_panel.mm
@@ -21,6 +21,7 @@ static FILE* dbgLog()
 
 #include "function_list_panel.h"
 #include "function_list_parser.h"
+#include "panel_layout.h"
 #include "app_state.h"
 #include "document_manager.h"
 #include "npp_constants.h"
@@ -556,94 +557,9 @@ void destroyFunctionListPanel()
 	sController = nil;
 }
 
-void relayoutFunctionListPanel()
+void* functionListContainerView()
 {
-	if (!ctx().mainWindow || !ctx().editorContainer)
-		return;
-
-	NSView* contentView = ctx().mainWindow.contentView;
-	if (!contentView)
-		return;
-
-	const CGFloat tabHeight = NPP_TAB_BAR_HEIGHT;
-	const CGFloat statusHeight = NPP_STATUS_BAR_HEIGHT;
-	NSRect baseEditorFrame = NSMakeRect(0, statusHeight,
-		contentView.bounds.size.width,
-		contentView.bounds.size.height - tabHeight - statusHeight);
-
-	CGFloat mapWidth = (ctx().documentMapEnabled ? static_cast<CGFloat>(ctx().documentMapWidth) : 0.0);
-	CGFloat flWidth = (ctx().functionListEnabled ? static_cast<CGFloat>(ctx().functionListWidth) : 0.0);
-	CGFloat chWidth = (ctx().clipboardHistoryEnabled ? static_cast<CGFloat>(ctx().clipboardHistoryWidth) : 0.0);
-	if (flWidth < 0) flWidth = 0;
-	if (mapWidth < 0) mapWidth = 0;
-	if (chWidth < 0) chWidth = 0;
-
-	// Clamp: total side panels cannot exceed (window width - 120px editor minimum)
-	CGFloat maxSide = std::max<CGFloat>(0.0, baseEditorFrame.size.width - 120.0);
-	if (mapWidth > maxSide)
-	{
-		mapWidth = maxSide;
-		ctx().documentMapWidth = static_cast<int>(mapWidth);
-	}
-	if (flWidth + mapWidth > maxSide)
-	{
-		flWidth = std::max<CGFloat>(0.0, maxSide - mapWidth);
-		ctx().functionListWidth = static_cast<int>(flWidth);
-	}
-	if (chWidth + flWidth + mapWidth > maxSide)
-	{
-		chWidth = std::max<CGFloat>(0.0, maxSide - flWidth - mapWidth);
-		ctx().clipboardHistoryWidth = static_cast<int>(chWidth);
-	}
-
-	NSRect editorFrame = baseEditorFrame;
-	editorFrame.size.width -= (chWidth + flWidth + mapWidth);
-	if (editorFrame.size.width < 120)
-		editorFrame.size.width = 120;
-
-	if (ctx().isSplit && ctx().splitView)
-	{
-		ctx().splitView.frame = editorFrame;
-		[ctx().splitView adjustSubviews];
-	}
-	else
-	{
-		ctx().editorContainer.frame = editorFrame;
-	}
-
-	// Panel frames (left to right after editor):
-	// 1. Clipboard History
-	NSView* chContainer = (__bridge NSView*)clipboardHistoryContainerView();
-	NSRect chFrame = NSMakeRect(NSMaxX(editorFrame), baseEditorFrame.origin.y, chWidth, baseEditorFrame.size.height);
-	if (chContainer)
-	{
-		chContainer.frame = chFrame;
-		chContainer.hidden = !ctx().clipboardHistoryEnabled;
-	}
-
-	// 2. Function List
-	NSRect flFrame = NSMakeRect(NSMaxX(chFrame), baseEditorFrame.origin.y, flWidth, baseEditorFrame.size.height);
-	if (sContainer)
-	{
-		sContainer.frame = flFrame;
-		sContainer.hidden = !ctx().functionListEnabled;
-	}
-
-	// 3. Document Map
-	if (ctx().documentMapContainer)
-	{
-		NSRect mapFrame = NSMakeRect(NSMaxX(flFrame), baseEditorFrame.origin.y, mapWidth, baseEditorFrame.size.height);
-		ctx().documentMapContainer.frame = mapFrame;
-		ctx().documentMapContainer.hidden = !ctx().documentMapEnabled;
-	}
-
-	layoutSplitTopTabBars();
-	if (ctx().documentMapScintilla)
-		ScintillaBridge_resizeToFit(ctx().documentMapScintilla);
-	if (ctx().scintillaView)
-		ScintillaBridge_resizeToFit(ctx().scintillaView);
-	if (ctx().isSplit && ctx().scintillaView2)
-		ScintillaBridge_resizeToFit(ctx().scintillaView2);
+	return (__bridge void*)sContainer;
 }
 
 void setFunctionListEnabled(bool enabled)
@@ -651,7 +567,7 @@ void setFunctionListEnabled(bool enabled)
 	ctx().functionListEnabled = enabled;
 	if (enabled && !sContainer)
 		initializeFunctionListPanel();
-	relayoutFunctionListPanel();
+	relayoutPanels();
 	if (enabled)
 		updateFunctionListNow();
 	else

--- a/macos/platform/function_list_panel.mm
+++ b/macos/platform/function_list_panel.mm
@@ -481,13 +481,13 @@ void initializeFunctionListPanel()
 
 	sController = [[FunctionListController alloc] init];
 
-	CGFloat width = static_cast<CGFloat>(ctx().functionListWidth);
+	CGFloat width = static_cast<CGFloat>(ctx().rightPanelWidth);
 	if (width < 120) width = 120;
 	if (width > 360) width = 360;
-	ctx().functionListWidth = static_cast<int>(width);
+	ctx().rightPanelWidth = static_cast<int>(width);
 
 	sContainer = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, width, 100)];
-	sContainer.autoresizingMask = NSViewMinXMargin | NSViewHeightSizable;
+	sContainer.autoresizingMask = NSViewWidthSizable;
 	[contentView addSubview:sContainer];
 
 	sEmptyLabel = [NSTextField labelWithString:@"No functions"];

--- a/macos/platform/menu_builder.mm
+++ b/macos/platform/menu_builder.mm
@@ -31,6 +31,8 @@ HMENU buildMenuBar()
 	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_COPY_FILENAME, L"Copy File &Name");
 	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_COPY_DIR_PATH, L"Copy &Directory Path");
 	AppendMenuW(hFileMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_OPENFOLDER, L"Open Fol&der...\tCtrl+Shift+K");
+	AppendMenuW(hFileMenu, MF_SEPARATOR, 0, nullptr);
 	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_PRINT, L"&Print...\tCtrl+P");
 	AppendMenuW(hFileMenu, MF_SEPARATOR, 0, nullptr);
 	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_CLOSE, L"&Close\tCtrl+W");
@@ -139,6 +141,10 @@ HMENU buildMenuBar()
 	            IDM_VIEW_FUNCTIONLIST, L"&Function List");
 	AppendMenuW(hViewMenu, MF_STRING | (ctx().clipboardHistoryEnabled ? MF_CHECKED : MF_UNCHECKED),
 	            IDM_VIEW_CLIPBOARD_HISTORY, L"Clipboard &History\tCtrl+Shift+H");
+	AppendMenuW(hViewMenu, MF_STRING | (ctx().fileBrowserEnabled ? MF_CHECKED : MF_UNCHECKED),
+	            IDM_VIEW_FILEBROWSER, L"File &Browser\tCtrl+Shift+E");
+	AppendMenuW(hViewMenu, MF_STRING | (ctx().fileSwitcherEnabled ? MF_CHECKED : MF_UNCHECKED),
+	            IDM_VIEW_FILESWITCHER, L"File &Switcher\tCtrl+Shift+O");
 	AppendMenuW(hViewMenu, MF_SEPARATOR, 0, nullptr);
 	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_ZOOMIN, L"Zoom &In\tCtrl+=");
 	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_ZOOMOUT, L"Zoom &Out\tCtrl+-");

--- a/macos/platform/menu_builder.mm
+++ b/macos/platform/menu_builder.mm
@@ -31,7 +31,7 @@ HMENU buildMenuBar()
 	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_COPY_FILENAME, L"Copy File &Name");
 	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_COPY_DIR_PATH, L"Copy &Directory Path");
 	AppendMenuW(hFileMenu, MF_SEPARATOR, 0, nullptr);
-	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_OPENFOLDER, L"Open Fol&der...\tCtrl+Shift+K");
+	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_OPENFOLDER, L"Open Fol&der...\tCtrl+Shift+J");
 	AppendMenuW(hFileMenu, MF_SEPARATOR, 0, nullptr);
 	AppendMenuW(hFileMenu, MF_STRING, IDM_FILE_PRINT, L"&Print...\tCtrl+P");
 	AppendMenuW(hFileMenu, MF_SEPARATOR, 0, nullptr);

--- a/macos/platform/npp_constants.h
+++ b/macos/platform/npp_constants.h
@@ -114,6 +114,9 @@ constexpr double NPP_STATUS_BAR_HEIGHT = 22.0;
 #define IDM_VIEW_CHANGE_HISTORY      42085
 #define IDM_VIEW_FUNCTIONLIST        42086
 #define IDM_VIEW_CLIPBOARD_HISTORY   42087
+#define IDM_VIEW_FILEBROWSER         42088
+#define IDM_VIEW_FILESWITCHER        42089
+#define IDM_FILE_OPENFOLDER          42094
 
 // Tab context menu command IDs
 #define IDM_TAB_CLOSE            42200

--- a/macos/platform/panel_divider.h
+++ b/macos/platform/panel_divider.h
@@ -1,0 +1,27 @@
+#pragma once
+#import <Cocoa/Cocoa.h>
+#include <functional>
+
+enum class DividerOrientation
+{
+	Vertical,    // between left/right zones (drag changes width)
+	Horizontal   // between stacked panels (drag changes height)
+};
+
+@interface PanelDividerView : NSView
+
+@property (nonatomic, assign) DividerOrientation orientation;
+@property (nonatomic, copy) void (^onDrag)(CGFloat delta);
+@property (nonatomic, copy) void (^onDoubleClick)(void);
+
+- (instancetype)initWithOrientation:(DividerOrientation)orientation;
+
+@end
+
+// C++ helper to create and add a divider between two views
+PanelDividerView* createPanelDivider(
+	DividerOrientation orientation,
+	NSView* parentView,
+	void (^onDrag)(CGFloat delta),
+	void (^onDoubleClick)(void)
+);

--- a/macos/platform/panel_divider.mm
+++ b/macos/platform/panel_divider.mm
@@ -1,0 +1,99 @@
+#import "panel_divider.h"
+
+static const CGFloat kDividerThickness = 3.0;
+
+@implementation PanelDividerView
+{
+	NSPoint _dragStart;
+	BOOL _isDragging;
+}
+
+- (instancetype)initWithOrientation:(DividerOrientation)orientation
+{
+	self = [super initWithFrame:NSZeroRect];
+	if (self)
+	{
+		_orientation = orientation;
+		_isDragging = NO;
+		self.wantsLayer = YES;
+		self.layer.backgroundColor = [[NSColor separatorColor] CGColor];
+	}
+	return self;
+}
+
+- (void)resetCursorRects
+{
+	if (_orientation == DividerOrientation::Vertical)
+	{
+		[self addCursorRect:self.bounds cursor:[NSCursor resizeLeftRightCursor]];
+	}
+	else
+	{
+		[self addCursorRect:self.bounds cursor:[NSCursor resizeUpDownCursor]];
+	}
+}
+
+- (void)mouseDown:(NSEvent*)event
+{
+	_dragStart = [event locationInWindow];
+	_isDragging = YES;
+
+	if (event.clickCount == 2 && self.onDoubleClick)
+	{
+		self.onDoubleClick();
+		_isDragging = NO;
+		return;
+	}
+}
+
+- (void)mouseDragged:(NSEvent*)event
+{
+	if (!_isDragging) return;
+
+	NSPoint current = [event locationInWindow];
+	CGFloat delta;
+
+	if (_orientation == DividerOrientation::Vertical)
+	{
+		delta = current.x - _dragStart.x;
+	}
+	else
+	{
+		delta = current.y - _dragStart.y;
+	}
+
+	_dragStart = current;
+
+	if (self.onDrag)
+	{
+		self.onDrag(delta);
+	}
+}
+
+- (void)mouseUp:(NSEvent*)event
+{
+	_isDragging = NO;
+}
+
+- (BOOL)acceptsFirstMouse:(NSEvent*)event
+{
+	return YES;
+}
+
+@end
+
+PanelDividerView* createPanelDivider(
+	DividerOrientation orientation,
+	NSView* parentView,
+	void (^onDrag)(CGFloat delta),
+	void (^onDoubleClick)(void))
+{
+	PanelDividerView* divider = [[PanelDividerView alloc] initWithOrientation:orientation];
+	divider.onDrag = onDrag;
+	divider.onDoubleClick = onDoubleClick;
+	divider.autoresizingMask = (orientation == DividerOrientation::Vertical)
+		? NSViewHeightSizable
+		: NSViewWidthSizable;
+	[parentView addSubview:divider];
+	return divider;
+}

--- a/macos/platform/panel_divider.mm
+++ b/macos/platform/panel_divider.mm
@@ -1,7 +1,5 @@
 #import "panel_divider.h"
 
-static const CGFloat kDividerThickness = 3.0;
-
 @implementation PanelDividerView
 {
 	NSPoint _dragStart;

--- a/macos/platform/panel_layout.h
+++ b/macos/platform/panel_layout.h
@@ -1,0 +1,16 @@
+// panel_layout.h — Central panel layout orchestrator
+// Positions all panels, editor, and dividers.
+
+#pragma once
+
+#import <Cocoa/Cocoa.h>
+
+void relayoutPanels();
+
+static const CGFloat kPanelCollapseThreshold = 60.0;
+static const CGFloat kMinEditorWidth = 120.0;
+static const CGFloat kDividerThickness = 3.0;
+
+static const int kDefaultLeftPanelWidth = 200;
+static const int kDefaultRightPanelWidth = 220;
+static const int kDefaultDocumentMapWidth = 140;

--- a/macos/platform/panel_layout.mm
+++ b/macos/platform/panel_layout.mm
@@ -15,18 +15,12 @@
 #include "panel_divider.h"
 #include "app_state.h"
 #include "clipboard_history_panel.h"
+#include "file_browser_panel.h"
+#include "file_switcher_panel.h"
 #include "function_list_panel.h"
 #include "npp_constants.h"
 #include "scintilla_bridge.h"
 #include "split_view.h"
-
-// ---------------------------------------------------------------------------
-// Stubs for panels not yet implemented (Tasks 6 and 7).
-// These use weak linkage so that the real implementations in
-// file_browser_panel.mm / file_switcher_panel.mm will override them.
-// ---------------------------------------------------------------------------
-__attribute__((weak)) void* fileBrowserContainerView() { return nullptr; }
-__attribute__((weak)) void* fileSwitcherContainerView() { return nullptr; }
 
 // ---------------------------------------------------------------------------
 // Static divider views — created lazily on first use

--- a/macos/platform/panel_layout.mm
+++ b/macos/platform/panel_layout.mm
@@ -20,7 +20,28 @@
 #include "function_list_panel.h"
 #include "npp_constants.h"
 #include "scintilla_bridge.h"
+#include "windows.h"
 #include "split_view.h"
+
+// ---------------------------------------------------------------------------
+// syncPanelMenuCheckmarks — updates View menu checks from ctx() flags
+// ---------------------------------------------------------------------------
+static void syncPanelMenuCheckmarks()
+{
+	if (!ctx().mainHwnd)
+		return;
+	HMENU hMenu = GetMenu(ctx().mainHwnd);
+	if (!hMenu)
+		return;
+	CheckMenuItem(hMenu, IDM_VIEW_FILEBROWSER,
+	              MF_BYCOMMAND | (ctx().fileBrowserEnabled ? MF_CHECKED : MF_UNCHECKED));
+	CheckMenuItem(hMenu, IDM_VIEW_FILESWITCHER,
+	              MF_BYCOMMAND | (ctx().fileSwitcherEnabled ? MF_CHECKED : MF_UNCHECKED));
+	CheckMenuItem(hMenu, IDM_VIEW_FUNCTIONLIST,
+	              MF_BYCOMMAND | (ctx().functionListEnabled ? MF_CHECKED : MF_UNCHECKED));
+	CheckMenuItem(hMenu, IDM_VIEW_CLIPBOARD_HISTORY,
+	              MF_BYCOMMAND | (ctx().clipboardHistoryEnabled ? MF_CHECKED : MF_UNCHECKED));
+}
 
 // ---------------------------------------------------------------------------
 // Static divider views — created lazily on first use
@@ -49,6 +70,7 @@ static void ensureLeftVerticalDivider(NSView* contentView)
 				ctx().fileBrowserEnabled = false;
 				ctx().fileSwitcherEnabled = false;
 				ctx().leftPanelWidth = kDefaultLeftPanelWidth;
+				syncPanelMenuCheckmarks();
 			}
 			relayoutPanels();
 		},
@@ -75,6 +97,7 @@ static void ensureRightVerticalDivider(NSView* contentView)
 				ctx().functionListEnabled = false;
 				ctx().clipboardHistoryEnabled = false;
 				ctx().rightPanelWidth = kDefaultRightPanelWidth;
+				syncPanelMenuCheckmarks();
 			}
 			relayoutPanels();
 		},

--- a/macos/platform/panel_layout.mm
+++ b/macos/platform/panel_layout.mm
@@ -253,16 +253,30 @@ void relayoutPanels()
 		}
 		else
 		{
-			// Single panel fills the entire zone
-			if (fbContainer && ctx().fileBrowserEnabled)
+			// Single panel fills the entire zone; hide the other
+			if (fbContainer)
 			{
-				fbContainer.frame = NSMakeRect(curX, zoneY, leftWidth, zoneH);
-				fbContainer.hidden = NO;
+				if (ctx().fileBrowserEnabled)
+				{
+					fbContainer.frame = NSMakeRect(curX, zoneY, leftWidth, zoneH);
+					fbContainer.hidden = NO;
+				}
+				else
+				{
+					fbContainer.hidden = YES;
+				}
 			}
-			if (fsContainer && ctx().fileSwitcherEnabled)
+			if (fsContainer)
 			{
-				fsContainer.frame = NSMakeRect(curX, zoneY, leftWidth, zoneH);
-				fsContainer.hidden = NO;
+				if (ctx().fileSwitcherEnabled)
+				{
+					fsContainer.frame = NSMakeRect(curX, zoneY, leftWidth, zoneH);
+					fsContainer.hidden = NO;
+				}
+				else
+				{
+					fsContainer.hidden = YES;
+				}
 			}
 			if (sLeftHorizontalDivider)
 				sLeftHorizontalDivider.hidden = YES;

--- a/macos/platform/panel_layout.mm
+++ b/macos/platform/panel_layout.mm
@@ -1,0 +1,399 @@
+// panel_layout.mm — Central panel layout orchestrator
+// Positions all panels (left zone, editor, doc map, right zone) and dividers.
+//
+// Layout order (left to right):
+//   [Left Zone] [|] [Editor] [DocMap] [|] [Right Zone]
+//
+// Left zone = File Browser (top) + File Switcher (bottom)
+// Right zone = Function List (top) + Clipboard History (bottom)
+// | = PanelDividerView (3px vertical dividers)
+
+#import <Cocoa/Cocoa.h>
+#include <algorithm>
+
+#include "panel_layout.h"
+#include "panel_divider.h"
+#include "app_state.h"
+#include "clipboard_history_panel.h"
+#include "function_list_panel.h"
+#include "npp_constants.h"
+#include "scintilla_bridge.h"
+#include "split_view.h"
+
+// ---------------------------------------------------------------------------
+// Stubs for panels not yet implemented (Tasks 6 and 7).
+// These use weak linkage so that the real implementations in
+// file_browser_panel.mm / file_switcher_panel.mm will override them.
+// ---------------------------------------------------------------------------
+__attribute__((weak)) void* fileBrowserContainerView() { return nullptr; }
+__attribute__((weak)) void* fileSwitcherContainerView() { return nullptr; }
+
+// ---------------------------------------------------------------------------
+// Static divider views — created lazily on first use
+// ---------------------------------------------------------------------------
+static PanelDividerView* sLeftVerticalDivider = nil;
+static PanelDividerView* sRightVerticalDivider = nil;
+static PanelDividerView* sLeftHorizontalDivider = nil;
+static PanelDividerView* sRightHorizontalDivider = nil;
+
+// ---------------------------------------------------------------------------
+// Divider creation helpers
+// ---------------------------------------------------------------------------
+
+static void ensureLeftVerticalDivider(NSView* contentView)
+{
+	if (sLeftVerticalDivider)
+		return;
+
+	sLeftVerticalDivider = createPanelDivider(
+		DividerOrientation::Vertical,
+		contentView,
+		^(CGFloat delta) {
+			ctx().leftPanelWidth += static_cast<int>(delta);
+			if (ctx().leftPanelWidth < static_cast<int>(kPanelCollapseThreshold))
+			{
+				ctx().fileBrowserEnabled = false;
+				ctx().fileSwitcherEnabled = false;
+				ctx().leftPanelWidth = kDefaultLeftPanelWidth;
+			}
+			relayoutPanels();
+		},
+		^{
+			ctx().leftPanelWidth = kDefaultLeftPanelWidth;
+			relayoutPanels();
+		}
+	);
+}
+
+static void ensureRightVerticalDivider(NSView* contentView)
+{
+	if (sRightVerticalDivider)
+		return;
+
+	sRightVerticalDivider = createPanelDivider(
+		DividerOrientation::Vertical,
+		contentView,
+		^(CGFloat delta) {
+			// Dragging right = zone gets smaller (negative adjustment)
+			ctx().rightPanelWidth -= static_cast<int>(delta);
+			if (ctx().rightPanelWidth < static_cast<int>(kPanelCollapseThreshold))
+			{
+				ctx().functionListEnabled = false;
+				ctx().clipboardHistoryEnabled = false;
+				ctx().rightPanelWidth = kDefaultRightPanelWidth;
+			}
+			relayoutPanels();
+		},
+		^{
+			ctx().rightPanelWidth = kDefaultRightPanelWidth;
+			relayoutPanels();
+		}
+	);
+}
+
+static void ensureLeftHorizontalDivider(NSView* contentView)
+{
+	if (sLeftHorizontalDivider)
+		return;
+
+	sLeftHorizontalDivider = createPanelDivider(
+		DividerOrientation::Horizontal,
+		contentView,
+		^(CGFloat delta) {
+			// delta is in points; convert to ratio change based on zone height
+			const CGFloat tabHeight = NPP_TAB_BAR_HEIGHT;
+			const CGFloat statusHeight = NPP_STATUS_BAR_HEIGHT;
+			CGFloat zoneHeight = contentView.bounds.size.height - tabHeight - statusHeight;
+			if (zoneHeight > 0)
+			{
+				ctx().fileBrowserHeightRatio += static_cast<CGFloat>(delta) / zoneHeight;
+				if (ctx().fileBrowserHeightRatio < 0.15)
+					ctx().fileBrowserHeightRatio = 0.15;
+				if (ctx().fileBrowserHeightRatio > 0.85)
+					ctx().fileBrowserHeightRatio = 0.85;
+			}
+			relayoutPanels();
+		},
+		^{
+			ctx().fileBrowserHeightRatio = 0.6;
+			relayoutPanels();
+		}
+	);
+}
+
+static void ensureRightHorizontalDivider(NSView* contentView)
+{
+	if (sRightHorizontalDivider)
+		return;
+
+	sRightHorizontalDivider = createPanelDivider(
+		DividerOrientation::Horizontal,
+		contentView,
+		^(CGFloat delta) {
+			// delta is in points; convert to ratio change based on zone height
+			const CGFloat tabHeight = NPP_TAB_BAR_HEIGHT;
+			const CGFloat statusHeight = NPP_STATUS_BAR_HEIGHT;
+			CGFloat zoneHeight = contentView.bounds.size.height - tabHeight - statusHeight;
+			if (zoneHeight > 0)
+			{
+				ctx().functionListHeightRatio += static_cast<CGFloat>(delta) / zoneHeight;
+				if (ctx().functionListHeightRatio < 0.15)
+					ctx().functionListHeightRatio = 0.15;
+				if (ctx().functionListHeightRatio > 0.85)
+					ctx().functionListHeightRatio = 0.85;
+			}
+			relayoutPanels();
+		},
+		^{
+			ctx().functionListHeightRatio = 0.5;
+			relayoutPanels();
+		}
+	);
+}
+
+// ---------------------------------------------------------------------------
+// relayoutPanels — main layout orchestrator
+// ---------------------------------------------------------------------------
+
+void relayoutPanels()
+{
+	if (!ctx().mainWindow || !ctx().editorContainer)
+		return;
+
+	NSView* contentView = ctx().mainWindow.contentView;
+	if (!contentView)
+		return;
+
+	const CGFloat tabHeight = NPP_TAB_BAR_HEIGHT;
+	const CGFloat statusHeight = NPP_STATUS_BAR_HEIGHT;
+	NSRect baseEditorFrame = NSMakeRect(0, statusHeight,
+		contentView.bounds.size.width,
+		contentView.bounds.size.height - tabHeight - statusHeight);
+
+	// -- Calculate zone widths ------------------------------------------------
+
+	bool leftZoneVisible = ctx().fileBrowserEnabled || ctx().fileSwitcherEnabled;
+	bool rightZoneVisible = ctx().functionListEnabled || ctx().clipboardHistoryEnabled;
+
+	CGFloat leftWidth = leftZoneVisible ? static_cast<CGFloat>(ctx().leftPanelWidth) : 0.0;
+	CGFloat mapWidth = ctx().documentMapEnabled ? static_cast<CGFloat>(ctx().documentMapWidth) : 0.0;
+	CGFloat rightWidth = rightZoneVisible ? static_cast<CGFloat>(ctx().rightPanelWidth) : 0.0;
+
+	if (leftWidth < 0) leftWidth = 0;
+	if (mapWidth < 0) mapWidth = 0;
+	if (rightWidth < 0) rightWidth = 0;
+
+	// Divider widths for visible zone boundaries
+	CGFloat leftDividerWidth = leftZoneVisible ? kDividerThickness : 0.0;
+	CGFloat rightDividerWidth = rightZoneVisible ? kDividerThickness : 0.0;
+
+	// -- Clamp: total side panels cannot exceed (window width - min editor) ---
+
+	CGFloat totalSide = leftWidth + leftDividerWidth + mapWidth + rightDividerWidth + rightWidth;
+	CGFloat maxSide = std::max<CGFloat>(0.0, baseEditorFrame.size.width - kMinEditorWidth);
+
+	if (totalSide > maxSide)
+	{
+		// Proportionally scale down widths
+		CGFloat dividerTotal = leftDividerWidth + rightDividerWidth;
+		CGFloat panelTotal = leftWidth + mapWidth + rightWidth;
+		CGFloat available = maxSide - dividerTotal;
+		if (available < 0) available = 0;
+
+		if (panelTotal > 0)
+		{
+			CGFloat scale = available / panelTotal;
+			leftWidth = std::max<CGFloat>(0.0, leftWidth * scale);
+			mapWidth = std::max<CGFloat>(0.0, mapWidth * scale);
+			rightWidth = std::max<CGFloat>(0.0, rightWidth * scale);
+
+			if (leftZoneVisible)
+				ctx().leftPanelWidth = static_cast<int>(leftWidth);
+			if (ctx().documentMapEnabled)
+				ctx().documentMapWidth = static_cast<int>(mapWidth);
+			if (rightZoneVisible)
+				ctx().rightPanelWidth = static_cast<int>(rightWidth);
+		}
+	}
+
+	// -- Position left-to-right -----------------------------------------------
+
+	CGFloat curX = baseEditorFrame.origin.x;
+	CGFloat zoneY = baseEditorFrame.origin.y;
+	CGFloat zoneH = baseEditorFrame.size.height;
+
+	// 1. Left zone
+	if (leftZoneVisible)
+	{
+		ensureLeftVerticalDivider(contentView);
+
+		NSView* fbContainer = (__bridge NSView*)fileBrowserContainerView();
+		NSView* fsContainer = (__bridge NSView*)fileSwitcherContainerView();
+		bool hasBoth = (fbContainer != nil) && (fsContainer != nil) &&
+		               ctx().fileBrowserEnabled && ctx().fileSwitcherEnabled;
+
+		if (hasBoth)
+		{
+			ensureLeftHorizontalDivider(contentView);
+
+			CGFloat topH = (zoneH - kDividerThickness) * ctx().fileBrowserHeightRatio;
+			CGFloat bottomH = zoneH - kDividerThickness - topH;
+
+			// File browser on top
+			fbContainer.frame = NSMakeRect(curX, zoneY + bottomH + kDividerThickness, leftWidth, topH);
+			fbContainer.hidden = NO;
+
+			// Horizontal divider
+			sLeftHorizontalDivider.frame = NSMakeRect(curX, zoneY + bottomH, leftWidth, kDividerThickness);
+			sLeftHorizontalDivider.hidden = NO;
+
+			// File switcher on bottom
+			fsContainer.frame = NSMakeRect(curX, zoneY, leftWidth, bottomH);
+			fsContainer.hidden = NO;
+		}
+		else
+		{
+			// Single panel fills the entire zone
+			if (fbContainer && ctx().fileBrowserEnabled)
+			{
+				fbContainer.frame = NSMakeRect(curX, zoneY, leftWidth, zoneH);
+				fbContainer.hidden = NO;
+			}
+			if (fsContainer && ctx().fileSwitcherEnabled)
+			{
+				fsContainer.frame = NSMakeRect(curX, zoneY, leftWidth, zoneH);
+				fsContainer.hidden = NO;
+			}
+			if (sLeftHorizontalDivider)
+				sLeftHorizontalDivider.hidden = YES;
+		}
+
+		curX += leftWidth;
+
+		// Left vertical divider
+		sLeftVerticalDivider.frame = NSMakeRect(curX, zoneY, kDividerThickness, zoneH);
+		sLeftVerticalDivider.hidden = NO;
+		curX += kDividerThickness;
+	}
+	else
+	{
+		// Hide left-zone elements
+		NSView* fbContainer = (__bridge NSView*)fileBrowserContainerView();
+		NSView* fsContainer = (__bridge NSView*)fileSwitcherContainerView();
+		if (fbContainer) fbContainer.hidden = YES;
+		if (fsContainer) fsContainer.hidden = YES;
+		if (sLeftVerticalDivider) sLeftVerticalDivider.hidden = YES;
+		if (sLeftHorizontalDivider) sLeftHorizontalDivider.hidden = YES;
+	}
+
+	// 2. Editor (+ doc map glued to right edge)
+	CGFloat editorWidth = baseEditorFrame.size.width - leftWidth - leftDividerWidth
+	                      - mapWidth - rightDividerWidth - rightWidth;
+	if (editorWidth < kMinEditorWidth)
+		editorWidth = kMinEditorWidth;
+
+	NSRect editorFrame = NSMakeRect(curX, zoneY, editorWidth, zoneH);
+
+	if (ctx().isSplit && ctx().splitView)
+	{
+		ctx().splitView.frame = editorFrame;
+		[ctx().splitView adjustSubviews];
+	}
+	else
+	{
+		ctx().editorContainer.frame = editorFrame;
+	}
+
+	curX += editorWidth;
+
+	// 3. Document Map (glued to editor right edge, no divider)
+	if (ctx().documentMapContainer)
+	{
+		NSRect mapFrame = NSMakeRect(curX, zoneY, mapWidth, zoneH);
+		ctx().documentMapContainer.frame = mapFrame;
+		ctx().documentMapContainer.hidden = !ctx().documentMapEnabled;
+		curX += mapWidth;
+	}
+
+	// 4. Right zone
+	if (rightZoneVisible)
+	{
+		ensureRightVerticalDivider(contentView);
+
+		// Right vertical divider
+		sRightVerticalDivider.frame = NSMakeRect(curX, zoneY, kDividerThickness, zoneH);
+		sRightVerticalDivider.hidden = NO;
+		curX += kDividerThickness;
+
+		NSView* flContainer = (__bridge NSView*)functionListContainerView();
+		NSView* chContainer = (__bridge NSView*)clipboardHistoryContainerView();
+		bool hasBoth = (flContainer != nil) && (chContainer != nil) &&
+		               ctx().functionListEnabled && ctx().clipboardHistoryEnabled;
+
+		if (hasBoth)
+		{
+			ensureRightHorizontalDivider(contentView);
+
+			CGFloat topH = (zoneH - kDividerThickness) * ctx().functionListHeightRatio;
+			CGFloat bottomH = zoneH - kDividerThickness - topH;
+
+			// Function list on top
+			flContainer.frame = NSMakeRect(curX, zoneY + bottomH + kDividerThickness, rightWidth, topH);
+			flContainer.hidden = NO;
+
+			// Horizontal divider
+			sRightHorizontalDivider.frame = NSMakeRect(curX, zoneY + bottomH, rightWidth, kDividerThickness);
+			sRightHorizontalDivider.hidden = NO;
+
+			// Clipboard history on bottom
+			chContainer.frame = NSMakeRect(curX, zoneY, rightWidth, bottomH);
+			chContainer.hidden = NO;
+		}
+		else
+		{
+			// Single panel fills the entire right zone
+			if (flContainer && ctx().functionListEnabled)
+			{
+				flContainer.frame = NSMakeRect(curX, zoneY, rightWidth, zoneH);
+				flContainer.hidden = NO;
+			}
+			else if (flContainer)
+			{
+				flContainer.hidden = YES;
+			}
+
+			if (chContainer && ctx().clipboardHistoryEnabled)
+			{
+				chContainer.frame = NSMakeRect(curX, zoneY, rightWidth, zoneH);
+				chContainer.hidden = NO;
+			}
+			else if (chContainer)
+			{
+				chContainer.hidden = YES;
+			}
+
+			if (sRightHorizontalDivider)
+				sRightHorizontalDivider.hidden = YES;
+		}
+	}
+	else
+	{
+		// Hide right-zone elements
+		NSView* flContainer = (__bridge NSView*)functionListContainerView();
+		NSView* chContainer = (__bridge NSView*)clipboardHistoryContainerView();
+		if (flContainer) flContainer.hidden = !ctx().functionListEnabled;
+		if (chContainer) chContainer.hidden = !ctx().clipboardHistoryEnabled;
+		if (sRightVerticalDivider) sRightVerticalDivider.hidden = YES;
+		if (sRightHorizontalDivider) sRightHorizontalDivider.hidden = YES;
+	}
+
+	// -- Finalize: tab bars and Scintilla resize ------------------------------
+
+	layoutSplitTopTabBars();
+	if (ctx().documentMapScintilla)
+		ScintillaBridge_resizeToFit(ctx().documentMapScintilla);
+	if (ctx().scintillaView)
+		ScintillaBridge_resizeToFit(ctx().scintillaView);
+	if (ctx().isSplit && ctx().scintillaView2)
+		ScintillaBridge_resizeToFit(ctx().scintillaView2);
+}

--- a/macos/platform/settings_manager.h
+++ b/macos/platform/settings_manager.h
@@ -36,6 +36,13 @@ struct AppSettings
 	int documentMapWidth = 140;
 	int functionListWidth = 200;
 	int clipboardHistoryWidth = 220;
+	bool fileBrowser = false;
+	bool fileSwitcher = false;
+	int leftPanelWidth = 200;
+	double fileBrowserHeightRatio = 0.6;
+	std::string fileBrowserRootPath;
+	int rightPanelWidth = 220;
+	double functionListHeightRatio = 0.5;
 
 	// Recent files
 	std::vector<std::string> recentFiles;

--- a/macos/platform/settings_manager.h
+++ b/macos/platform/settings_manager.h
@@ -34,8 +34,6 @@ struct AppSettings
 	bool clipboardHistory = false;
 	bool showChangeHistory = true;
 	int documentMapWidth = 140;
-	int functionListWidth = 200;
-	int clipboardHistoryWidth = 220;
 	bool fileBrowser = false;
 	bool fileSwitcher = false;
 	int leftPanelWidth = 200;

--- a/macos/platform/settings_manager.mm
+++ b/macos/platform/settings_manager.mm
@@ -86,8 +86,6 @@ bool SettingsManager::load()
 	if ([json[@"clipboardHistory"] isKindOfClass:[NSNumber class]])     settings.clipboardHistory = [json[@"clipboardHistory"] boolValue];
 	if ([json[@"showChangeHistory"] isKindOfClass:[NSNumber class]])    settings.showChangeHistory = [json[@"showChangeHistory"] boolValue];
 	if ([json[@"documentMapWidth"] isKindOfClass:[NSNumber class]])     settings.documentMapWidth = [json[@"documentMapWidth"] intValue];
-	if ([json[@"functionListWidth"] isKindOfClass:[NSNumber class]])    settings.functionListWidth = [json[@"functionListWidth"] intValue];
-	if ([json[@"clipboardHistoryWidth"] isKindOfClass:[NSNumber class]])settings.clipboardHistoryWidth = [json[@"clipboardHistoryWidth"] intValue];
 	if ([json[@"fileBrowser"] isKindOfClass:[NSNumber class]])      settings.fileBrowser = [json[@"fileBrowser"] boolValue];
 	if ([json[@"fileSwitcher"] isKindOfClass:[NSNumber class]])     settings.fileSwitcher = [json[@"fileSwitcher"] boolValue];
 	if ([json[@"leftPanelWidth"] isKindOfClass:[NSNumber class]])   settings.leftPanelWidth = [json[@"leftPanelWidth"] intValue];
@@ -165,8 +163,6 @@ bool SettingsManager::save()
 		@"clipboardHistory": @(settings.clipboardHistory),
 		@"showChangeHistory": @(settings.showChangeHistory),
 		@"documentMapWidth": @(settings.documentMapWidth),
-		@"functionListWidth": @(settings.functionListWidth),
-		@"clipboardHistoryWidth": @(settings.clipboardHistoryWidth),
 		@"fileBrowser": @(settings.fileBrowser),
 		@"fileSwitcher": @(settings.fileSwitcher),
 		@"leftPanelWidth": @(settings.leftPanelWidth),

--- a/macos/platform/settings_manager.mm
+++ b/macos/platform/settings_manager.mm
@@ -90,7 +90,12 @@ bool SettingsManager::load()
 	if ([json[@"fileSwitcher"] isKindOfClass:[NSNumber class]])     settings.fileSwitcher = [json[@"fileSwitcher"] boolValue];
 	if ([json[@"leftPanelWidth"] isKindOfClass:[NSNumber class]])   settings.leftPanelWidth = [json[@"leftPanelWidth"] intValue];
 	if ([json[@"fileBrowserHeightRatio"] isKindOfClass:[NSNumber class]]) settings.fileBrowserHeightRatio = [json[@"fileBrowserHeightRatio"] doubleValue];
-	if ([json[@"fileBrowserRootPath"] isKindOfClass:[NSString class]]) settings.fileBrowserRootPath = [json[@"fileBrowserRootPath"] UTF8String];
+	if ([json[@"fileBrowserRootPath"] isKindOfClass:[NSString class]])
+	{
+		const char* rootPath = [json[@"fileBrowserRootPath"] UTF8String];
+		if (rootPath)
+			settings.fileBrowserRootPath = rootPath;
+	}
 	if ([json[@"rightPanelWidth"] isKindOfClass:[NSNumber class]])  settings.rightPanelWidth = [json[@"rightPanelWidth"] intValue];
 	if ([json[@"functionListHeightRatio"] isKindOfClass:[NSNumber class]]) settings.functionListHeightRatio = [json[@"functionListHeightRatio"] doubleValue];
 
@@ -167,7 +172,7 @@ bool SettingsManager::save()
 		@"fileSwitcher": @(settings.fileSwitcher),
 		@"leftPanelWidth": @(settings.leftPanelWidth),
 		@"fileBrowserHeightRatio": @(settings.fileBrowserHeightRatio),
-		@"fileBrowserRootPath": settings.fileBrowserRootPath.empty() ? @"" : @(settings.fileBrowserRootPath.c_str()),
+		@"fileBrowserRootPath": stringFromFileSystemPath(settings.fileBrowserRootPath) ?: @"",
 		@"rightPanelWidth": @(settings.rightPanelWidth),
 		@"functionListHeightRatio": @(settings.functionListHeightRatio),
 		@"recentFiles":  recentArr

--- a/macos/platform/settings_manager.mm
+++ b/macos/platform/settings_manager.mm
@@ -96,7 +96,23 @@ bool SettingsManager::load()
 		if (rootPath)
 			settings.fileBrowserRootPath = rootPath;
 	}
-	if ([json[@"rightPanelWidth"] isKindOfClass:[NSNumber class]])  settings.rightPanelWidth = [json[@"rightPanelWidth"] intValue];
+	if ([json[@"rightPanelWidth"] isKindOfClass:[NSNumber class]])
+	{
+		settings.rightPanelWidth = [json[@"rightPanelWidth"] intValue];
+	}
+	else
+	{
+		// Migration: derive rightPanelWidth from legacy per-panel width keys
+		NSNumber* flWidth = json[@"functionListWidth"];
+		NSNumber* chWidth = json[@"clipboardHistoryWidth"];
+		int migrated = 0;
+		if ([flWidth isKindOfClass:[NSNumber class]])
+			migrated = [flWidth intValue];
+		if ([chWidth isKindOfClass:[NSNumber class]] && [chWidth intValue] > migrated)
+			migrated = [chWidth intValue];
+		if (migrated > 0)
+			settings.rightPanelWidth = migrated;
+	}
 	if ([json[@"functionListHeightRatio"] isKindOfClass:[NSNumber class]]) settings.functionListHeightRatio = [json[@"functionListHeightRatio"] doubleValue];
 
 	// Recent files

--- a/macos/platform/settings_manager.mm
+++ b/macos/platform/settings_manager.mm
@@ -88,6 +88,13 @@ bool SettingsManager::load()
 	if ([json[@"documentMapWidth"] isKindOfClass:[NSNumber class]])     settings.documentMapWidth = [json[@"documentMapWidth"] intValue];
 	if ([json[@"functionListWidth"] isKindOfClass:[NSNumber class]])    settings.functionListWidth = [json[@"functionListWidth"] intValue];
 	if ([json[@"clipboardHistoryWidth"] isKindOfClass:[NSNumber class]])settings.clipboardHistoryWidth = [json[@"clipboardHistoryWidth"] intValue];
+	if ([json[@"fileBrowser"] isKindOfClass:[NSNumber class]])      settings.fileBrowser = [json[@"fileBrowser"] boolValue];
+	if ([json[@"fileSwitcher"] isKindOfClass:[NSNumber class]])     settings.fileSwitcher = [json[@"fileSwitcher"] boolValue];
+	if ([json[@"leftPanelWidth"] isKindOfClass:[NSNumber class]])   settings.leftPanelWidth = [json[@"leftPanelWidth"] intValue];
+	if ([json[@"fileBrowserHeightRatio"] isKindOfClass:[NSNumber class]]) settings.fileBrowserHeightRatio = [json[@"fileBrowserHeightRatio"] doubleValue];
+	if ([json[@"fileBrowserRootPath"] isKindOfClass:[NSString class]]) settings.fileBrowserRootPath = [json[@"fileBrowserRootPath"] UTF8String];
+	if ([json[@"rightPanelWidth"] isKindOfClass:[NSNumber class]])  settings.rightPanelWidth = [json[@"rightPanelWidth"] intValue];
+	if ([json[@"functionListHeightRatio"] isKindOfClass:[NSNumber class]]) settings.functionListHeightRatio = [json[@"functionListHeightRatio"] doubleValue];
 
 	// Recent files
 	settings.recentFiles.clear();
@@ -160,6 +167,13 @@ bool SettingsManager::save()
 		@"documentMapWidth": @(settings.documentMapWidth),
 		@"functionListWidth": @(settings.functionListWidth),
 		@"clipboardHistoryWidth": @(settings.clipboardHistoryWidth),
+		@"fileBrowser": @(settings.fileBrowser),
+		@"fileSwitcher": @(settings.fileSwitcher),
+		@"leftPanelWidth": @(settings.leftPanelWidth),
+		@"fileBrowserHeightRatio": @(settings.fileBrowserHeightRatio),
+		@"fileBrowserRootPath": settings.fileBrowserRootPath.empty() ? @"" : @(settings.fileBrowserRootPath.c_str()),
+		@"rightPanelWidth": @(settings.rightPanelWidth),
+		@"functionListHeightRatio": @(settings.functionListHeightRatio),
 		@"recentFiles":  recentArr
 	};
 

--- a/macos/platform/settings_manager.mm
+++ b/macos/platform/settings_manager.mm
@@ -89,7 +89,13 @@ bool SettingsManager::load()
 	if ([json[@"fileBrowser"] isKindOfClass:[NSNumber class]])      settings.fileBrowser = [json[@"fileBrowser"] boolValue];
 	if ([json[@"fileSwitcher"] isKindOfClass:[NSNumber class]])     settings.fileSwitcher = [json[@"fileSwitcher"] boolValue];
 	if ([json[@"leftPanelWidth"] isKindOfClass:[NSNumber class]])   settings.leftPanelWidth = [json[@"leftPanelWidth"] intValue];
-	if ([json[@"fileBrowserHeightRatio"] isKindOfClass:[NSNumber class]]) settings.fileBrowserHeightRatio = [json[@"fileBrowserHeightRatio"] doubleValue];
+	if ([json[@"fileBrowserHeightRatio"] isKindOfClass:[NSNumber class]])
+	{
+		double ratio = [json[@"fileBrowserHeightRatio"] doubleValue];
+		if (ratio < 0.15) ratio = 0.15;
+		else if (ratio > 0.85) ratio = 0.85;
+		settings.fileBrowserHeightRatio = ratio;
+	}
 	if ([json[@"fileBrowserRootPath"] isKindOfClass:[NSString class]])
 	{
 		const char* rootPath = [json[@"fileBrowserRootPath"] UTF8String];
@@ -113,7 +119,13 @@ bool SettingsManager::load()
 		if (migrated > 0)
 			settings.rightPanelWidth = migrated;
 	}
-	if ([json[@"functionListHeightRatio"] isKindOfClass:[NSNumber class]]) settings.functionListHeightRatio = [json[@"functionListHeightRatio"] doubleValue];
+	if ([json[@"functionListHeightRatio"] isKindOfClass:[NSNumber class]])
+	{
+		double ratio = [json[@"functionListHeightRatio"] doubleValue];
+		if (ratio < 0.15) ratio = 0.15;
+		else if (ratio > 0.85) ratio = 0.85;
+		settings.functionListHeightRatio = ratio;
+	}
 
 	// Recent files
 	settings.recentFiles.clear();

--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -21,6 +21,7 @@
 #include "document_map.h"
 #include "function_list_panel.h"
 #include "panel_layout.h"
+#include "file_switcher_panel.h"
 #include "scintilla_notify.h"
 #include "macro_manager.h"
 #include "windows.h"
@@ -148,6 +149,7 @@ void doSplit()
 								ctx().documents2[tabIdx].modified = true;
 								updateTabModifiedIndicator(1, tabIdx);
 								updateWindowDocumentEdited();
+								reloadFileSwitcherData();
 							}
 						}
 					}
@@ -162,6 +164,7 @@ void doSplit()
 								ctx().documents2[tabIdx].modified = false;
 								updateTabModifiedIndicator(1, tabIdx);
 								updateWindowDocumentEdited();
+								reloadFileSwitcherData();
 							}
 						}
 					}

--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -138,6 +138,7 @@ void doSplit()
 						ctx().activeView = 1;
 						bindDocumentMapToActiveView();
 						bindFunctionListToActiveView();
+						bindFileSwitcherToActiveView();
 					}
 					else if (scn->nmhdr.code == SCN_SAVEPOINTLEFT)
 					{

--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -20,6 +20,7 @@
 #include "sync_scroll.h"
 #include "document_map.h"
 #include "function_list_panel.h"
+#include "panel_layout.h"
 #include "scintilla_notify.h"
 #include "macro_manager.h"
 #include "windows.h"
@@ -277,7 +278,7 @@ void doSplit()
 		ScintillaBridge_sendMessage(ctx().scintillaView2, SCI_SETWRAPMODE, wrapMode, 0);
 	}
 
-	relayoutFunctionListPanel();
+	relayoutPanels();
 	bindDocumentMapToActiveView();
 	updateDocumentMapViewport();
 	bindFunctionListToActiveView();
@@ -350,7 +351,7 @@ void doUnsplit()
 
 	layoutSplitTopTabBars();
 	updateSplitMenuState();
-	relayoutFunctionListPanel();
+	relayoutPanels();
 	bindDocumentMapToActiveView();
 	updateDocumentMapViewport();
 	bindFunctionListToActiveView();

--- a/macos/platform/wndproc.mm
+++ b/macos/platform/wndproc.mm
@@ -32,6 +32,8 @@
 #include "document_map.h"
 #include "function_list_panel.h"
 #include "clipboard_history_panel.h"
+#include "file_browser_panel.h"
+#include "file_switcher_panel.h"
 #include "change_history.h"
 #include "hash_tools.h"
 #include "macro_manager.h"
@@ -531,6 +533,29 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 					              MF_BYCOMMAND | (ctx().clipboardHistoryEnabled ? MF_CHECKED : MF_UNCHECKED));
 				return 0;
 			}
+			case IDM_VIEW_FILEBROWSER:
+			{
+				setFileBrowserEnabled(!ctx().fileBrowserEnabled);
+				HMENU hMenu = GetMenu(hWnd);
+				if (hMenu)
+					CheckMenuItem(hMenu, IDM_VIEW_FILEBROWSER,
+					              MF_BYCOMMAND | (ctx().fileBrowserEnabled ? MF_CHECKED : MF_UNCHECKED));
+				return 0;
+			}
+			case IDM_VIEW_FILESWITCHER:
+			{
+				setFileSwitcherEnabled(!ctx().fileSwitcherEnabled);
+				HMENU hMenu = GetMenu(hWnd);
+				if (hMenu)
+					CheckMenuItem(hMenu, IDM_VIEW_FILESWITCHER,
+					              MF_BYCOMMAND | (ctx().fileSwitcherEnabled ? MF_CHECKED : MF_UNCHECKED));
+				return 0;
+			}
+			case IDM_FILE_OPENFOLDER:
+			{
+				openFolderWithDialog();
+				return 0;
+			}
 			case IDM_VIEW_CHANGE_HISTORY:
 			{
 				ctx().showChangeHistory = !ctx().showChangeHistory;
@@ -674,6 +699,10 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 					              MF_BYCOMMAND | (ctx().functionListEnabled ? MF_CHECKED : MF_UNCHECKED));
 					CheckMenuItem(hMenu, IDM_VIEW_CLIPBOARD_HISTORY,
 					              MF_BYCOMMAND | (ctx().clipboardHistoryEnabled ? MF_CHECKED : MF_UNCHECKED));
+					CheckMenuItem(hMenu, IDM_VIEW_FILEBROWSER,
+					              MF_BYCOMMAND | (ctx().fileBrowserEnabled ? MF_CHECKED : MF_UNCHECKED));
+					CheckMenuItem(hMenu, IDM_VIEW_FILESWITCHER,
+					              MF_BYCOMMAND | (ctx().fileSwitcherEnabled ? MF_CHECKED : MF_UNCHECKED));
 					CheckMenuItem(hMenu, IDM_EDIT_AUTOCLOSE_BRACKETS,
 					              MF_BYCOMMAND | (ctx().autoCloseBrackets ? MF_CHECKED : MF_UNCHECKED));
 					CheckMenuItem(hMenu, IDM_VIEW_SYNCHRONIZE_SCROLLING,


### PR DESCRIPTION
 Summary:
  - File Browser panel (#23) — tree view with FSEvents, context menu, icon caching
  - File Switcher panel (#35) — compact open-docs list with split-view support
  - Resizable dividers across all panels (drag to resize, auto-collapse at 60px)
  - Right-zone vertical stacking for Function List + Clipboard History
  - Layout orchestrator refactor (relayoutPanels() in panel_layout.mm)

  10 commits, 23 files changed, ~2,300 lines added. Closes #23, closes #35.