### PR TITLE
[codex] Implement ComparePlus navigation commands

### DIFF
--- a/docs/compare-plus-host-inventory.md
+++ b/docs/compare-plus-host-inventory.md
@@ -1,7 +1,7 @@
 # ComparePlus Host-Surface Inventory
 
-Generated as part of Phase 0, Issue #100. Updated after ComparePlus colors and
-Visual Filters work.
+Generated as part of Phase 0, Issue #100. Updated after ComparePlus colors,
+Visual Filters, and navigation command work.
 
 Status note: "accepted no-op" means the macOS host consumes the message so
 ComparePlus can continue, but there is no equivalent visible macOS UI surface yet.
@@ -49,6 +49,20 @@ ComparePlus can continue, but there is no equivalent visible macOS UI surface ye
 | `NPPN_GLOBALMODIFIED` | Compare.cpp | **NOT EMITTED** |
 | `NPPN_DARKMODECHANGED` | Compare.cpp | **NOT EMITTED** |
 | `NPPN_WORDSTYLESUPDATED` | Compare.cpp | **NOT EMITTED** |
+
+## Command Alias / Navigation Surface
+
+| Command | Used In | Host Status |
+|---------|---------|-------------|
+| `IDM_VIEW_GOTO_ANOTHER_VIEW` (`10001`) | NppHelpers.cpp (moveFileToOtherView) | **IMPLEMENTED** (aliases to `doMoveToOtherView`) |
+| `IDM_VIEW_CLONE_TO_ANOTHER_VIEW` (`10002`) | Plugin-compatible clone commands | **IMPLEMENTED** (aliases to `doCloneToOtherView`) |
+| `IDM_VIEW_SYNSCROLLV` (`44035`) | Compare.cpp (NppState compare/normal mode) | **IMPLEMENTED** (maps to host synchronized scrolling state) |
+| `IDM_VIEW_SYNSCROLLH` (`44036`) | Compare.cpp (NppState compare/normal mode) | **IMPLEMENTED** (accepted no-op; macOS has no separate horizontal sync surface) |
+| `IDM_VIEW_SWITCHTO_OTHER_VIEW` (`44072`) | Compare.cpp (split-view compare setup) | **IMPLEMENTED** (focuses the other split editor without moving the document) |
+| `IDM_VIEW_TAB_NEXT` (`44095`) | Compare.cpp (single-view compare setup) | **IMPLEMENTED** (activates next tab in active view) |
+| `IDM_VIEW_TAB_PREV` (`44096`) | Compare.cpp (single-view compare setup) | **IMPLEMENTED** (activates previous tab in active view) |
+| `IDM_VIEW_TAB_MOVEBACKWARD` (`44099`) | Compare.cpp (compare setup tab ordering) | **IMPLEMENTED** (moves active tab one slot backward) |
+| `IDM_EDIT_SETREADONLY` (`42028`) | Compare.cpp (temp compare buffers) | **IMPLEMENTED** (toggles Scintilla read-only state for active buffer) |
 
 ## Dialog / Control Surface
 

--- a/docs/compare-plus-host-inventory.md
+++ b/docs/compare-plus-host-inventory.md
@@ -1,7 +1,7 @@
 # ComparePlus Host-Surface Inventory
 
 Generated as part of Phase 0, Issue #100. Updated after ComparePlus colors,
-Visual Filters, and navigation command work.
+Visual Filters, and navigation commands work.
 
 Status note: "accepted no-op" means the macOS host consumes the message so
 ComparePlus can continue, but there is no equivalent visible macOS UI surface yet.

--- a/macos/platform/document_data.h
+++ b/macos/platform/document_data.h
@@ -52,6 +52,7 @@ struct DocumentData
 	intptr_t firstVisibleLine = 0;
 	bool modified = false;
 	bool savePointValid = true; // false when Scintilla's save point doesn't reflect real saved state
+	bool readOnly = false;
 	int languageIndex = 2; // Default: C++
 	std::vector<int> bookmarkedLines; // Persisted across tab switches
 	int encoding = ENC_UTF8;

