### PR TITLE
fix: improve Split View handling (#95)

### DIFF
--- a/macos/platform/document_manager.h
+++ b/macos/platform/document_manager.h
@@ -24,6 +24,8 @@ void closeTab(int tabIndex);
 
 void reorderTabInView(int viewIndex, int fromIndex, int toIndex);
 
+void migrateTabToView(int viewIndex, const DocumentData& doc);
+
 void updateTabModifiedIndicator(int viewIndex, int tabIndex);
 void updateWindowDocumentEdited();
 

--- a/macos/platform/document_manager.mm
+++ b/macos/platform/document_manager.mm
@@ -294,8 +294,10 @@ void migrateTabToView(int viewIndex, const DocumentData& doc)
 	HWND tabHwnd = (viewIndex == 0) ? ctx().tabHwnd : ctx().tabHwnd2;
 
 	DocumentData newDoc = doc;
-	newDoc.functionListDocumentId = allocateFunctionListDocumentId();
-	newDoc.functionListRevision = 0;
+	// Keep the existing functionListDocumentId so cached entries remain valid.
+	// Only allocate a new one if the source didn't have one.
+	if (newDoc.functionListDocumentId == 0)
+		newDoc.functionListDocumentId = allocateFunctionListDocumentId();
 	docs.push_back(newDoc);
 
 	int newIndex = static_cast<int>(docs.size()) - 1;

--- a/macos/platform/document_manager.mm
+++ b/macos/platform/document_manager.mm
@@ -288,6 +288,32 @@ void closeTab(int tabIndex)
 	closeTabFromView(ctx().activeView, tabIndex);
 }
 
