### PR TITLE
Honor system dark mode in ComparePlus diff colors

### DIFF
--- a/docs/compare-plus-host-inventory.md
+++ b/docs/compare-plus-host-inventory.md
@@ -47,8 +47,8 @@ ComparePlus can continue, but there is no equivalent visible macOS UI surface ye
 | `NPPM_GETCURRENTCMDLINE` | Compare.cpp (checkCmdLine) | **IMPLEMENTED** (nppm_handler.mm, returns empty command line) |
 | `NPPM_GETCURRENTNATIVELANGENCODING` | NppHelpers.h | **IMPLEMENTED** (nppm_handler.mm, returns UTF-8) |
 | `NPPN_GLOBALMODIFIED` | Compare.cpp | **NOT EMITTED** |
-| `NPPN_DARKMODECHANGED` | Compare.cpp | **NOT EMITTED** |
-| `NPPN_WORDSTYLESUPDATED` | Compare.cpp | **NOT EMITTED** |
+| `NPPN_DARKMODECHANGED` | Compare.cpp | **EMITTED** (app_delegate.mm `appearanceChanged:`) |
+| `NPPN_WORDSTYLESUPDATED` | Compare.cpp | **NOT EMITTED** (no host style-configurator UI yet to drive it; ComparePlus handles it identically to `NPPN_DARKMODECHANGED`, so dark-mode toggles already refresh its colors) |
 
 ## Command Alias / Navigation Surface
 
@@ -90,4 +90,5 @@ SETLINENUMBERWIDTHMODE, GETBOOKMARKID, GETNATIVELANGFILENAME, GETCURRENTCMDLINE,
 GETCURRENTNATIVELANGENCODING
 
 NPPN: NPPN_READY, NPPN_SHUTDOWN, NPPN_LANGCHANGED, NPPN_FILEBEFORECLOSE, NPPN_FILESAVED,
-NPPN_FILEOPENED, NPPN_FILECLOSED, NPPN_BUFFERACTIVATED, NPPN_BEFORESHUTDOWN, NPPN_TBMODIFICATION
+NPPN_FILEOPENED, NPPN_FILECLOSED, NPPN_BUFFERACTIVATED, NPPN_BEFORESHUTDOWN, NPPN_TBMODIFICATION,
+NPPN_DARKMODECHANGED

--- a/macos/platform/app_delegate.mm
+++ b/macos/platform/app_delegate.mm
@@ -626,6 +626,11 @@ static void setDockIconFromLogo()
 			ScintillaBridge_sendMessage(ctx().scintillaView, SCI_COLOURISE, 0, -1);
 		if (ctx().isSplit && ctx().scintillaView2)
 			ScintillaBridge_sendMessage(ctx().scintillaView2, SCI_COLOURISE, 0, -1);
+
+		SCNotification darkNotif{};
+		darkNotif.nmhdr.hwndFrom = ctx().mainHwnd;
+		darkNotif.nmhdr.code = NPPN_DARKMODECHANGED;
+		pluginManager().notify(&darkNotif);
 	});
 }
 

--- a/macos/platform/appearance.h
+++ b/macos/platform/appearance.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+bool isAppDarkMode();
 void applyFoldMarkerColorsToView(void* sci, bool isDark);
 void applyAppearanceToView(void* sci, int langIdx, bool isDark);
 void applyAppearance();

--- a/macos/platform/appearance.mm
+++ b/macos/platform/appearance.mm
@@ -13,6 +13,13 @@
 #include "smart_highlight.h"
 #include "change_history.h"
 