--- a/macos/platform/document_manager.mm
+++ b/macos/platform/document_manager.mm
@@ -54,6 +54,7 @@ void saveViewState(void* sci, std::vector<DocumentData>& docs, int tabIdx)
 	doc.anchorPos = ScintillaBridge_sendMessage(sci, SCI_GETANCHOR, 0, 0);
 	doc.firstVisibleLine = ScintillaBridge_sendMessage(sci, SCI_GETFIRSTVISIBLELINE, 0, 0);
 	doc.zoomLevel = static_cast<int>(ScintillaBridge_sendMessage(sci, SCI_GETZOOM, 0, 0));
+	doc.readOnly = ScintillaBridge_sendMessage(sci, SCI_GETREADONLY, 0, 0) != 0;
 	if (doc.savePointValid)
 		doc.modified = ScintillaBridge_sendMessage(sci, SCI_GETMODIFY, 0, 0) != 0;
 
@@ -82,6 +83,7 @@ void restoreViewToScintilla(void* sci, std::vector<DocumentData>& docs, int tabI
 
 	auto& doc = docs[tabIndex];
 	ctx().suppressSavePointNotifications = true;
+	ScintillaBridge_sendMessage(sci, SCI_SETREADONLY, 0, 0);
 	ScintillaBridge_sendMessage(sci, SCI_SETTEXT, 0, (intptr_t)doc.content.c_str());
 	if (!doc.modified)
 		ScintillaBridge_sendMessage(sci, SCI_SETSAVEPOINT, 0, 0);
@@ -98,6 +100,7 @@ void restoreViewToScintilla(void* sci, std::vector<DocumentData>& docs, int tabI
 		ScintillaBridge_sendMessage(sci, SCI_MARKERADD, bkLine, BOOKMARK_MARKER);
 
 	ScintillaBridge_sendMessage(sci, SCI_SETZOOM, doc.zoomLevel, 0);
+	ScintillaBridge_sendMessage(sci, SCI_SETREADONLY, doc.readOnly ? 1 : 0, 0);
 
 	refreshLineNumberMargin(sci);
 }

--- a/macos/platform/document_manager.mm
+++ b/macos/platform/document_manager.mm
@@ -206,6 +206,7 @@ int addNewTabToView(int viewIndex, const std::wstring& title, const std::string&
 	activeTab = newIndex;
 
 	ctx().suppressSavePointNotifications = true;
+	ScintillaBridge_sendMessage(sci, SCI_SETREADONLY, 0, 0);
 	ScintillaBridge_sendMessage(sci, SCI_SETTEXT, 0, (intptr_t)content.c_str());
 	ScintillaBridge_sendMessage(sci, SCI_SETSAVEPOINT, 0, 0);
 	ScintillaBridge_sendMessage(sci, SCI_GOTOPOS, 0, 0);

--- a/macos/platform/npp_constants.h
+++ b/macos/platform/npp_constants.h
@@ -71,6 +71,10 @@ constexpr double NPP_STATUS_BAR_HEIGHT = 22.0;
 #define IDM_EDIT_INSERT_DATETIME_LONG  42047
 #define IDM_EDIT_AUTOCLOSE_BRACKETS  42048
 
+// Upstream Notepad++ command IDs used by vendored plugins.
+// Keep these numeric values aligned with plugins/*/src/NppAPI/menuCmdID.h.
+#define IDM_EDIT_SETREADONLY          42028
+
 // Case conversions (Sprint P2)
 #define IDM_EDIT_SENTENCECASE    42100
 #define IDM_EDIT_INVERTCASE      42101
@@ -117,6 +121,16 @@ constexpr double NPP_STATUS_BAR_HEIGHT = 22.0;
 #define IDM_VIEW_FILEBROWSER         42088
 #define IDM_VIEW_FILESWITCHER        42089
 #define IDM_FILE_OPENFOLDER          42094
+
+// Upstream Notepad++ view command IDs sent by plugins through NPPM_MENUCOMMAND.
+#define IDM_VIEW_GOTO_ANOTHER_VIEW     10001
+#define IDM_VIEW_CLONE_TO_ANOTHER_VIEW 10002
+#define IDM_VIEW_SYNSCROLLV            44035
+#define IDM_VIEW_SYNSCROLLH            44036
+#define IDM_VIEW_SWITCHTO_OTHER_VIEW   44072
+#define IDM_VIEW_TAB_NEXT              44095
+#define IDM_VIEW_TAB_PREV              44096
+#define IDM_VIEW_TAB_MOVEBACKWARD      44099
 
 // Tab context menu command IDs
 #define IDM_TAB_CLOSE            42200
@@ -240,6 +254,7 @@ enum {
 	SCI_SCROLLCARET = 2169,
 	SCI_GETSELECTIONSTART = 2143,
 	SCI_GETSELECTIONEND = 2145,
+	SCI_GETREADONLY = 2140,
 	SCI_SETREADONLY = 2171,
 	SCI_SETTARGETSTART = 2190,
 	SCI_GETTARGETSTART = 2191,

--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -563,6 +563,7 @@ void doMoveToOtherView()
 		dstDocs[dstIdx].firstVisibleLine = docCopy.firstVisibleLine;
 		dstDocs[dstIdx].bookmarkedLines = docCopy.bookmarkedLines;
 		dstDocs[dstIdx].zoomLevel = docCopy.zoomLevel;
+		dstDocs[dstIdx].readOnly = docCopy.readOnly;
 	}
 
 	closeTabFromView(srcView, srcTab);
@@ -598,5 +599,6 @@ void doCloneToOtherView()
 		dstDocs[dstIdx].firstVisibleLine = docCopy.firstVisibleLine;
 		dstDocs[dstIdx].bookmarkedLines = docCopy.bookmarkedLines;
 		dstDocs[dstIdx].zoomLevel = docCopy.zoomLevel;
+		dstDocs[dstIdx].readOnly = docCopy.readOnly;
 	}
 }

