### PR TITLE
[codex] Add ComparePlus colors and visual filters on macOS

### DIFF
--- a/docs/compare-plus-host-inventory.md
+++ b/docs/compare-plus-host-inventory.md
@@ -1,6 +1,7 @@
 # ComparePlus Host-Surface Inventory
 
-Generated as part of Phase 0, Issue #100. Updated after Phase 3 ComparePlus host work.
+Generated as part of Phase 0, Issue #100. Updated after ComparePlus colors and
+Visual Filters work.
 
 Status note: "accepted no-op" means the macOS host consumes the message so
 ComparePlus can continue, but there is no equivalent visible macOS UI surface yet.
@@ -48,6 +49,18 @@ ComparePlus can continue, but there is no equivalent visible macOS UI surface ye
 | `NPPN_GLOBALMODIFIED` | Compare.cpp | **NOT EMITTED** |
 | `NPPN_DARKMODECHANGED` | Compare.cpp | **NOT EMITTED** |
 | `NPPN_WORDSTYLESUPDATED` | Compare.cpp | **NOT EMITTED** |
+
+## Dialog / Control Surface
+
+| Surface | Used In | macOS Status |
+|---------|---------|--------------|
+| Compare Options dialog | CompareOptionsDialog.cpp | **IMPLEMENTED** (template + real upstream dialog) |
+| Settings dialog | SettingsDialog.cpp | **IMPLEMENTED** (template + real upstream dialog) |
+| Settings color controls | ColorCombo.h | **IMPLEMENTED** (NSColorWell bridge, persists through UserSettings) |
+| Visual Filters dialog | VisualFiltersDialog.cpp | **IMPLEMENTED** (template + real upstream dialog) |
+| About dialog / URL links | AboutDialog.cpp, URLCtrl.cpp | **NOT IMPLEMENTED** (accepted no-op stubs) |
+| NavBar docking panel | NavDialog.cpp | **NOT IMPLEMENTED** (blocked on `NPPM_DMM*` host surface) |
+| Progress dialog | ProgressDlg.cpp | **IMPLEMENTED** (functional no-UI stub; compare never stalls/cancels) |
 
 ## Already Implemented (working)
 