+bool isAppDarkMode()
+{
+	NSAppearanceName appearanceName = [NSApp.effectiveAppearance
+		bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
+	return [appearanceName isEqualToString:NSAppearanceNameDarkAqua];
+}
+
 void applyFoldMarkerColorsToView(void* sci, bool isDark)
 {
 	if (!sci) return;
@@ -78,9 +85,7 @@ void applyAppearance()
 {
 	if (!ctx().scintillaView) return;
 
-	NSAppearanceName appearanceName = [NSApp.effectiveAppearance
-		bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
-	bool isDark = [appearanceName isEqualToString:NSAppearanceNameDarkAqua];
+	bool isDark = isAppDarkMode();
 
 	int langIdx = 0;
 	if (ctx().activeTab >= 0 && ctx().activeTab < static_cast<int>(ctx().documents.size()))

--- a/macos/platform/nppm_handler.mm
+++ b/macos/platform/nppm_handler.mm
@@ -236,9 +236,10 @@ LRESULT handleNppmMessage(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
 		case NPPM_GETEDITORDEFAULTBACKGROUNDCOLOR:
 			// Returned as 0x00BBGGRR (Win32 COLORREF). Must match the
-			// Scintilla default-style background actually painted (see
-			// appearance.mm:33), or plugins derive marker shades against
-			// the wrong base — ComparePlus's "blank" marker in particular.
+			// background Scintilla paints for style 32 in
+			// applyAppearanceToView (SCI_STYLESETBACK), or plugins derive
+			// marker shades against the wrong base — ComparePlus's "blank"
+			// marker in particular.
 			return isAppDarkMode() ? 0x001E1E1E : 0x00FFFFFF;
 
 		case NPPM_GETEDITORDEFAULTFOREGROUNDCOLOR:

--- a/macos/platform/nppm_handler.mm
+++ b/macos/platform/nppm_handler.mm
@@ -12,6 +12,7 @@
 #include "menu_builder.h"
 #include "string_utils.h"
 #include "compare_plus_visibility.h"
+#include "appearance.h"
 #include "Notepad_plus_msgs.h"
 #include "Scintilla.h"
 
@@ -234,21 +235,20 @@ LRESULT handleNppmMessage(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 		}
 
 		case NPPM_GETEDITORDEFAULTBACKGROUNDCOLOR:
-			// Returned as 0x00BBGGRR (Win32 COLORREF). White matches our
-			// default light-mode Scintilla background. Plugins derive
-			// dependent colors (ComparePlus's "blank" marker shade) from
-			// this; returning 0 / black made the whole diff wash read as
-			// near-black, hiding the actual marker colors.
-			// TODO Phase 5: dark-mode branch.
-			return 0x00FFFFFF;
+			// Returned as 0x00BBGGRR (Win32 COLORREF). Must match the
+			// Scintilla default-style background actually painted (see
+			// appearance.mm:33), or plugins derive marker shades against
+			// the wrong base — ComparePlus's "blank" marker in particular.
+			return isAppDarkMode() ? 0x001E1E1E : 0x00FFFFFF;
 
 		case NPPM_GETEDITORDEFAULTFOREGROUNDCOLOR:
-			return 0x00000000;
+			return isAppDarkMode() ? 0x00D4D4D4 : 0x00000000;
 
 		case NPPM_ISDARKMODEENABLED:
-			// Until we wire up real dark-mode detection, report light mode.
-			// ComparePlus picks its color palette based on this.
-			return FALSE;
+			// ComparePlus picks its color palette based on this; on TRUE
+			// it switches to Settings.useDarkColors() so diff backgrounds
+			// stay legible against a dark editor background.
+			return isAppDarkMode() ? TRUE : FALSE;
 
 		case NPPM_ALLOCATEMARKER:
 		{


### PR DESCRIPTION
## Summary

ComparePlus diff highlights stayed in their bright light-mode palette even when macOS was set to dark mode, washing out the underlying text. Three plugin-host messages were hardcoded to "light", and `NPPN_DARKMODECHANGED` was never emitted, so the plugin couldn't switch palettes.

- `nppm_handler.mm` — `NPPM_ISDARKMODEENABLED`, `NPPM_GETEDITORDEFAULTBACKGROUNDCOLOR`, `NPPM_GETEDITORDEFAULTFOREGROUNDCOLOR` now report real state. The bg/fg values (`0x1E1E1E` / `0xD4D4D4`) match what Scintilla actually paints in `appearance.mm`, so plugins that derive marker shades from these (ComparePlus's "blank" marker, for instance) draw against the right base.
- `app_delegate.mm` — emit `NPPN_DARKMODECHANGED` from `appearanceChanged:` after the host has re-applied its own appearance and re-colorised the editors. Safe to fire before any plugin loads (notify is a no-op on an empty plugin list).
- `appearance.{h,mm}` — extracted `isAppDarkMode()` from the inline check in `applyAppearance()`; reused in `nppm_handler.mm`.
- `docs/compare-plus-host-inventory.md` — `NPPN_DARKMODECHANGED` marked emitted. `NPPN_WORDSTYLESUPDATED` still not fired (no host style-configurator UI to drive it; ComparePlus's handler treats it identically to `NPPN_DARKMODECHANGED`, so dark-mode toggles already refresh its colors).

## Test plan

- [ ] Light mode: open two files with diffs, `Set as First`, `Compare`. Diff highlights match the existing light palette (yellows/greens/oranges).
- [ ] Dark mode: same scenario. Diff highlights use the muted dark palette and the diff text stays readable.
- [ ] With a compare active, toggle System Settings → Appearance between Light and Dark. ComparePlus colors should swap immediately without re-running compare.
- [ ] Toggle appearance with no plugins loaded / before plugins finish loading — no crash, no log noise.
- [ ] Other in-tree plugins (HelloPaperWasp) still load and behave the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)