--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -564,6 +564,9 @@ void doMoveToOtherView()
 		dstDocs[dstIdx].bookmarkedLines = docCopy.bookmarkedLines;
 		dstDocs[dstIdx].zoomLevel = docCopy.zoomLevel;
 		dstDocs[dstIdx].readOnly = docCopy.readOnly;
+		void* dstSci = (dstView == 0) ? ctx().scintillaView : ctx().scintillaView2;
+		if (dstSci)
+			ScintillaBridge_sendMessage(dstSci, SCI_SETREADONLY, docCopy.readOnly ? 1 : 0, 0);
 	}
 
 	closeTabFromView(srcView, srcTab);
@@ -600,5 +603,8 @@ void doCloneToOtherView()
 		dstDocs[dstIdx].bookmarkedLines = docCopy.bookmarkedLines;
 		dstDocs[dstIdx].zoomLevel = docCopy.zoomLevel;
 		dstDocs[dstIdx].readOnly = docCopy.readOnly;
+		void* dstSci = (dstView == 0) ? ctx().scintillaView : ctx().scintillaView2;
+		if (dstSci)
+			ScintillaBridge_sendMessage(dstSci, SCI_SETREADONLY, docCopy.readOnly ? 1 : 0, 0);
 	}
 }

--- a/macos/platform/wndproc.mm
+++ b/macos/platform/wndproc.mm
@@ -43,6 +43,97 @@
 #include "nppm_handler.h"
 #include "Notepad_plus_msgs.h"
 
