### PR TITLE
fix: enable HTML tag folding (#97)

### DIFF
--- a/macos/platform/lexer_styles.mm
+++ b/macos/platform/lexer_styles.mm
@@ -339,19 +339,19 @@ void applyLanguageToView(void* sci, int langIndex)
 	ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"fold.comment", (intptr_t)"1");
 	ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"fold.preprocessor", (intptr_t)"1");
 
-	// HTML-family fold properties (hypertext, phpscript, xml all use LexHTML.cxx)
+	// HTML-family properties (hypertext, phpscript, xml all use LexHTML.cxx)
 	if (strcmp(lang.lexerName, "hypertext") == 0 ||
 		strcmp(lang.lexerName, "phpscript") == 0 ||
 		strcmp(lang.lexerName, "xml") == 0)
 	{
 		ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"fold.html", (intptr_t)"1");
 		ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"fold.hypertext.comment", (intptr_t)"1");
-	}
 
-	// XML: disable embedded scripts (matches upstream setXmlLexer behavior)
-	if (strcmp(lang.lexerName, "xml") == 0)
-	{
-		ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"lexer.xml.allow.scripts", (intptr_t)"0");
+		// XML disables embedded scripts; other LexHTML-based lexers must re-enable them
+		// so switching away from XML does not inherit the XML-only setting.
+		ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY,
+			(uintptr_t)"lexer.xml.allow.scripts",
+			(intptr_t)(strcmp(lang.lexerName, "xml") == 0 ? "0" : "1"));
 	}
 
 	ScintillaBridge_sendMessage(sci, SCI_STYLESETFONT, 32, (intptr_t)ctx().fontName.c_str());

--- a/macos/platform/lexer_styles.mm
+++ b/macos/platform/lexer_styles.mm
@@ -339,6 +339,21 @@ void applyLanguageToView(void* sci, int langIndex)
 	ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"fold.comment", (intptr_t)"1");
 	ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"fold.preprocessor", (intptr_t)"1");
 
+	// HTML-family fold properties (hypertext, phpscript, xml all use LexHTML.cxx)
+	if (strcmp(lang.lexerName, "hypertext") == 0 ||
+		strcmp(lang.lexerName, "phpscript") == 0 ||
+		strcmp(lang.lexerName, "xml") == 0)
+	{
+		ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"fold.html", (intptr_t)"1");
+		ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"fold.hypertext.comment", (intptr_t)"1");
+	}
+
+	// XML: disable embedded scripts (matches upstream setXmlLexer behavior)
+	if (strcmp(lang.lexerName, "xml") == 0)
+	{
+		ScintillaBridge_sendMessage(sci, SCI_SETPROPERTY, (uintptr_t)"lexer.xml.allow.scripts", (intptr_t)"0");
+	}
+
 	ScintillaBridge_sendMessage(sci, SCI_STYLESETFONT, 32, (intptr_t)ctx().fontName.c_str());
 	ScintillaBridge_sendMessage(sci, SCI_STYLESETSIZE, 32, ctx().fontSize);
 


### PR DESCRIPTION
## Summary

- Enable HTML tag folding by setting `fold.html=1` for `hypertext`, `phpscript`, and `xml` lexers in `applyLanguageToView()`
- Add `fold.hypertext.comment=1` for embedded script comment folding (Windows parity)
- Set `lexer.xml.allow.scripts=0` for XML files to match upstream `setXmlLexer()` behavior

Closes #97

## Test plan

- [ ] Open an HTML file — verify fold markers appear next to tag pairs (`<div>`, `<section>`, etc.)
- [ ] Click a fold marker — content between open/close tags should collapse
- [ ] Verify nested tags create nested, independently foldable regions
- [ ] Verify self-closing tags (`<br/>`, `<img/>`) do NOT create fold points
- [ ] Open an XML file — verify tag folding works
- [ ] Open a PHP file — verify tag folding works
- [ ] Open a C++ file — verify brace folding still works (no regression)
- [ ] Open a Python file — verify indent folding still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)