+void migrateTabToView(int viewIndex, const DocumentData& doc)
+{
+	auto& docs = (viewIndex == 0) ? ctx().documents : ctx().documents2;
+	HWND tabHwnd = (viewIndex == 0) ? ctx().tabHwnd : ctx().tabHwnd2;
+
+	DocumentData newDoc = doc;
+	newDoc.functionListDocumentId = allocateFunctionListDocumentId();
+	newDoc.functionListRevision = 0;
+	docs.push_back(newDoc);
+
+	int newIndex = static_cast<int>(docs.size()) - 1;
+
+	if (tabHwnd)
+	{
+		TCITEMW tcItem = {};
+		tcItem.mask = TCIF_TEXT;
+		wchar_t titleBuf[256];
+		wcsncpy(titleBuf, newDoc.title.c_str(), 255);
+		titleBuf[255] = L'\0';
+		tcItem.pszText = titleBuf;
+		SendMessageW(tabHwnd, TCM_INSERTITEMW, newIndex, reinterpret_cast<LPARAM>(&tcItem));
+	}
+
+	updateTabModifiedIndicator(viewIndex, newIndex);
+}
+
 void reorderTabInView(int viewIndex, int fromIndex, int toIndex)
 {
 	auto& docs = (viewIndex == 0) ? ctx().documents : ctx().documents2;

--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -139,6 +139,7 @@ void doSplit()
 		ctx().sciContainer2 = nil;
 		[ctx().splitView removeFromSuperview];
 		ctx().splitView = nil;
+		ctx().editorContainer.translatesAutoresizingMaskIntoConstraints = YES;
 		ctx().editorContainer.frame = originalFrame;
 		ctx().editorContainer.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 		[contentView addSubview:ctx().editorContainer];
@@ -385,17 +386,43 @@ void doUnsplit()
 	[contentView addSubview:ctx().editorContainer];
 	ScintillaBridge_resizeToFit(ctx().scintillaView);
 
-	// Migrate documents from view 2 to view 0 — preserve all tabs (no filePath dedup)
+	// Migrate documents from view 2 to view 0.
+	// Skip unmodified mirrors (same filePath already in view 0 and not modified)
+	// to avoid duplicating the initial split clone. Preserve modified clones
+	// since they may have diverged.
 	int migratedActiveIdx = -1;
 	for (int i = 0; i < static_cast<int>(docsToMigrate.size()); ++i)
 	{
 		const auto& doc = docsToMigrate[i];
-		// Skip empty untitled unmodified placeholder documents
-		if (doc.filePath.empty() && !doc.modified && doc.content.empty())
+
+		bool skip = false;
+		if (!doc.modified)
+		{
+			if (!doc.filePath.empty())
+			{
+				// Skip unmodified doc if same file already open in view 0
+				for (const auto& d : ctx().documents)
+				{
+					if (d.filePath == doc.filePath)
+					{
+						skip = true;
+						break;
+					}
+				}
+			}
+			else if (doc.content.empty())
+			{
+				// Skip empty untitled unmodified placeholder
+				skip = true;
+			}
+		}
+
+		if (skip)
 		{
 			invalidateFunctionListCacheForDocument(doc.functionListDocumentId);
 			continue;
 		}
+
 		if (wasActiveInView2 && i == view2ActiveIdx)
 			migratedActiveIdx = static_cast<int>(ctx().documents.size());
 		migrateTabToView(0, doc);
@@ -412,6 +439,8 @@ void doUnsplit()
 	    && migratedActiveIdx < static_cast<int>(ctx().documents.size()))
 	{
 		ctx().activeTab = migratedActiveIdx;
+		if (ctx().tabHwnd)
+			SendMessageW(ctx().tabHwnd, TCM_SETCURSEL, ctx().activeTab, 0);
 	}
 
 	// Restore main Scintilla content from the active document
@@ -444,12 +473,14 @@ void doUnsplit()
 	reloadFileSwitcherData();
 	updateStatusBar();
 
-	// Deferred display refresh after Cocoa completes layout
+	// Deferred display refresh after Cocoa completes layout.
+	// Capture the pointer before dispatch to avoid races with ctx() changes.
+	void* capturedSciView = ctx().scintillaView;
 	dispatch_async(dispatch_get_main_queue(), ^{
-		ScintillaBridge_resizeToFit(ctx().scintillaView);
-		if (ctx().scintillaView)
+		if (capturedSciView)
 		{
-			NSView* view = (__bridge NSView*)ctx().scintillaView;
+			ScintillaBridge_resizeToFit(capturedSciView);
+			NSView* view = (__bridge NSView*)capturedSciView;
 			[view setNeedsDisplay:YES];
 		}
 	});

--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -24,6 +24,7 @@
 #include "file_switcher_panel.h"
 #include "scintilla_notify.h"
 #include "macro_manager.h"
+#include "status_bar.h"
 #include "windows.h"
 #include "commctrl.h"
 
@@ -90,6 +91,9 @@ void doSplit()
 
 	NSView* contentView = ctx().mainWindow.contentView;
 
+	// Save original frame for rollback if Scintilla creation fails
+	NSRect originalFrame = ctx().editorContainer.frame;
+
 	ctx().splitView = [[NSSplitView alloc] initWithFrame:ctx().editorContainer.frame];
 	ctx().splitView.vertical = YES;
 	ctx().splitView.dividerStyle = NSSplitViewDividerStyleThin;
@@ -122,7 +126,26 @@ void doSplit()
 	[ctx().editorContainer2 addSubview:ctx().sciContainer2];
 
 	ctx().scintillaView2 = ScintillaBridge_createView((__bridge void*)ctx().sciContainer2, 0, 0, 0, 0);
-	if (ctx().scintillaView2)
+	if (!ctx().scintillaView2)
+	{
+		// Rollback: restore editorContainer to contentView
+		[ctx().editorContainer removeFromSuperview];
+		if (ctx().tabHwnd2)
+		{
+			DestroyWindow(ctx().tabHwnd2);
+			ctx().tabHwnd2 = nullptr;
+		}
+		ctx().editorContainer2 = nil;
+		ctx().sciContainer2 = nil;
+		[ctx().splitView removeFromSuperview];
+		ctx().splitView = nil;
+		ctx().editorContainer.frame = originalFrame;
+		ctx().editorContainer.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+		[contentView addSubview:ctx().editorContainer];
+		ScintillaBridge_resizeToFit(ctx().scintillaView);
+		return;
+	}
+
 	{
 		configureScintilla(ctx().scintillaView2);
 		ScintillaBridge_setNotifyCallback(ctx().scintillaView2, 1,
@@ -295,8 +318,18 @@ void doUnsplit()
 
 	NSView* contentView = ctx().mainWindow.contentView;
 
+	// Save both views' state before destroying anything
 	if (ctx().scintillaView2)
 		saveViewState(ctx().scintillaView2, ctx().documents2, ctx().activeTab2);
+	if (ctx().scintillaView)
+		saveViewState(ctx().scintillaView, ctx().documents, ctx().activeTab);
+
+	// Capture which document the user was editing
+	bool wasActiveInView2 = (ctx().activeView == 1);
+	int view2ActiveIdx = ctx().activeTab2;
+
+	// Snapshot documents2 for migration before clearing
+	std::vector<DocumentData> docsToMigrate = ctx().documents2;
 
 	// If incremental search bar is in the closing view, remove it first
 	if (isIncrementalSearchVisible() && ctx().incrementalSearchBar)
@@ -308,6 +341,7 @@ void doUnsplit()
 		}
 	}
 
+	// Destroy second Scintilla view
 	if (ctx().scintillaView2)
 	{
 		cancelPendingSmartHighlight();
@@ -317,6 +351,7 @@ void doUnsplit()
 		ctx().scintillaView2 = nullptr;
 	}
 
+	// Destroy second tab bar
 	if (ctx().tabHwnd2)
 	{
 		DestroyWindow(ctx().tabHwnd2);
@@ -325,6 +360,7 @@ void doUnsplit()
 
 	ctx().sciContainer2 = nil;
 
+	// Reparent editorContainer back to contentView
 	[ctx().editorContainer removeFromSuperview];
 	if (ctx().editorContainer2)
 	{
@@ -335,6 +371,12 @@ void doUnsplit()
 	[ctx().splitView removeFromSuperview];
 	ctx().splitView = nil;
 
+	// NSSplitView sets translatesAutoresizingMaskIntoConstraints=NO on arranged
+	// subviews and manages them via Auto Layout. After removing editorContainer
+	// from the split view, restore autoresizing mask behavior so the explicitly
+	// set frame is respected by contentView's layout.
+	ctx().editorContainer.translatesAutoresizingMaskIntoConstraints = YES;
+
 	CGFloat tabHeight = NPP_TAB_BAR_HEIGHT;
 	CGFloat statusHeight = NPP_STATUS_BAR_HEIGHT;
 	CGFloat editorHeight = contentView.bounds.size.height - tabHeight - statusHeight;
@@ -343,11 +385,40 @@ void doUnsplit()
 	[contentView addSubview:ctx().editorContainer];
 	ScintillaBridge_resizeToFit(ctx().scintillaView);
 
+	// Migrate documents from view 2 to view 0 — preserve all tabs (no filePath dedup)
+	int migratedActiveIdx = -1;
+	for (int i = 0; i < static_cast<int>(docsToMigrate.size()); ++i)
+	{
+		const auto& doc = docsToMigrate[i];
+		// Skip empty untitled unmodified placeholder documents
+		if (doc.filePath.empty() && !doc.modified && doc.content.empty())
+		{
+			invalidateFunctionListCacheForDocument(doc.functionListDocumentId);
+			continue;
+		}
+		if (wasActiveInView2 && i == view2ActiveIdx)
+			migratedActiveIdx = static_cast<int>(ctx().documents.size());
+		migrateTabToView(0, doc);
+	}
+
 	ctx().documents2.clear();
 	ctx().activeTab2 = -1;
 	ctx().activeView = 0;
 	ctx().isSplit = false;
 	ctx().syncScrollReentrant = false;
+
+	// If user was focused on view 2, switch to that migrated tab
+	if (wasActiveInView2 && migratedActiveIdx >= 0
+	    && migratedActiveIdx < static_cast<int>(ctx().documents.size()))
+	{
+		ctx().activeTab = migratedActiveIdx;
+	}
+
+	// Restore main Scintilla content from the active document
+	restoreViewToScintilla(ctx().scintillaView, ctx().documents, ctx().activeTab);
+	if (ctx().activeTab >= 0 && ctx().activeTab < static_cast<int>(ctx().documents.size()))
+		applyLanguageToView(ctx().scintillaView, ctx().documents[ctx().activeTab].languageIndex);
+
 	refreshSyncScrollAnchor();
 
 	if (isIncrementalSearchVisible())
@@ -356,9 +427,32 @@ void doUnsplit()
 	layoutSplitTopTabBars();
 	updateSplitMenuState();
 	relayoutPanels();
+
+	// Restore focus and update UI to reflect the active document
+	ScintillaBridge_focus(ctx().scintillaView);
+
+	if (ctx().activeTab >= 0 && ctx().activeTab < static_cast<int>(ctx().documents.size()))
+	{
+		NSString* title = WideToNSString(ctx().documents[ctx().activeTab].title.c_str());
+		[ctx().mainWindow setTitle:[NSString stringWithFormat:@"Notepad++ — %@", title]];
+	}
+	updateWindowDocumentEdited();
+
 	bindDocumentMapToActiveView();
 	updateDocumentMapViewport();
 	bindFunctionListToActiveView();
+	reloadFileSwitcherData();
+	updateStatusBar();
+
+	// Deferred display refresh after Cocoa completes layout
+	dispatch_async(dispatch_get_main_queue(), ^{
+		ScintillaBridge_resizeToFit(ctx().scintillaView);
+		if (ctx().scintillaView)
+		{
+			NSView* view = (__bridge NSView*)ctx().scintillaView;
+			[view setNeedsDisplay:YES];
+		}
+	});
 }
 
 void doMoveToOtherView()


### PR DESCRIPTION
## Summary

- **Fixes blank editor on unsplit**: `NSSplitView` sets `translatesAutoresizingMaskIntoConstraints=NO` on arranged subviews. When `editorContainer` was reparented to `contentView`, Auto Layout collapsed it to zero height. Restoring `translatesAutoresizingMaskIntoConstraints=YES` after removal fixes the layout.
- **Migrates view-2 documents back to view-0**: Previously `documents2.clear()` silently dropped all tabs from the second view. Now all non-placeholder documents are migrated back, preserving clones with divergent edits.
- **Preserves active document focus**: If the user was editing in view 2, that document becomes the active tab after unsplit.
- **Adds safety rollback in `doSplit()`**: If `ScintillaBridge_createView` fails, the split is rolled back cleanly instead of leaving the app in a half-split state.

Closes #95

## Test plan

- [ ] Open a file, split view, unsplit — editor should show content, not blank
- [ ] Repeat split/unsplit 5+ times rapidly — should remain stable
- [ ] Split, move a tab to view 2, unsplit — tab preserved in view 0
- [ ] Split, clone to view 2, edit the clone, unsplit — both copies preserved
- [ ] Split, click in view 2, edit, unsplit — that document is now active in view 0
- [ ] Split with only 1 tab, unsplit — works correctly
- [ ] Split, edit in view 2 (modified state), unsplit — modified indicator preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)