+namespace {
+
+void updateSynchronizeScrollingMenu(HWND hWnd)
+{
+	HMENU hMenu = GetMenu(hWnd);
+	if (hMenu)
+	{
+		CheckMenuItem(hMenu, IDM_VIEW_SYNCHRONIZE_SCROLLING,
+		              MF_BYCOMMAND | (ctx().syncScrolling ? MF_CHECKED : MF_UNCHECKED));
+	}
+}
+
+void togglePluginVerticalSync(HWND hWnd)
+{
+	setSyncScrollingEnabled(!ctx().syncScrolling);
+	updateSynchronizeScrollingMenu(hWnd);
+}
+
+void focusEditorView(int viewIndex)
+{
+	if (viewIndex < 0 || viewIndex > 1)
+		return;
+	if (viewIndex == 1 && !ctx().isSplit)
+		return;
+
+	void* sci = (viewIndex == 0) ? ctx().scintillaView : ctx().scintillaView2;
+	if (!sci)
+		return;
+
+	ScintillaBridge_focus(sci);
+	ctx().activeView = viewIndex;
+	bindDocumentMapToActiveView();
+	bindFunctionListToActiveView();
+	bindFileSwitcherToActiveView();
+	if (isIncrementalSearchVisible())
+		updateIncrementalSearchTarget();
+	updateStatusBar();
+	updateWindowDocumentEdited();
+}
+
+void focusOtherEditorView()
+{
+	if (!ctx().isSplit)
+		return;
+	focusEditorView(ctx().activeView == 0 ? 1 : 0);
+}
+
+void switchActiveTabByOffset(int offset)
+{
+	auto& docs = ctx().activeDocuments();
+	int& activeTab = ctx().activeTabIndex();
+	if (docs.size() < 2 || activeTab < 0)
+		return;
+
+	const int count = static_cast<int>(docs.size());
+	int tabIndex = (activeTab + offset) % count;
+	if (tabIndex < 0)
+		tabIndex += count;
+	switchToTabInView(ctx().activeView, tabIndex);
+}
+
+void moveActiveTabBackward()
+{
+	int& activeTab = ctx().activeTabIndex();
+	if (activeTab <= 0)
+		return;
+
+	reorderTabInView(ctx().activeView, activeTab, activeTab - 1);
+	HWND tabHwnd = ctx().activeTabHwnd();
+	if (tabHwnd)
+		SendMessageW(tabHwnd, TCM_SETCURSEL, activeTab, 0);
+}
+
+void toggleActiveReadOnly()
+{
+	void* sci = ctx().activeScintillaView();
+	if (!sci)
+		return;
+
+	bool readOnly = ScintillaBridge_sendMessage(sci, SCI_GETREADONLY, 0, 0) != 0;
+	bool newReadOnly = !readOnly;
+	ScintillaBridge_sendMessage(sci, SCI_SETREADONLY, newReadOnly ? 1 : 0, 0);
+
+	auto& docs = ctx().activeDocuments();
+	int tabIdx = ctx().activeTabIndex();
+	if (tabIdx >= 0 && tabIdx < static_cast<int>(docs.size()))
+		docs[tabIdx].readOnly = newReadOnly;
+}
+
+} // namespace
+
 LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	switch (msg)
@@ -200,6 +291,9 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 					if (sci) ScintillaBridge_sendMessage(sci, SCI_SELECTALL, 0, 0);
 					return 0;
 				}
+				case IDM_EDIT_SETREADONLY:
+					toggleActiveReadOnly();
+					return 0;
 
 				case IDM_VIEW_WORDWRAP:
 				{
@@ -523,12 +617,14 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 				if (!ctx().isSplit)
 					return 0;
 				setSyncScrollingEnabled(!ctx().syncScrolling);
-				HMENU hMenu = GetMenu(hWnd);
-				if (hMenu)
-					CheckMenuItem(hMenu, IDM_VIEW_SYNCHRONIZE_SCROLLING,
-					              MF_BYCOMMAND | (ctx().syncScrolling ? MF_CHECKED : MF_UNCHECKED));
+				updateSynchronizeScrollingMenu(hWnd);
 				return 0;
 			}
+			case IDM_VIEW_SYNSCROLLV:
+				togglePluginVerticalSync(hWnd);
+				return 0;
+			case IDM_VIEW_SYNSCROLLH:
+				return 0;
 			case IDM_VIEW_DOCUMENTMAP:
 			{
 				setDocumentMapEnabled(!ctx().documentMapEnabled);
@@ -611,12 +707,24 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 				case IDM_VIEW_UNSPLIT:
 					doUnsplit();
 					return 0;
+				case IDM_VIEW_SWITCHTO_OTHER_VIEW:
+					focusOtherEditorView();
+					return 0;
+				case IDM_VIEW_TAB_PREV:
+					switchActiveTabByOffset(-1);
+					return 0;
+				case IDM_VIEW_TAB_NEXT:
+					switchActiveTabByOffset(1);
+					return 0;
+				case IDM_VIEW_TAB_MOVEBACKWARD:
+					moveActiveTabBackward();
+					return 0;
 				case IDM_VIEW_MOVETOOTHER:
-				case 10001: // IDM_VIEW_GOTO_ANOTHER_VIEW — used by ComparePlus & other plugins
+				case IDM_VIEW_GOTO_ANOTHER_VIEW: // used by ComparePlus & other plugins
 					doMoveToOtherView();
 					return 0;
 				case IDM_VIEW_CLONETOOTHER:
-				case 10002: // IDM_VIEW_CLONE_TO_ANOTHER_VIEW — used by plugins
+				case IDM_VIEW_CLONE_TO_ANOTHER_VIEW: // used by plugins
 					doCloneToOtherView();
 					return 0;
 

--- a/macos/platform/wndproc.mm
+++ b/macos/platform/wndproc.mm
@@ -57,6 +57,9 @@ void updateSynchronizeScrollingMenu(HWND hWnd)
 
 void togglePluginVerticalSync(HWND hWnd)
 {
+	if (!ctx().isSplit)
+		return;
+
 	setSyncScrollingEnabled(!ctx().syncScrolling);
 	updateSynchronizeScrollingMenu(hWnd);
 }

--- a/macos/shim/src/win32_menu_impl.mm
+++ b/macos/shim/src/win32_menu_impl.mm
@@ -5,6 +5,7 @@
 #include "windows.h"
 #include "commdlg.h"
 #include "handle_registry.h"
+#include "npp_constants.h"
 #include "win32_string_helpers.h"
 
 #include <vector>
@@ -300,6 +301,27 @@ static NSMenuItem* findMenuItemRecursive(NSMenu* menu, UINT cmdId)
 		}
 	}
 	return nil;