--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -481,6 +481,7 @@ add_library(ComparePlus MODULE
     "${COMPARE_PLUS_DIR}/src/NppAPI/DockingFeature/StaticDialog.cpp"
     "${COMPARE_PLUS_DIR}/src/CompareOptionsDlg/CompareOptionsDialog.cpp"
     "${COMPARE_PLUS_DIR}/src/SettingsDlg/SettingsDialog.cpp"
+    "${COMPARE_PLUS_DIR}/src/macOS/ColorComboMac.mm"
     "${COMPARE_PLUS_DIR}/src/macOS/MacCompatStubs.cpp"
 )
 target_include_directories(ComparePlus PRIVATE
@@ -512,6 +513,10 @@ set_target_properties(ComparePlus PROPERTIES
 )
 target_compile_options(ComparePlus PRIVATE -Wno-deprecated-declarations)
 target_link_options(ComparePlus PRIVATE -undefined dynamic_lookup)
+target_link_libraries(ComparePlus PRIVATE
+    "-framework AppKit"
+    "-framework Foundation"
+)
 
 add_custom_target(install_compare_plus
     DEPENDS ComparePlus

--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -480,6 +480,7 @@ add_library(ComparePlus MODULE
     "${COMPARE_PLUS_DIR}/src/Engine/Engine.cpp"
     "${COMPARE_PLUS_DIR}/src/NppAPI/DockingFeature/StaticDialog.cpp"
     "${COMPARE_PLUS_DIR}/src/CompareOptionsDlg/CompareOptionsDialog.cpp"
+    "${COMPARE_PLUS_DIR}/src/VisualFiltersDlg/VisualFiltersDialog.cpp"
     "${COMPARE_PLUS_DIR}/src/SettingsDlg/SettingsDialog.cpp"
     "${COMPARE_PLUS_DIR}/src/macOS/ColorComboMac.mm"
     "${COMPARE_PLUS_DIR}/src/macOS/MacCompatStubs.cpp"

--- a/macos/shim/src/dialog_controls.mm
+++ b/macos/shim/src/dialog_controls.mm
@@ -146,17 +146,8 @@ HWND createDialogControl(const DlgControlDescriptor& desc,
 		}
 		case DlgControlClass::ColorCombo:
 		{
-			// ColorCombo is a Win32 owner-draw combo. On macOS this is
-			// currently a disabled NSColorWell placeholder — it does not
-			// mirror ColorCombo::setColor() yet, because ColorCombo::init
-			// is stubbed on macOS (MacCompatStubs.cpp) so the plugin's
-			// saved colors never reach the well. The one-way bridge and
-			// NSColorWell -> ColorCombo::_color pickling land together in
-			// a follow-up that un-stubs ColorCombo. Disabling the well
-			// prevents the "picked a color that didn't save" confusion
-			// until then.
 			NSColorWell* well = [[NSColorWell alloc] initWithFrame:frame];
-			well.enabled = NO;
+			well.enabled = YES;
 			[parent addSubview:well];
 			return registerDialogChild(well, desc, ownerDialog, ControlType::None, L"ColorCombo");
 		}

--- a/macos/shim/src/dialog_template_visual_filters.mm
+++ b/macos/shim/src/dialog_template_visual_filters.mm
@@ -1,0 +1,57 @@
+// Hand-translated IDD_VISUAL_FILTERS_DIALOG from Compare.rc.
+//
+// Controls ordered to match the .rc top to bottom; rect units are
+// dialog units (DLU). The dialog only uses labels, group boxes,
+// checkboxes, and OK/Cancel buttons, all already supported by the shim.
+
+#ifdef __APPLE__
+
+#import <Foundation/Foundation.h>
+#include "windows.h"
+#include "dialog_template.h"
+
+#include "../../plugins/comparePlus/src/resource.h"
+
+namespace {
+
+struct AutoRegister
+{
+	AutoRegister()
+	{
+		DialogTemplateCpp t;
+		t.id    = IDD_VISUAL_FILTERS_DIALOG;
+		t.title = L"ComparePlus   Visual Filters";
+		t.x = 0; t.y = 0; t.cx = 150; t.cy = 208;
+
+		t.controls = {
+			{ DlgControlClass::Static, IDC_NOTE, L"NOTE: First line can never be hidden",
+			  10, 8, 130, 16 },
+			{ DlgControlClass::GroupBox, IDC_FILTERS, L"Diffs Filters",
+			  7, 29, 136, 121 },
+			{ DlgControlClass::Checkbox, IDC_HIDE_MATCHES, L"Hide matches",
+			  15, 46, 115, 16 },
+			{ DlgControlClass::Checkbox, IDC_HIDE_ALL_DIFFS, L"Hide all diffs",
+			  15, 66, 115, 16 },
+			{ DlgControlClass::Checkbox, IDC_HIDE_NEW_LINES, L"Hide added/removed lines",
+			  20, 86, 110, 16 },
+			{ DlgControlClass::Checkbox, IDC_HIDE_CHANGED_LINES, L"Hide changed lines",
+			  20, 106, 110, 16 },
+			{ DlgControlClass::Checkbox, IDC_HIDE_MOVED_LINES, L"Hide moved lines",
+			  20, 126, 114, 16 },
+			{ DlgControlClass::Checkbox, IDC_SHOW_ONLY_SELECTIONS, L"Show only compared selections",
+			  15, 159, 120, 16 },
+			{ DlgControlClass::Button, IDOK, L"OK",
+			  20, 185, 45, 16, /*isDefault*/ true },
+			{ DlgControlClass::Button, IDCANCEL, L"Cancel",
+			  85, 185, 45, 16 },
+		};
+
+		registerDialogTemplate(t);
+	}
+};
+
+AutoRegister _register;
+
+} // namespace
+
+#endif // __APPLE__

--- a/plugins/comparePlus/src/SettingsDlg/ColorCombo.h
+++ b/plugins/comparePlus/src/SettingsDlg/ColorCombo.h
@@ -32,10 +32,14 @@ public :
 	};
 
 	virtual void init(HINSTANCE hInst, HWND hParent, HWND hCombo);
+#ifdef __APPLE__
+	virtual void destroy();
+#else
 	virtual void destroy()
 	{
 		::DestroyWindow(_hSelf);
 	};
+#endif
 
 	void onSelect()
 	{
@@ -45,7 +49,11 @@ public :
 	void setColor(COLORREF color)
 	{
 		_color = color;
+#ifdef __APPLE__
+		drawColor();
+#else
 		::RedrawWindow(_comboBoxInfo.hwndCombo, &_comboBoxInfo.rcItem, NULL, RDW_INVALIDATE | RDW_UPDATENOW);
+#endif
 	};
 
 	COLORREF getColor()

--- a/plugins/comparePlus/src/macOS/ColorComboMac.mm
+++ b/plugins/comparePlus/src/macOS/ColorComboMac.mm
@@ -22,10 +22,10 @@ static CGFloat colorByte(BYTE value)
 
 static NSColor* nsColorFromColorRef(COLORREF color)
 {
-	return [NSColor colorWithCalibratedRed:colorByte(GetRValue(color))
-	                                green:colorByte(GetGValue(color))
-	                                 blue:colorByte(GetBValue(color))
-	                                alpha:1.0];
+	return [NSColor colorWithSRGBRed:colorByte(GetRValue(color))
+	                           green:colorByte(GetGValue(color))
+	                            blue:colorByte(GetBValue(color))
+	                           alpha:1.0];
 }
 
 static BYTE componentToByte(CGFloat value)

--- a/plugins/comparePlus/src/macOS/ColorComboMac.mm
+++ b/plugins/comparePlus/src/macOS/ColorComboMac.mm
@@ -1,0 +1,146 @@
+#ifdef __APPLE__
+
+#import <Cocoa/Cocoa.h>
+
+#include "SettingsDlg/ColorCombo.h"
+#include "handle_registry.h"
+
+namespace {
+
+static NSMutableDictionary<NSNumber*, id>* s_colorWellTargets = nil;
+
+static NSNumber* keyForHwnd(HWND hwnd)
+{
+	return [NSNumber numberWithUnsignedLongLong:
+		static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(hwnd))];
+}
+
+static CGFloat colorByte(BYTE value)
+{
+	return static_cast<CGFloat>(value) / 255.0;
+}
+
+static NSColor* nsColorFromColorRef(COLORREF color)
+{
+	return [NSColor colorWithCalibratedRed:colorByte(GetRValue(color))
+	                                green:colorByte(GetGValue(color))
+	                                 blue:colorByte(GetBValue(color))
+	                                alpha:1.0];
+}
+
+static BYTE componentToByte(CGFloat value)
+{
+	if (value <= 0.0) return 0;
+	if (value >= 1.0) return 255;
+	return static_cast<BYTE>(value * 255.0 + 0.5);
+}
+
+static COLORREF colorRefFromNSColor(NSColor* color)
+{
+	NSColor* rgb = [color colorUsingColorSpace:[NSColorSpace sRGBColorSpace]];
+	if (!rgb)
+		rgb = [color colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
+	if (!rgb)
+		return RGB(0, 0, 0);
+
+	CGFloat r = 0.0;
+	CGFloat g = 0.0;
+	CGFloat b = 0.0;
+	CGFloat a = 0.0;
+	[rgb getRed:&r green:&g blue:&b alpha:&a];
+	return RGB(componentToByte(r), componentToByte(g), componentToByte(b));
+}
+
+static NSColorWell* colorWellForHwnd(HWND hwnd)
+{
+	auto* info = HandleRegistry::getWindowInfo(hwnd);
+	if (!info || !info->nativeView)
+		return nil;
+
+	id view = (__bridge id)info->nativeView;
+	if (![view isKindOfClass:[NSColorWell class]])
+		return nil;
+
+	return (NSColorWell*)view;
+}
+
+} // namespace
+
+@interface ComparePlusColorWellTarget : NSObject
+@property (assign) ColorCombo* colorCombo;
+- (void)colorChanged:(id)sender;
+@end
+
+@implementation ComparePlusColorWellTarget
+- (void)colorChanged:(id)sender
+{
+	if (!self.colorCombo || ![sender isKindOfClass:[NSColorWell class]])
+		return;
+
+	NSColorWell* well = (NSColorWell*)sender;
+	self.colorCombo->setColor(colorRefFromNSColor(well.color));
+}
+@end
+
+void ColorCombo::init(HINSTANCE hInst, HWND hParent, HWND hCombo)
+{
+	Window::init(hInst, hParent);
+	_hSelf = nullptr;
+	_hDefaultComboProc = nullptr;
+
+	_comboBoxInfo = {};
+	_comboBoxInfo.cbSize = sizeof(_comboBoxInfo);
+	_comboBoxInfo.hwndCombo = hCombo;
+
+	::SetWindowLongPtrW(hCombo, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(this));
+
+	NSColorWell* well = colorWellForHwnd(hCombo);
+	if (!well)
+		return;
+
+	well.enabled = YES;
+	well.color = nsColorFromColorRef(_color);
+
+	if (!s_colorWellTargets)
+		s_colorWellTargets = [[NSMutableDictionary alloc] init];
+
+	ComparePlusColorWellTarget* target = [[ComparePlusColorWellTarget alloc] init];
+	target.colorCombo = this;
+	well.target = target;
+	well.action = @selector(colorChanged:);
+	[s_colorWellTargets setObject:target forKey:keyForHwnd(hCombo)];
+	[target release];
+}
+
+void ColorCombo::destroy()
+{
+	HWND hCombo = _comboBoxInfo.hwndCombo;
+	if (hCombo)
+	{
+		NSColorWell* well = colorWellForHwnd(hCombo);
+		if (well)
+		{
+			well.target = nil;
+			well.action = nil;
+		}
+
+		::SetWindowLongPtrW(hCombo, GWLP_USERDATA, 0);
+		[s_colorWellTargets removeObjectForKey:keyForHwnd(hCombo)];
+	}
+
+	_comboBoxInfo = {};
+	_hDefaultComboProc = nullptr;
+	_hSelf = nullptr;
+}
+
+void ColorCombo::drawColor()
+{
+	NSColorWell* well = colorWellForHwnd(_comboBoxInfo.hwndCombo);
+	if (!well)
+		return;
+
+	well.enabled = YES;
+	well.color = nsColorFromColorRef(_color);
+}
+
+#endif // __APPLE__

--- a/plugins/comparePlus/src/macOS/MacCompatStubs.cpp
+++ b/plugins/comparePlus/src/macOS/MacCompatStubs.cpp
@@ -152,16 +152,13 @@ UINT     VisualFiltersDialog::doDialog(UserSettings*)       { return 0; }
 intptr_t VisualFiltersDialog::run_dlgProc(UINT, WPARAM, LPARAM)  { return 0; }
 
 // ---------------------------------------------------------------------------
-// URLCtrl / ColorCombo — members of AboutDialog and SettingsDialog
-// respectively. Anchor their vtables with one out-of-line virtual each.
+// URLCtrl — member of AboutDialog. Anchor its vtable with out-of-line no-ops.
+// ColorCombo has a macOS implementation in ColorComboMac.mm.
 // ---------------------------------------------------------------------------
 
 void URLCtrl::create(HWND, const wchar_t*, COLORREF) {}
 void URLCtrl::create(HWND, int, HWND)                {}
 void URLCtrl::destroy()                              {}
-
-void ColorCombo::init(HINSTANCE, HWND, HWND) {}
-void ColorCombo::drawColor() {}
 
 // ---------------------------------------------------------------------------
 // LibHelpers — git/svn integration. Compare.cpp references these from menu

--- a/plugins/comparePlus/src/macOS/MacCompatStubs.cpp
+++ b/plugins/comparePlus/src/macOS/MacCompatStubs.cpp
@@ -139,17 +139,13 @@ void NavDialog::NavView::reset() {}
 int  NavDialog::NavView::docToBmpLine(intptr_t) const { return 0; }
 
 // ---------------------------------------------------------------------------
-// AboutDialog / CompareOptionsDialog / VisualFiltersDialog / SettingsDialog
-// Each lives only inside a menu-handler function, so the body of doDialog()
-// never runs until a user clicks the corresponding menu item. Returning 0
-// is interpreted upstream as "dialog closed without action".
+// AboutDialog lives only inside a menu-handler function, so the body of
+// doDialog() never runs until a user clicks the corresponding menu item.
+// Returning 0 is interpreted upstream as "dialog closed without action".
 // ---------------------------------------------------------------------------
 
 UINT     AboutDialog::doDialog()                            { return 0; }
 intptr_t AboutDialog::run_dlgProc(UINT, WPARAM, LPARAM)     { return 0; }
-
-UINT     VisualFiltersDialog::doDialog(UserSettings*)       { return 0; }
-intptr_t VisualFiltersDialog::run_dlgProc(UINT, WPARAM, LPARAM)  { return 0; }
 
 // ---------------------------------------------------------------------------
 // URLCtrl — member of AboutDialog. Anchor its vtable with out-of-line no-ops.


### PR DESCRIPTION
## Summary

- Bridge ComparePlus settings color controls to native macOS color wells so selected colors flow back into `UserSettings`.
- Add the macOS hand-translated Visual Filters dialog template and compile the real upstream visual filter dialog.
- Refresh the ComparePlus host inventory documentation for the newly implemented dialog/control surface.

## Validation

- `cmake -G Xcode ..`
- `cmake --build . --target ComparePlus --config Debug`
- `cmake --build . --target MacNotePlusPlus --config Debug`
- `cmake --build . --target npp_macos_compile_test --config Debug`
- `cmake --build . --target npp_build_test --config Debug`
- `./Debug/npp_build_test`
- `git diff --check macos-port...HEAD`
- Runtime smoke test: installed the freshly built `ComparePlus.dylib`, packaged/launched `MacNote++.app`, confirmed the plugin loaded, opened Visual Filters and Settings, verified "Hide all diffs" disables "Hide matches", and confirmed Settings exposes seven color wells.