### PR TITLE
fix: correct split view tab bar positioning, redraw, and focus

### DIFF
--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -59,9 +59,10 @@ void layoutSplitTopTabBars()
 	if (leftTabInfo && leftTabInfo->nativeView)
 	{
 		NSView* leftTabView = (__bridge NSView*)leftTabInfo->nativeView;
-		if (ctx().isSplit && ctx().editorContainer)
+		if (ctx().isSplit && ctx().editorContainer && ctx().splitView)
 		{
-			leftTabView.frame = NSMakeRect(ctx().editorContainer.frame.origin.x, topY,
+			CGFloat splitBaseX = ctx().splitView.frame.origin.x;
+			leftTabView.frame = NSMakeRect(splitBaseX + ctx().editorContainer.frame.origin.x, topY,
 			                               ctx().editorContainer.frame.size.width, tabHeight);
 		}
 		else
@@ -72,13 +73,14 @@ void layoutSplitTopTabBars()
 		}
 	}
 
-	if (ctx().isSplit && ctx().tabHwnd2 && ctx().editorContainer2)
+	if (ctx().isSplit && ctx().tabHwnd2 && ctx().editorContainer2 && ctx().splitView)
 	{
 		auto* rightTabInfo = HandleRegistry::getWindowInfo(ctx().tabHwnd2);
 		if (rightTabInfo && rightTabInfo->nativeView)
 		{
+			CGFloat splitBaseX = ctx().splitView.frame.origin.x;
 			NSView* rightTabView = (__bridge NSView*)rightTabInfo->nativeView;
-			rightTabView.frame = NSMakeRect(ctx().editorContainer2.frame.origin.x, topY,
+			rightTabView.frame = NSMakeRect(splitBaseX + ctx().editorContainer2.frame.origin.x, topY,
 			                                ctx().editorContainer2.frame.size.width, tabHeight);
 		}
 	}
@@ -342,6 +344,7 @@ void doUnsplit()
 	ctx().editorContainer.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 	[contentView addSubview:ctx().editorContainer];
 	ScintillaBridge_resizeToFit(ctx().scintillaView);
+	ScintillaBridge_sendMessage(ctx().scintillaView, SCI_COLOURISE, 0, -1);
 
 	ctx().documents2.clear();
 	ctx().activeTab2 = -1;
@@ -353,12 +356,12 @@ void doUnsplit()
 	if (isIncrementalSearchVisible())
 		updateIncrementalSearchTarget();
 
-	layoutSplitTopTabBars();
 	updateSplitMenuState();
 	relayoutPanels();
 	bindDocumentMapToActiveView();
 	updateDocumentMapViewport();
 	bindFunctionListToActiveView();
+	ScintillaBridge_focus(ctx().scintillaView);
 }
 
 void doMoveToOtherView()

--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -361,7 +361,8 @@ void doUnsplit()
 	bindDocumentMapToActiveView();
 	updateDocumentMapViewport();
 	bindFunctionListToActiveView();
-	ScintillaBridge_focus(ctx().scintillaView);
+	if (!isIncrementalSearchVisible())
+		ScintillaBridge_focus(ctx().scintillaView);
 }
 
 void doMoveToOtherView()


### PR DESCRIPTION
## Summary
- Fix tab bar coordinates in split mode to use contentView coordinates instead of splitView-local coordinates, preventing misalignment when panels (file browser, function list) are visible
- Force Scintilla redraw via `SCI_COLOURISE` after unsplit reparenting so the editor content is displayed
- Remove redundant `layoutSplitTopTabBars()` call that ran before `relayoutPanels()` with stale frame data
- Add `ScintillaBridge_focus()` after unsplit to restore keyboard focus to the remaining editor

## Test plan
- [ ] Split with no panels → both tab bars aligned with their editor panes
- [ ] Unsplit → remaining editor shows content and accepts keyboard input
- [ ] Split with file browser enabled → tab bars offset correctly (not overlapping panel)
- [ ] Split with function list enabled → tab bars positioned correctly
- [ ] Split with both panels → correct tab bar alignment
- [ ] Unsplit from right pane active → left pane gets focus, shows content
- [ ] Resize window while split with panels → tab bars follow correctly
- [ ] Drag split divider with panels → tab bars reposition correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)