+}
+
+static UINT menuCommandAlias(UINT cmdId)
+{
+	switch (cmdId)
+	{
+		case IDM_VIEW_SYNSCROLLV:
+			return IDM_VIEW_SYNCHRONIZE_SCROLLING;
+		default:
+			return cmdId;
+	}
+}
+
+static bool syntheticMenuState(UINT cmdId, UINT& state)
+{
+	if (cmdId == IDM_VIEW_SYNSCROLLH)
+	{
+		state = 0;
+		return true;
+	}
+	return false;
 }
 
 // ============================================================
@@ -754,6 +776,13 @@ BOOL DeleteMenu(HMENU hMenu, UINT uPosition, UINT uFlags)
 
 BOOL EnableMenuItem(HMENU hMenu, UINT uIDEnableItem, UINT uEnable)
 {
+	if (!(uEnable & MF_BYPOSITION))
+	{
+		if (uIDEnableItem == IDM_VIEW_SYNSCROLLH)
+			return MF_ENABLED;
+		uIDEnableItem = menuCommandAlias(uIDEnableItem);
+	}
+
 	NSMenu* menu = resolveMenu(hMenu);
 	if (!menu) return static_cast<BOOL>(-1);
 
@@ -775,6 +804,13 @@ BOOL EnableMenuItem(HMENU hMenu, UINT uIDEnableItem, UINT uEnable)
 
 BOOL CheckMenuItem(HMENU hMenu, UINT uIDCheckItem, UINT uCheck)
 {
+	if (!(uCheck & MF_BYPOSITION))
+	{
+		if (uIDCheckItem == IDM_VIEW_SYNSCROLLH)
+			return MF_UNCHECKED;
+		uIDCheckItem = menuCommandAlias(uIDCheckItem);
+	}
+
 	NSMenu* menu = resolveMenu(hMenu);
 	if (!menu) return static_cast<BOOL>(-1);
 
@@ -900,6 +936,14 @@ int GetMenuStringW(HMENU hMenu, UINT uIDItem, LPWSTR lpString, int cchMax, UINT 
 
 UINT GetMenuState(HMENU hMenu, UINT uId, UINT uFlags)
 {
+	if (!(uFlags & MF_BYPOSITION))
+	{
+		UINT state = 0;
+		if (syntheticMenuState(uId, state))
+			return state;
+		uId = menuCommandAlias(uId);
+	}
+
 	NSMenu* menu = resolveMenu(hMenu);
 	if (!menu) return static_cast<UINT>(-1);
 


### PR DESCRIPTION
## Summary

Implements the ComparePlus navigation command aliases from the reviewed plan so the plugin can drive the macOS host through NPPM_MENUCOMMAND for split focus, tab navigation, tab reordering, synchronized scrolling, and temporary read-only buffers.

## Changes

- Added upstream Notepad++ command IDs used by ComparePlus to the macOS constants surface.
- Routed ComparePlus navigation commands in the main window command dispatcher.
- Added menu-state aliasing for vertical synchronized scrolling and accepted horizontal sync as a no-op on macOS.
- Persisted Scintilla read-only state in document data across tab/view restores.
- Updated the ComparePlus host-surface inventory documentation.

## Validation

- cmake --build . --target MacNotePlusPlus
- cmake --build . --target ComparePlus
- cmake --build . --target install_compare_plus
- git -c core.whitespace=cr-at-eol diff --check