### PR TITLE
[codex] Keep followed files current while inactive

### DIFF
--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -378,6 +378,8 @@ add_executable(PaperWasp
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/file_path_ops.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/tab_bar_view.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/tab_context_menu.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/age_bar_view.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform/follow_mode.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/smart_highlight.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/incremental_search.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform/find_in_files.mm"

--- a/macos/platform/age_bar_view.h
+++ b/macos/platform/age_bar_view.h
@@ -1,0 +1,36 @@
+// age_bar_view.h — Follow Mode UI: per-line age heatmap strip and editor container.
+// Part of the PaperWasp macOS app.
+
+#pragma once
+
+#import <Cocoa/Cocoa.h>
+
+@class NppAgeBarView;
+
+// NSView subclass that hosts the Scintilla view and (when follow mode is active)
+// the age bar strip on its right edge. Overrides setFrameSize: to keep both
+// subviews positioned correctly when the container is resized by the panel layout.
+@interface NppEditorContainer : NSView
+@property (nonatomic, assign) int viewIndex; // 0 = main, 1 = sub-split
+@property (nonatomic, weak) NSView* scintillaChild; // ScintillaView or wrapping container
+@property (nonatomic, strong, readonly) NppAgeBarView* ageBar;
+@property (nonatomic, assign) BOOL ageBarVisible;
+- (void)applyLayout;
+@end
+
+// Custom NSView that paints a minimap-style age heatmap for the followed document
+// bound to the given editor view (0 = main, 1 = sub-split).
+@interface NppAgeBarView : NSView
+@property (nonatomic, assign) int viewIndex;
+@end
+
+// Public bar width (used by NppEditorContainer to inset Scintilla)
+extern const CGFloat kNppAgeBarWidth;
+
+// Invalidate all visible age bars (call after settings change so colors refresh
+// without waiting for the next timer tick).
+void invalidateAllAgeBars(void);
+
+// Invalidate the age bar bound to a specific view index (0 main, 1 sub-split).
+// Called from the Scintilla scroll/update handler so the bar tracks scrolling.
+void invalidateAgeBarForView(int viewIndex);

--- a/macos/platform/age_bar_view.mm
+++ b/macos/platform/age_bar_view.mm
@@ -1,0 +1,342 @@
+// age_bar_view.mm — Follow Mode UI: per-line age heatmap strip and editor container.
+// Part of the PaperWasp macOS app.
+
+#import "age_bar_view.h"
+#include "app_state.h"
+#include "settings_manager.h"
+#include "scintilla_bridge.h"
+#include "npp_constants.h"
+
+#include <mach/mach_time.h>
+#include <algorithm>
+#include <cmath>
+
+const CGFloat kNppAgeBarWidth = 14.0;
+
+#ifndef SCI_POINTYFROMPOSITION
+#define SCI_POINTYFROMPOSITION 2165
+#endif
+#ifndef SCI_TEXTHEIGHT
+#define SCI_TEXTHEIGHT 2279
+#endif
+
+// ---------------------------------------------------------------------------
+// Timer registry — one shared 4 Hz timer drives all visible age bars so colors
+// fade smoothly without per-keystroke invalidation.
+// ---------------------------------------------------------------------------
+
+static NSMutableArray<NppAgeBarView*>* sLiveBars = nil;
+static NSTimer* sTickTimer = nil;
+
+static void ensureBarRegistry()
+{
+	if (!sLiveBars)
+		sLiveBars = [NSMutableArray array];
+}
+
+static void onTick()
+{
+	if (!sLiveBars) return;
+	for (NppAgeBarView* bar in sLiveBars)
+	{
+		if (!bar.hidden && bar.window)
+			[bar setNeedsDisplay:YES];
+	}
+}
+
+static void startTimerIfNeeded()
+{
+	if (sTickTimer) return;
+	sTickTimer = [NSTimer scheduledTimerWithTimeInterval:0.25
+	                                              repeats:YES
+	                                                block:^(NSTimer* /*t*/) { onTick(); }];
+}
+
+static void stopTimerIfIdle()
+{
+	if (!sTickTimer) return;
+	BOOL anyVisible = NO;
+	for (NppAgeBarView* bar in sLiveBars)
+	{
+		if (!bar.hidden && bar.window) { anyVisible = YES; break; }
+	}
+	if (!anyVisible)
+	{
+		[sTickTimer invalidate];
+		sTickTimer = nil;
+	}
+}
+
+void invalidateAllAgeBars(void)
+{
+	if (!sLiveBars) return;
+	for (NppAgeBarView* bar in sLiveBars)
+		[bar setNeedsDisplay:YES];
+}
+
+void invalidateAgeBarForView(int viewIndex)
+{
+	if (!sLiveBars) return;
+	for (NppAgeBarView* bar in sLiveBars)
+	{
+		if (bar.viewIndex == viewIndex && !bar.hidden)
+			[bar setNeedsDisplay:YES];
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static uint64_t currentMillis()
+{
+	static mach_timebase_info_data_t tb = {0, 0};
+	if (tb.denom == 0)
+		mach_timebase_info(&tb);
+	uint64_t now = mach_absolute_time();
+	// to nanoseconds, then ms
+	return (now * tb.numer / tb.denom) / 1000000ULL;
+}
+
+static NSColor* colorFromARGB(uint32_t argb)
+{
+	CGFloat a = ((argb >> 24) & 0xFF) / 255.0;
+	CGFloat r = ((argb >> 16) & 0xFF) / 255.0;
+	CGFloat g = ((argb >>  8) & 0xFF) / 255.0;
+	CGFloat b = ( argb        & 0xFF) / 255.0;
+	return [NSColor colorWithCalibratedRed:r green:g blue:b alpha:a];
+}
+
+static NSColor* lerpColor(NSColor* a, NSColor* b, CGFloat t)
+{
+	if (t <= 0) return a;
+	if (t >= 1) return b;
+	CGFloat ar, ag, ab, aa;
+	CGFloat br, bg, bb, ba;
+	[a getRed:&ar green:&ag blue:&ab alpha:&aa];
+	[b getRed:&br green:&bg blue:&bb alpha:&ba];
+	return [NSColor colorWithCalibratedRed:ar + (br - ar) * t
+	                                 green:ag + (bg - ag) * t
+	                                  blue:ab + (bb - ab) * t
+	                                 alpha:aa + (ba - aa) * t];
+}
+
+// Map an age in milliseconds to a heatmap color using the 3 stops + 3 thresholds.
+// <newSec → newColor; between new and medium → lerp(new, medium); between medium
+// and old → lerp(medium, old); >oldSec → oldColor.
+static NSColor* colorForAge(uint64_t ageMs)
+{
+	int tNew = ctx().followThresholdNewSec;
+	int tMid = ctx().followThresholdMediumSec;
+	int tOld = ctx().followThresholdOldSec;
+	if (tNew < 0) tNew = 0;
+	if (tMid < tNew + 1) tMid = tNew + 1;
+	if (tOld < tMid + 1) tOld = tMid + 1;
+
+	NSColor* cNew = colorFromARGB(ctx().followColorNew);
+	NSColor* cMid = colorFromARGB(ctx().followColorMedium);
+	NSColor* cOld = colorFromARGB(ctx().followColorOld);
+
+	double sec = (double)ageMs / 1000.0;
+	if (sec <= tNew) return cNew;
+	if (sec >= tOld) return cOld;
+	if (sec < tMid)
+	{
+		CGFloat t = (sec - tNew) / (tMid - tNew);
+		return lerpColor(cNew, cMid, t);
+	}
+	CGFloat t = (sec - tMid) / (tOld - tMid);
+	return lerpColor(cMid, cOld, t);
+}
+
+// Resolve the active document for a given view index, or nullptr if no tab is open.
+static DocumentData* activeDocForView(int viewIndex)
+{
+	auto& docs = (viewIndex == 0) ? ctx().documents : ctx().documents2;
+	int idx = (viewIndex == 0) ? ctx().activeTab : ctx().activeTab2;
+	if (idx < 0 || idx >= (int)docs.size()) return nullptr;
+	return &docs[idx];
+}
+
+// ---------------------------------------------------------------------------
+// NppAgeBarView
+// ---------------------------------------------------------------------------
+
+@implementation NppAgeBarView
+
+- (instancetype)initWithFrame:(NSRect)frameRect
+{
+	self = [super initWithFrame:frameRect];
+	if (self)
+	{
+		ensureBarRegistry();
+		[sLiveBars addObject:self];
+	}
+	return self;
+}
+
+- (void)dealloc
+{
+	if (sLiveBars)
+		[sLiveBars removeObject:self];
+	stopTimerIfIdle();
+}
+
+- (void)viewDidMoveToWindow
+{
+	[super viewDidMoveToWindow];
+	if (self.window && !self.hidden)
+		startTimerIfNeeded();
+	else
+		stopTimerIfIdle();
+}
+
+- (void)setHidden:(BOOL)hidden
+{
+	[super setHidden:hidden];
+	if (!hidden)
+		startTimerIfNeeded();
+	else
+		stopTimerIfIdle();
+}
+
+- (BOOL)isFlipped { return YES; } // top-down so Y aligns with Scintilla's Y
+
+- (BOOL)isDarkMode
+{
+	NSAppearanceName name = [self.effectiveAppearance
+		bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
+	return [name isEqualToString:NSAppearanceNameDarkAqua];
+}
+
+- (void)drawRect:(NSRect)dirtyRect
+{
+	// Background — match the editor: white in light mode, near-black in dark mode.
+	BOOL dark = [self isDarkMode];
+	NSColor* bg = dark
+		? [NSColor colorWithCalibratedWhite:0.12 alpha:1.0]
+		: [NSColor whiteColor];
+	[bg setFill];
+	NSRectFill(self.bounds);
+
+	DocumentData* doc = activeDocForView(_viewIndex);
+	if (!doc || !doc->followMode) return;
+
+	void* sci = (_viewIndex == 0) ? ctx().scintillaView : ctx().scintillaView2;
+	if (!sci) return;
+
+	const auto& bt = doc->lineBirthTimes;
+	if (bt.empty()) return;
+
+	CGFloat w = self.bounds.size.width;
+	CGFloat h = self.bounds.size.height;
+	if (w <= 0 || h <= 0) return;
+
+	uint64_t now = currentMillis();
+
+	intptr_t firstVis      = ScintillaBridge_sendMessage(sci, SCI_GETFIRSTVISIBLELINE, 0, 0);
+	intptr_t linesOnScreen = ScintillaBridge_sendMessage(sci, SCI_LINESONSCREEN, 0, 0);
+	intptr_t totalDocLines = (intptr_t)bt.size();
+
+	// Walk every visible line, paint a rectangle in the bar at the same Y as
+	// the line in the editor so colors stay locked to lines as the user scrolls.
+	for (intptr_t v = 0; v <= linesOnScreen; ++v)
+	{
+		intptr_t visibleLine = firstVis + v;
+		intptr_t docLine = ScintillaBridge_sendMessage(sci, SCI_DOCLINEFROMVISIBLE,
+		                                               (uintptr_t)visibleLine, 0);
+		if (docLine < 0 || docLine >= totalDocLines) continue;
+
+		intptr_t pos = ScintillaBridge_sendMessage(sci, SCI_POSITIONFROMLINE,
+		                                           (uintptr_t)docLine, 0);
+		intptr_t y  = ScintillaBridge_sendMessage(sci, SCI_POINTYFROMPOSITION, 0, pos);
+		intptr_t lh = ScintillaBridge_sendMessage(sci, SCI_TEXTHEIGHT,
+		                                          (uintptr_t)docLine, 0);
+		if (lh <= 0) continue;
+		if ((CGFloat)y >= h) break;
+
+		uint64_t birth = bt[(size_t)docLine];
+		NSColor* c;
+		if (birth == 0)
+		{
+			c = colorFromARGB(ctx().followColorOld);
+		}
+		else
+		{
+			uint64_t age = (now < birth) ? 0 : (now - birth);
+			c = colorForAge(age);
+		}
+
+		[c setFill];
+		NSRectFill(NSMakeRect(0, (CGFloat)y, w, (CGFloat)lh));
+	}
+}
+
+@end
+
+// ---------------------------------------------------------------------------
+// NppEditorContainer
+// ---------------------------------------------------------------------------
+
+@implementation NppEditorContainer
+
+- (instancetype)initWithFrame:(NSRect)frameRect
+{
+	self = [super initWithFrame:frameRect];
+	if (self)
+	{
+		_viewIndex = 0;
+		_ageBarVisible = NO;
+		_ageBar = [[NppAgeBarView alloc] initWithFrame:NSMakeRect(0, 0, kNppAgeBarWidth, frameRect.size.height)];
+		_ageBar.viewIndex = 0;
+		_ageBar.hidden = YES;
+		_ageBar.autoresizingMask = NSViewMinXMargin | NSViewHeightSizable;
+		[self addSubview:_ageBar];
+	}
+	return self;
+}
+
+- (void)setViewIndex:(int)viewIndex
+{
+	_viewIndex = viewIndex;
+	_ageBar.viewIndex = viewIndex;
+}
+
+- (void)setAgeBarVisible:(BOOL)visible
+{
+	if (_ageBarVisible == visible) return;
+	_ageBarVisible = visible;
+	_ageBar.hidden = !visible;
+	[self applyLayout];
+	[_ageBar setNeedsDisplay:YES];
+}
+
+- (void)setScintillaChild:(NSView*)child
+{
+	_scintillaChild = child;
+	// Manage the child's frame ourselves so we can inset for the age bar.
+	if (child)
+		child.autoresizingMask = NSViewNotSizable;
+	[self applyLayout];
+}
+
+- (void)setFrameSize:(NSSize)newSize
+{
+	[super setFrameSize:newSize];
+	[self applyLayout];
+}
+
+- (void)applyLayout
+{
+	NSSize sz = self.bounds.size;
+	CGFloat barW = _ageBarVisible ? kNppAgeBarWidth : 0.0;
+	CGFloat sciW = std::max<CGFloat>(0.0, sz.width - barW);
+
+	if (_scintillaChild)
+		_scintillaChild.frame = NSMakeRect(0, 0, sciW, sz.height);
+
+	if (_ageBar)
+		_ageBar.frame = NSMakeRect(sciW, 0, barW, sz.height);
+}
+
+@end

--- a/macos/platform/age_bar_view.mm
+++ b/macos/platform/age_bar_view.mm
@@ -25,19 +25,19 @@ const CGFloat kNppAgeBarWidth = 14.0;
 // fade smoothly without per-keystroke invalidation.
 // ---------------------------------------------------------------------------
 
-static NSMutableArray<NppAgeBarView*>* sLiveBars = nil;
+static NSHashTable<NppAgeBarView*>* sLiveBars = nil;
 static NSTimer* sTickTimer = nil;
 
 static void ensureBarRegistry()
 {
 	if (!sLiveBars)
-		sLiveBars = [NSMutableArray array];
+		sLiveBars = [NSHashTable weakObjectsHashTable];
 }
 
 static void onTick()
 {
 	if (!sLiveBars) return;
-	for (NppAgeBarView* bar in sLiveBars)
+	for (NppAgeBarView* bar in sLiveBars.allObjects)
 	{
 		if (!bar.hidden && bar.window)
 			[bar setNeedsDisplay:YES];
@@ -56,7 +56,7 @@ static void stopTimerIfIdle()
 {
 	if (!sTickTimer) return;
 	BOOL anyVisible = NO;
-	for (NppAgeBarView* bar in sLiveBars)
+	for (NppAgeBarView* bar in sLiveBars.allObjects)
 	{
 		if (!bar.hidden && bar.window) { anyVisible = YES; break; }
 	}
@@ -70,14 +70,14 @@ static void stopTimerIfIdle()
 void invalidateAllAgeBars(void)
 {
 	if (!sLiveBars) return;
-	for (NppAgeBarView* bar in sLiveBars)
+	for (NppAgeBarView* bar in sLiveBars.allObjects)
 		[bar setNeedsDisplay:YES];
 }
 
 void invalidateAgeBarForView(int viewIndex)
 {
 	if (!sLiveBars) return;
-	for (NppAgeBarView* bar in sLiveBars)
+	for (NppAgeBarView* bar in sLiveBars.allObjects)
 	{
 		if (bar.viewIndex == viewIndex && !bar.hidden)
 			[bar setNeedsDisplay:YES];

--- a/macos/platform/app_delegate.mm
+++ b/macos/platform/app_delegate.mm
@@ -26,6 +26,8 @@
 #include "file_monitor_mac.h"
 #include "brace_match.h"
 #include "smart_highlight.h"
+#include "age_bar_view.h"
+#include "follow_mode.h"
 #include "auto_indent.h"
 #include "auto_close.h"
 #include "sync_scroll.h"
@@ -143,6 +145,12 @@ static void setDockIconFromLogo()
 	ctx().rightPanelWidth = s.rightPanelWidth;
 	ctx().functionListHeightRatio = s.functionListHeightRatio;
 	ctx().documentMapWidth = s.documentMapWidth;
+	ctx().followColorNew = s.followColorNew;
+	ctx().followColorMedium = s.followColorMedium;
+	ctx().followColorOld = s.followColorOld;
+	ctx().followThresholdNewSec = s.followThresholdNewSec;
+	ctx().followThresholdMediumSec = s.followThresholdMediumSec;
+	ctx().followThresholdOldSec = s.followThresholdOldSec;
 	setDockIconFromLogo();
 
 	ctx().recentFiles.clear();
@@ -243,8 +251,10 @@ static void setDockIconFromLogo()
 	}
 
 	NSRect editorFrame = NSMakeRect(0, statusHeight, contentView.bounds.size.width, editorHeight);
-	ctx().editorContainer = [[NSView alloc] initWithFrame:editorFrame];
-	ctx().editorContainer.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+	NppEditorContainer* mainContainer = [[NppEditorContainer alloc] initWithFrame:editorFrame];
+	mainContainer.viewIndex = 0;
+	mainContainer.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+	ctx().editorContainer = mainContainer;
 	[contentView addSubview:ctx().editorContainer];
 
 	ctx().scintillaView = ScintillaBridge_createView((__bridge void*)ctx().editorContainer, 0, 0, 0, 0);
@@ -253,6 +263,7 @@ static void setDockIconFromLogo()
 		NSLog(@"ERROR: Failed to create ScintillaView!");
 		return;
 	}
+	mainContainer.scintillaChild = (__bridge NSView*)ctx().scintillaView;
 
 	// Register main Scintilla view with HandleRegistry so SendMessage(sciHandle, SCI_*, ...) works
 	{
@@ -356,6 +367,8 @@ static void setDockIconFromLogo()
 						scheduleSmartHighlight(ctx().scintillaView);
 					handleSyncScrollUpdate(ctx().scintillaView, scn->updated);
 					handleDocumentMapUpdateUI(ctx().scintillaView, scn->updated);
+					if (scn->updated & SC_UPDATE_V_SCROLL)
+						invalidateAgeBarForView(0);
 				}
 				else if (scn->nmhdr.code == SCN_CHARADDED)
 				{
@@ -375,6 +388,8 @@ static void setDockIconFromLogo()
 				{
 					if (scn->linesAdded != 0)
 						refreshLineNumberMargin(ctx().scintillaView);
+
+					handleFollowModified(0, scn);
 
 					if (ctx().autoCloseBrackets)
 					{

--- a/macos/platform/app_state.h
+++ b/macos/platform/app_state.h
@@ -61,6 +61,14 @@ struct AppContext
 	bool autoCloseBrackets = true;
 	bool showChangeHistory = true;
 
+	// Follow mode colors and time thresholds (mirror of AppSettings)
+	uint32_t followColorNew = 0xFF00C800;
+	uint32_t followColorMedium = 0xFFE0A040;
+	uint32_t followColorOld = 0xFF202020;
+	int followThresholdNewSec = 5;
+	int followThresholdMediumSec = 60;
+	int followThresholdOldSec = 300;
+
 	// Split view state
 	void* scintillaView2 = nullptr;
 	HWND scintillaSecondHwnd = nullptr;
@@ -119,6 +127,12 @@ struct AppContext
 
 	// Notification suppression (prevents false dirty indicators during tab switches)
 	bool suppressSavePointNotifications = false;
+
+	// Suppresses follow-mode line-age tracking during programmatic buffer
+	// restores (tab switch reloads the buffer, but we want existing ages kept).
+	// Distinct from suppressSavePointNotifications because the tail-follow
+	// append path also sets that flag to avoid marking the buffer dirty.
+	bool suppressFollowTracking = false;
 
 	// Auto-close internal edit guard (prevents recursive handling on programmatic edits)
 	bool autoCloseInternalEdit = false;

--- a/macos/platform/document_data.h
+++ b/macos/platform/document_data.h
@@ -61,6 +61,12 @@ struct DocumentData
 	uint64_t functionListDocumentId = 0;
 	uint64_t functionListRevision = 0;
 	uint64_t bufferId = 0; // Stable buffer ID for plugin API (NPPM_GETCURRENTBUFFERID etc.)
+
+	// Follow Mode: tail-follow external file changes; render per-line age heatmap.
+	bool followMode = false;
+	std::vector<uint64_t> lineBirthTimes; // monotonic ms per line index
+	uint64_t lastKnownFileSize = 0;       // last on-disk size we've observed
+	bool followSuspended = false;         // true when external change arrived while dirty
 };
 
 // Allocate a unique buffer ID (monotonic, never reused)

--- a/macos/platform/document_manager.mm
+++ b/macos/platform/document_manager.mm
@@ -21,6 +21,7 @@
 #include "handle_registry.h"
 #include "tab_bar_view.h"
 #include "win32_tab_control_impl.h"
+#include "follow_mode.h"
 
 static uint64_t sNextFunctionListDocumentId = 1;
 static uint64_t sNextBufferId = 1;
@@ -83,6 +84,7 @@ void restoreViewToScintilla(void* sci, std::vector<DocumentData>& docs, int tabI
 
 	auto& doc = docs[tabIndex];
 	ctx().suppressSavePointNotifications = true;
+	ctx().suppressFollowTracking = true;
 	ScintillaBridge_sendMessage(sci, SCI_SETREADONLY, 0, 0);
 	ScintillaBridge_sendMessage(sci, SCI_SETTEXT, 0, (intptr_t)doc.content.c_str());
 	if (!doc.modified)
@@ -94,6 +96,7 @@ void restoreViewToScintilla(void* sci, std::vector<DocumentData>& docs, int tabI
 	// For modified documents, this makes Scintilla think it's clean when it isn't.
 	// Mark the save point as invalid so SCN_SAVEPOINTREACHED won't clear modified.
 	doc.savePointValid = !doc.modified;
+	ctx().suppressFollowTracking = false;
 	ctx().suppressSavePointNotifications = false;
 
 	for (int bkLine : doc.bookmarkedLines)
@@ -151,6 +154,8 @@ void switchToTabInView(int viewIndex, int tabIndex)
 	NSString* title = WideToNSString(doc.title.c_str());
 	[ctx().mainWindow setTitle:[NSString stringWithFormat:@"PaperWasp — %@", title]];
 	updateWindowDocumentEdited();
+
+	refreshFollowUIForViewActiveTab(viewIndex);
 
 	// Notify plugins that a buffer was activated
 	{
@@ -245,6 +250,10 @@ void closeTabFromView(int viewIndex, int tabIndex)
 	if (tabIndex < 0 || tabIndex >= static_cast<int>(docs.size()))
 		return;
 	if (!sci) return;
+
+	// Tear down follow-mode plumbing before the buffer disappears.
+	if (docs[tabIndex].followMode)
+		stopFollowForBufferAtIndex(viewIndex, tabIndex);
 
 	const uint64_t closingBufferId = docs[tabIndex].bufferId;
 

--- a/macos/platform/file_monitor_mac.h
+++ b/macos/platform/file_monitor_mac.h
@@ -31,6 +31,14 @@ public:
 	// Stop watching a directory.
 	void removeDirectory(const std::wstring& path);
 
+	// Start watching a specific file path for changes. The per-file callback fires on
+	// modify/remove/rename in addition to (not in place of) the global setCallback hook.
+	// Multiple files can be watched independently.
+	bool addFilePath(const std::wstring& path, FileMonitorCallback callback);
+
+	// Stop watching a specific file path.
+	void removeFilePath(const std::wstring& path);
+
 	// Set callback for immediate notification (called on the main thread).
 	void setCallback(FileMonitorCallback callback);
 

--- a/macos/platform/file_monitor_mac.mm
+++ b/macos/platform/file_monitor_mac.mm
@@ -10,6 +10,8 @@
 #include <vector>
 #include <string>
 
+struct FileWatchContext;
+
 // Helper: wchar_t (UTF-32) → NSString → std::string (UTF-8)
 static std::string WideToUTF8(const std::wstring& ws)
 {
@@ -48,7 +50,7 @@ struct FileMonitorMac::Impl
 	std::vector<FSEventStreamRef> fileStreams;
 	std::vector<std::wstring> watchedFiles;
 	std::vector<FileMonitorCallback> fileCallbacks;
-	std::vector<void*> fileContexts;
+	std::vector<FileWatchContext*> fileContexts;
 
 	bool terminated = false;
 };
@@ -100,7 +102,7 @@ static void fseventsCallback(ConstFSEventStreamRef streamRef,
 struct FileWatchContext
 {
 	FileMonitorMac::Impl* impl;
-	FileMonitorCallback callback;
+	std::wstring watchedPath;
 };
 
 static void fileWatchCallback(ConstFSEventStreamRef /*streamRef*/,
@@ -131,8 +133,28 @@ static void fileWatchCallback(ConstFSEventStreamRef /*streamRef*/,
 		NSString* nsPath = (__bridge NSString*)cfPath;
 		std::wstring widePath = UTF8ToWide([nsPath UTF8String]);
 
-		if (fwc && fwc->callback)
-			fwc->callback(action, widePath);
+		FileMonitorCallback globalCallback;
+		FileMonitorCallback fileCallback;
+		if (fwc && fwc->impl)
+		{
+			std::lock_guard<std::mutex> lock(fwc->impl->mutex);
+			fwc->impl->eventQueue.push({action, widePath});
+			globalCallback = fwc->impl->callback;
+
+			for (size_t j = 0; j < fwc->impl->watchedFiles.size(); ++j)
+			{
+				if (fwc->impl->watchedFiles[j] == fwc->watchedPath)
+				{
+					fileCallback = fwc->impl->fileCallbacks[j];
+					break;
+				}
+			}
+		}
+
+		if (globalCallback)
+			globalCallback(action, widePath);
+		if (fileCallback)
+			fileCallback(action, widePath);
 	}
 }
 
@@ -226,9 +248,9 @@ bool FileMonitorMac::addFilePath(const std::wstring& path, FileMonitorCallback c
 	CFStringRef cfPath = (__bridge CFStringRef)nsPath;
 	CFArrayRef pathsToWatch = CFArrayCreate(nullptr, (const void**)&cfPath, 1, &kCFTypeArrayCallBacks);
 
-	// Heap-allocated context: per-file callback survives for the stream's lifetime.
+	// Heap-allocated context: identifies which watched file this stream belongs to.
 	// Freed in removeFilePath()/terminate().
-	auto* fwc = new FileWatchContext{m_impl, callback};
+	auto* fwc = new FileWatchContext{m_impl, path};
 
 	FSEventStreamContext context = {};
 	context.info = fwc;
@@ -274,7 +296,7 @@ void FileMonitorMac::removeFilePath(const std::wstring& path)
 			if (m_impl->watchedFiles[i] == path)
 			{
 				streamToStop = m_impl->fileStreams[i];
-				ctxToFree = static_cast<FileWatchContext*>(m_impl->fileContexts[i]);
+				ctxToFree = m_impl->fileContexts[i];
 				m_impl->fileStreams.erase(m_impl->fileStreams.begin() + i);
 				m_impl->watchedFiles.erase(m_impl->watchedFiles.begin() + i);
 				m_impl->fileCallbacks.erase(m_impl->fileCallbacks.begin() + i);
@@ -329,8 +351,7 @@ void FileMonitorMac::terminate()
 		m_impl->watchedPaths.clear();
 
 		fileStreamsToStop = std::move(m_impl->fileStreams);
-		for (void* p : m_impl->fileContexts)
-			fileContextsToFree.push_back(static_cast<FileWatchContext*>(p));
+		fileContextsToFree = std::move(m_impl->fileContexts);
 		m_impl->fileStreams.clear();
 		m_impl->watchedFiles.clear();
 		m_impl->fileCallbacks.clear();

--- a/macos/platform/file_monitor_mac.mm
+++ b/macos/platform/file_monitor_mac.mm
@@ -40,6 +40,16 @@ struct FileMonitorMac::Impl
 	FileMonitorCallback callback;
 	std::vector<FSEventStreamRef> streams;
 	std::vector<std::wstring> watchedPaths;
+
+	// Per-file watch streams: parallel arrays keyed by full file path. The
+	// per-stream FSEvents context info pointer is owned by `fileContexts` here so
+	// we can free it on removeFilePath()/terminate() without needing to query
+	// the stream back (FSEventStreamCopyContext doesn't exist).
+	std::vector<FSEventStreamRef> fileStreams;
+	std::vector<std::wstring> watchedFiles;
+	std::vector<FileMonitorCallback> fileCallbacks;
+	std::vector<void*> fileContexts;
+
 	bool terminated = false;
 };
 
@@ -82,6 +92,47 @@ static void fseventsCallback(ConstFSEventStreamRef streamRef,
 
 		if (impl->callback)
 			impl->callback(action, widePath);
+	}
+}
+
+// Per-file FSEvents callback. The stream watches a single path; the per-file
+// callback was paired with that stream at addFilePath() time via context.info.
+struct FileWatchContext
+{
+	FileMonitorMac::Impl* impl;
+	FileMonitorCallback callback;
+};
+
+static void fileWatchCallback(ConstFSEventStreamRef /*streamRef*/,
+                               void* clientCallBackInfo,
+                               size_t numEvents,
+                               void* eventPaths,
+                               const FSEventStreamEventFlags eventFlags[],
+                               const FSEventStreamEventId /*eventIds*/[])
+{
+	auto* fwc = static_cast<FileWatchContext*>(clientCallBackInfo);
+	CFArrayRef pathArray = static_cast<CFArrayRef>(eventPaths);
+
+	for (size_t i = 0; i < numEvents; ++i)
+	{
+		FileMonitorAction action;
+		FSEventStreamEventFlags flags = eventFlags[i];
+
+		if (flags & kFSEventStreamEventFlagItemRemoved)
+			action = FileMonitorAction::Removed;
+		else if (flags & kFSEventStreamEventFlagItemRenamed)
+			action = FileMonitorAction::RenamedNew;
+		else if (flags & kFSEventStreamEventFlagItemCreated)
+			action = FileMonitorAction::Added;
+		else
+			action = FileMonitorAction::Modified;
+
+		CFStringRef cfPath = static_cast<CFStringRef>(CFArrayGetValueAtIndex(pathArray, i));
+		NSString* nsPath = (__bridge NSString*)cfPath;
+		std::wstring widePath = UTF8ToWide([nsPath UTF8String]);
+
+		if (fwc && fwc->callback)
+			fwc->callback(action, widePath);
 	}
 }
 
@@ -153,6 +204,95 @@ void FileMonitorMac::removeDirectory(const std::wstring& path)
 	}
 }
 
+bool FileMonitorMac::addFilePath(const std::wstring& path, FileMonitorCallback callback)
+{
+	std::lock_guard<std::mutex> lock(m_impl->mutex);
+	if (m_impl->terminated) return false;
+
+	std::string utf8Path = WideToUTF8(path);
+	if (utf8Path.empty()) return false;
+
+	// If already watching, replace the callback in-place.
+	for (size_t i = 0; i < m_impl->watchedFiles.size(); ++i)
+	{
+		if (m_impl->watchedFiles[i] == path)
+		{
+			m_impl->fileCallbacks[i] = std::move(callback);
+			return true;
+		}
+	}
+
+	NSString* nsPath = [NSString stringWithUTF8String:utf8Path.c_str()];
+	CFStringRef cfPath = (__bridge CFStringRef)nsPath;
+	CFArrayRef pathsToWatch = CFArrayCreate(nullptr, (const void**)&cfPath, 1, &kCFTypeArrayCallBacks);
+
+	// Heap-allocated context: per-file callback survives for the stream's lifetime.
+	// Freed in removeFilePath()/terminate().
+	auto* fwc = new FileWatchContext{m_impl, callback};
+
+	FSEventStreamContext context = {};
+	context.info = fwc;
+
+	FSEventStreamRef stream = FSEventStreamCreate(
+		nullptr,
+		&fileWatchCallback,
+		&context,
+		pathsToWatch,
+		kFSEventStreamEventIdSinceNow,
+		0.1, // low latency for log tailing
+		kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagUseCFTypes
+	);
+
+	CFRelease(pathsToWatch);
+
+	if (!stream)
+	{
+		delete fwc;
+		return false;
+	}
+
+	FSEventStreamScheduleWithRunLoop(stream, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+	FSEventStreamStart(stream);
+
+	m_impl->fileStreams.push_back(stream);
+	m_impl->watchedFiles.push_back(path);
+	m_impl->fileCallbacks.push_back(std::move(callback));
+	m_impl->fileContexts.push_back(fwc);
+
+	return true;
+}
+
+void FileMonitorMac::removeFilePath(const std::wstring& path)
+{
+	FSEventStreamRef streamToStop = nullptr;
+	FileWatchContext* ctxToFree = nullptr;
+
+	{
+		std::lock_guard<std::mutex> lock(m_impl->mutex);
+		for (size_t i = 0; i < m_impl->watchedFiles.size(); ++i)
+		{
+			if (m_impl->watchedFiles[i] == path)
+			{
+				streamToStop = m_impl->fileStreams[i];
+				ctxToFree = static_cast<FileWatchContext*>(m_impl->fileContexts[i]);
+				m_impl->fileStreams.erase(m_impl->fileStreams.begin() + i);
+				m_impl->watchedFiles.erase(m_impl->watchedFiles.begin() + i);
+				m_impl->fileCallbacks.erase(m_impl->fileCallbacks.begin() + i);
+				m_impl->fileContexts.erase(m_impl->fileContexts.begin() + i);
+				break;
+			}
+		}
+	}
+
+	if (streamToStop)
+	{
+		FSEventStreamStop(streamToStop);
+		FSEventStreamInvalidate(streamToStop);
+		FSEventStreamRelease(streamToStop);
+	}
+	delete ctxToFree;
+}
+
 void FileMonitorMac::setCallback(FileMonitorCallback callback)
 {
 	std::lock_guard<std::mutex> lock(m_impl->mutex);
@@ -177,6 +317,8 @@ void FileMonitorMac::terminate()
 	// FSEventStreamStop can block waiting for in-flight callbacks that
 	// also acquire the mutex, so holding it here would deadlock.
 	std::vector<FSEventStreamRef> streamsToStop;
+	std::vector<FSEventStreamRef> fileStreamsToStop;
+	std::vector<FileWatchContext*> fileContextsToFree;
 	{
 		std::lock_guard<std::mutex> lock(m_impl->mutex);
 		if (m_impl->terminated) return;
@@ -185,6 +327,14 @@ void FileMonitorMac::terminate()
 		streamsToStop = std::move(m_impl->streams);
 		m_impl->streams.clear();
 		m_impl->watchedPaths.clear();
+
+		fileStreamsToStop = std::move(m_impl->fileStreams);
+		for (void* p : m_impl->fileContexts)
+			fileContextsToFree.push_back(static_cast<FileWatchContext*>(p));
+		m_impl->fileStreams.clear();
+		m_impl->watchedFiles.clear();
+		m_impl->fileCallbacks.clear();
+		m_impl->fileContexts.clear();
 	}
 
 	for (auto stream : streamsToStop)
@@ -193,4 +343,12 @@ void FileMonitorMac::terminate()
 		FSEventStreamInvalidate(stream);
 		FSEventStreamRelease(stream);
 	}
+	for (auto stream : fileStreamsToStop)
+	{
+		FSEventStreamStop(stream);
+		FSEventStreamInvalidate(stream);
+		FSEventStreamRelease(stream);
+	}
+	for (auto* fwc : fileContextsToFree)
+		delete fwc;
 }

--- a/macos/platform/follow_mode.h
+++ b/macos/platform/follow_mode.h
@@ -1,0 +1,25 @@
+// follow_mode.h — Tail-follow external file changes + per-line age tracking.
+// Part of the PaperWasp macOS app.
+
+#pragma once
+
+struct SciNotification;
+
+// Toggle Follow Mode on the active tab of the given view (0 = main, 1 = sub-split).
+// Updates the buffer flag, wires/unwires the file watch, updates tab indicators
+// and the age bar visibility.
+void toggleFollowModeForActiveTab(int viewIndex);
+
+// Toggle Follow Mode on a specific tab in a specific view (used by tab right-click).
+void toggleFollowMode(int viewIndex, int tabIndex);
+
+// SCN_MODIFIED notification hook — records lineBirthTimes for inserted lines
+// and erases them for deleted lines on the active tab of the given view.
+void handleFollowModified(int viewIndex, const SciNotification* scn);
+
+// Called when the active tab in a view changes; refreshes the age bar visibility
+// and rebinds the bar to the new active document.
+void refreshFollowUIForViewActiveTab(int viewIndex);
+
+// Called when a tab is being closed — stops watching the file and clears state.
+void stopFollowForBufferAtIndex(int viewIndex, int tabIndex);

--- a/macos/platform/follow_mode.mm
+++ b/macos/platform/follow_mode.mm
@@ -1,0 +1,546 @@
+// follow_mode.mm — Tail-follow external file changes + per-line age tracking.
+// Part of the PaperWasp macOS app.
+
+#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
+#include "follow_mode.h"
+#include "age_bar_view.h"
+#include "app_state.h"
+#include "scintilla_bridge.h"
+#include "scintilla_config.h"
+#include "scintilla_notify.h"
+#include "npp_constants.h"
+#include "file_monitor_mac.h"
+#include "document_manager.h"
+#include "file_operations.h"
+#include "handle_registry.h"
+#include "tab_bar_view.h"
+#include "string_utils.h"
+
+#include <mach/mach_time.h>
+#include <sys/stat.h>
+#include <fstream>
+#include <vector>
+#include <algorithm>
+
+#ifndef SCI_APPENDTEXT
+#define SCI_APPENDTEXT 2282
+#endif
+
+class FollowMirrorSuppression
+{
+public:
+	FollowMirrorSuppression()
+		: _savePoint(ctx().suppressSavePointNotifications)
+		, _followTracking(ctx().suppressFollowTracking)
+	{
+		ctx().suppressSavePointNotifications = true;
+		ctx().suppressFollowTracking = true;
+	}
+
+	~FollowMirrorSuppression()
+	{
+		ctx().suppressFollowTracking = _followTracking;
+		ctx().suppressSavePointNotifications = _savePoint;
+	}
+
+private:
+	bool _savePoint;
+	bool _followTracking;
+};
+
+// ---------------------------------------------------------------------------
+// Time helper (mirrors age_bar_view.mm's local helper)
+// ---------------------------------------------------------------------------
+
+static uint64_t currentMillisFM()
+{
+	static mach_timebase_info_data_t tb = {0, 0};
+	if (tb.denom == 0)
+		mach_timebase_info(&tb);
+	return (mach_absolute_time() * tb.numer / tb.denom) / 1000000ULL;
+}
+
+// ---------------------------------------------------------------------------
+// View/doc lookup helpers
+// ---------------------------------------------------------------------------
+
+static void* scintillaForView(int viewIndex)
+{
+	return (viewIndex == 0) ? ctx().scintillaView : ctx().scintillaView2;
+}
+
+static std::vector<DocumentData>& docsForView(int viewIndex)
+{
+	return (viewIndex == 0) ? ctx().documents : ctx().documents2;
+}
+
+static int activeTabForView(int viewIndex)
+{
+	return (viewIndex == 0) ? ctx().activeTab : ctx().activeTab2;
+}
+
+static NppEditorContainer* editorContainerForView(int viewIndex)
+{
+	NSView* v = (viewIndex == 0) ? ctx().editorContainer : ctx().editorContainer2;
+	return [v isKindOfClass:[NppEditorContainer class]] ? (NppEditorContainer*)v : nil;
+}
+
+// Locate (viewIndex, tabIndex) for a given filePath if any tab in any view is
+// currently following it. Returns true on match.
+static bool findFollowingTabForPath(const std::wstring& path, int& outView, int& outTab)
+{
+	for (int vi = 0; vi < 2; ++vi)
+	{
+		auto& docs = docsForView(vi);
+		for (size_t i = 0; i < docs.size(); ++i)
+		{
+			if (docs[i].followMode && docs[i].filePath == path)
+			{
+				outView = vi;
+				outTab = (int)i;
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+// ---------------------------------------------------------------------------
+// Tab eye-icon + age bar visibility sync
+// ---------------------------------------------------------------------------
+
+static void updateTabFollowedIndicator(int viewIndex, int tabIndex)
+{
+	HWND tabHwnd = (viewIndex == 0) ? ctx().tabHwnd : ctx().tabHwnd2;
+	if (!tabHwnd) return;
+	auto& docs = docsForView(viewIndex);
+	if (tabIndex < 0 || tabIndex >= (int)docs.size()) return;
+
+	auto* info = HandleRegistry::getWindowInfo(tabHwnd);
+	if (!info || !info->nativeView) return;
+	NppTabBarView* tabView = (__bridge NppTabBarView*)info->nativeView;
+	[tabView setFollowed:docs[tabIndex].followMode forTabAtIndex:tabIndex];
+}
+
+// Forward decl: defined below alongside the other file-watch helpers, but
+// refreshFollowUIForViewActiveTab() above the helpers needs to call it.
+static void catchUpFollowedTab(int viewIndex);
+
+static void applyAgeBarVisibilityForActive(int viewIndex)
+{
+	NppEditorContainer* container = editorContainerForView(viewIndex);
+	if (!container) return;
+	auto& docs = docsForView(viewIndex);
+	int tab = activeTabForView(viewIndex);
+	bool show = (tab >= 0 && tab < (int)docs.size() && docs[tab].followMode);
+	container.ageBarVisible = show;
+}
+
+void refreshFollowUIForViewActiveTab(int viewIndex)
+{
+	applyAgeBarVisibilityForActive(viewIndex);
+	catchUpFollowedTab(viewIndex);
+
+	// For follow-mode tabs, re-anchor the view to the new bottom on activation —
+	// the saved firstVisibleLine/cursor from restoreViewToScintilla() points at
+	// wherever the user left the view, but follow semantics ("tail -F") mean
+	// "reattach to the end" on return.
+	auto& docs = docsForView(viewIndex);
+	int tab = activeTabForView(viewIndex);
+	if (tab < 0 || tab >= (int)docs.size()) return;
+	if (!docs[tab].followMode) return;
+	void* sci = scintillaForView(viewIndex);
+	if (!sci) return;
+	intptr_t lineCount = ScintillaBridge_sendMessage(sci, SCI_GETLINECOUNT, 0, 0);
+	if (lineCount > 0)
+		ScintillaBridge_sendMessage(sci, SCI_GOTOLINE, (uintptr_t)(lineCount - 1), 0);
+}
+
+// ---------------------------------------------------------------------------
+// File reading helpers
+// ---------------------------------------------------------------------------
+
+static uint64_t fileSizeBytes(const std::wstring& wpath)
+{
+	NSString* nsPath = WideToNSString(wpath.c_str());
+	if (!nsPath) return 0;
+	struct stat st;
+	const char* fs = [nsPath fileSystemRepresentation];
+	if (!fs || stat(fs, &st) != 0) return 0;
+	return (uint64_t)st.st_size;
+}
+
+static std::string readFileRange(const std::wstring& wpath, uint64_t offset, uint64_t length)
+{
+	if (length == 0) return "";
+	NSString* nsPath = WideToNSString(wpath.c_str());
+	if (!nsPath) return "";
+	const char* fs = [nsPath fileSystemRepresentation];
+	if (!fs) return "";
+	std::ifstream f(fs, std::ios::binary);
+	if (!f.is_open()) return "";
+	f.seekg((std::streamoff)offset, std::ios::beg);
+	std::string out;
+	out.resize((size_t)length);
+	f.read(&out[0], (std::streamsize)length);
+	out.resize((size_t)f.gcount());
+	return out;
+}
+
+static std::string decodeFollowBytes(const std::string& bytes, int encoding, bool entireFile)
+{
+	if (bytes.empty()) return "";
+	int effectiveEncoding = (!entireFile && encoding == ENC_UTF8_BOM) ? ENC_UTF8 : encoding;
+	NSData* data = [NSData dataWithBytes:bytes.data() length:bytes.size()];
+	return decodeFileData(data, effectiveEncoding);
+}
+
+static size_t lineCountForContent(const std::string& content)
+{
+	size_t lineCount = 1;
+	for (size_t i = 0; i < content.size(); ++i)
+	{
+		if (content[i] == '\r')
+		{
+			++lineCount;
+			if (i + 1 < content.size() && content[i + 1] == '\n')
+				++i;
+		}
+		else if (content[i] == '\n')
+		{
+			++lineCount;
+		}
+	}
+	return lineCount;
+}
+
+static size_t normalizeLineBirthTimes(DocumentData& doc)
+{
+	size_t lineCount = lineCountForContent(doc.content);
+	doc.lineBirthTimes.resize(lineCount, 0);
+	return lineCount;
+}
+
+static void markFollowAppendLineBirths(DocumentData& doc, size_t oldLineCount)
+{
+	size_t newLineCount = lineCountForContent(doc.content);
+	if (newLineCount == 0)
+		return;
+
+	doc.lineBirthTimes.resize(newLineCount, 0);
+	size_t firstTouchedLine = (oldLineCount > 0) ? oldLineCount - 1 : 0;
+	if (firstTouchedLine >= newLineCount)
+		firstTouchedLine = newLineCount - 1;
+
+	uint64_t now = currentMillisFM();
+	for (size_t i = firstTouchedLine; i < newLineCount; ++i)
+		doc.lineBirthTimes[i] = now;
+}
+
+static std::string appendFileRangeToDocument(DocumentData& doc, const std::wstring& path,
+                                             uint64_t offset, uint64_t newSize)
+{
+	if (newSize <= offset)
+	{
+		doc.lastKnownFileSize = newSize;
+		return "";
+	}
+
+	std::string rawBytes = readFileRange(path, offset, newSize - offset);
+	if (rawBytes.empty())
+		return "";
+
+	size_t oldLineCount = normalizeLineBirthTimes(doc);
+	std::string appendedText = decodeFollowBytes(rawBytes, doc.encoding, false);
+	if (!appendedText.empty())
+	{
+		doc.content.append(appendedText);
+		doc.eolMode = detectEOLMode(doc.content.c_str(), doc.content.size());
+		markFollowAppendLineBirths(doc, oldLineCount);
+	}
+	doc.lastKnownFileSize = offset + (uint64_t)rawBytes.size();
+	doc.followSuspended = false;
+	return appendedText;
+}
+
+static bool replaceDocumentWithFile(DocumentData& doc, const std::wstring& path)
+{
+	uint64_t size = fileSizeBytes(path);
+	std::string rawContent = readFileRange(path, 0, size);
+	if (rawContent.size() != (size_t)size)
+		return false;
+
+	doc.content = decodeFollowBytes(rawContent, doc.encoding, true);
+	doc.eolMode = detectEOLMode(doc.content.c_str(), doc.content.size());
+	doc.lineBirthTimes.assign(lineCountForContent(doc.content), (uint64_t)0);
+	doc.lastKnownFileSize = size;
+	doc.followSuspended = false;
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// SCN_MODIFIED hook — records lineBirthTimes for the active tab of viewIndex.
+// ---------------------------------------------------------------------------
+
+void handleFollowModified(int viewIndex, const SciNotification* scn)
+{
+	if (!scn) return;
+	if (!(scn->modificationType & (SC_MOD_INSERTTEXT | SC_MOD_DELETETEXT))) return;
+	// Tab-switch restores re-insert the entire buffer into Scintilla. We need
+	// to treat those inserts as not-new so existing line ages survive the
+	// round-trip. We can't piggyback on suppressSavePointNotifications because
+	// other programmatic edit paths also set that flag to avoid dirty marks.
+	if (ctx().suppressFollowTracking) return;
+	auto& docs = docsForView(viewIndex);
+	int tab = activeTabForView(viewIndex);
+	if (tab < 0 || tab >= (int)docs.size()) return;
+	DocumentData& doc = docs[tab];
+	if (!doc.followMode) return;
+
+	// Tail-follow only cares about lines being added at the end or removed from
+	// the end. SCN_MODIFIED's `line` field can be unreliable, so resize the
+	// timestamp vector to match the new line count and tag newly-appended
+	// entries with the current time. Interior edits won't refresh per-line ages
+	// but that's outside the tail-follow contract.
+	void* sci = scintillaForView(viewIndex);
+	if (!sci) return;
+	intptr_t newLineCount = ScintillaBridge_sendMessage(sci, SCI_GETLINECOUNT, 0, 0);
+	if (newLineCount < 0) newLineCount = 0;
+	size_t newSize = (size_t)newLineCount;
+	size_t oldSize = doc.lineBirthTimes.size();
+	if (newSize > oldSize)
+	{
+		uint64_t now = currentMillisFM();
+		doc.lineBirthTimes.resize(newSize, now);
+	}
+	else if (newSize < oldSize)
+	{
+		doc.lineBirthTimes.resize(newSize);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// File-watch callback dispatcher
+// ---------------------------------------------------------------------------
+
+static void scrollScintillaToBottom(void* sci)
+{
+	if (!sci) return;
+	intptr_t lineCount = ScintillaBridge_sendMessage(sci, SCI_GETLINECOUNT, 0, 0);
+	if (lineCount > 0)
+		ScintillaBridge_sendMessage(sci, SCI_GOTOLINE, (uintptr_t)(lineCount - 1), 0);
+}
+
+static void appendTextToVisibleScintilla(int viewIndex, DocumentData& doc, const std::string& text)
+{
+	void* sci = scintillaForView(viewIndex);
+	if (!sci || text.empty()) return;
+
+	{
+		FollowMirrorSuppression suppress;
+		ScintillaBridge_sendMessage(sci, SCI_APPENDTEXT,
+		                            (uintptr_t)text.size(), (intptr_t)text.data());
+		ScintillaBridge_sendMessage(sci, SCI_SETSAVEPOINT, 0, 0);
+	}
+
+	doc.modified = false;
+	doc.savePointValid = true;
+	scrollScintillaToBottom(sci);
+	refreshLineNumberMargin(sci);
+	invalidateAgeBarForView(viewIndex);
+}
+
+static void replaceVisibleScintillaFromDocument(int viewIndex, DocumentData& doc)
+{
+	void* sci = scintillaForView(viewIndex);
+	if (!sci) return;
+
+	bool wasReadOnly = ScintillaBridge_sendMessage(sci, SCI_GETREADONLY, 0, 0) != 0;
+	{
+		FollowMirrorSuppression suppress;
+		ScintillaBridge_sendMessage(sci, SCI_SETREADONLY, 0, 0);
+		ScintillaBridge_sendMessage(sci, SCI_CLEARALL, 0, 0);
+		if (!doc.content.empty())
+			ScintillaBridge_sendMessage(sci, SCI_APPENDTEXT,
+			                            (uintptr_t)doc.content.size(), (intptr_t)doc.content.data());
+		ScintillaBridge_sendMessage(sci, SCI_EMPTYUNDOBUFFER, 0, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETSAVEPOINT, 0, 0);
+		ScintillaBridge_sendMessage(sci, SCI_SETREADONLY, wasReadOnly ? 1 : 0, 0);
+	}
+
+	doc.modified = false;
+	doc.savePointValid = true;
+	scrollScintillaToBottom(sci);
+	refreshLineNumberMargin(sci);
+	invalidateAgeBarForView(viewIndex);
+}
+
+// Stops follow mode without prompting (deletion / explicit toggle off).
+static void stopFollowAt(int viewIndex, int tabIndex, bool unwatch)
+{
+	auto& docs = docsForView(viewIndex);
+	if (tabIndex < 0 || tabIndex >= (int)docs.size()) return;
+	DocumentData& doc = docs[tabIndex];
+	if (!doc.followMode) return;
+
+	std::wstring path = doc.filePath;
+	doc.followMode = false;
+	doc.lineBirthTimes.clear();
+	doc.lastKnownFileSize = 0;
+	doc.followSuspended = false;
+
+	if (unwatch && !path.empty() && ctx().fileMonitor)
+	{
+		int otherView = -1, otherTab = -1;
+		if (!findFollowingTabForPath(path, otherView, otherTab))
+			ctx().fileMonitor->removeFilePath(path);
+	}
+
+	updateTabFollowedIndicator(viewIndex, tabIndex);
+	if (tabIndex == activeTabForView(viewIndex))
+		applyAgeBarVisibilityForActive(viewIndex);
+}
+
+void stopFollowForBufferAtIndex(int viewIndex, int tabIndex)
+{
+	stopFollowAt(viewIndex, tabIndex, true);
+}
+
+// Safety net for coalesced/missed file events. Normal FSEvents callbacks keep
+// DocumentData current even while hidden; activation only has to bridge any
+// size delta that slipped past the watcher into the now-visible Scintilla view.
+static void catchUpFollowedTab(int viewIndex)
+{
+	auto& docs = docsForView(viewIndex);
+	int tab = activeTabForView(viewIndex);
+	if (tab < 0 || tab >= (int)docs.size()) return;
+	DocumentData& doc = docs[tab];
+	if (!doc.followMode || doc.filePath.empty() || doc.modified) return;
+
+	void* sci = scintillaForView(viewIndex);
+	if (!sci) return;
+
+	uint64_t newSize = fileSizeBytes(doc.filePath);
+	if (newSize < doc.lastKnownFileSize)
+	{
+		if (replaceDocumentWithFile(doc, doc.filePath))
+			replaceVisibleScintillaFromDocument(viewIndex, doc);
+		return;
+	}
+	if (newSize > doc.lastKnownFileSize)
+	{
+		uint64_t offset = doc.lastKnownFileSize;
+		std::string appended = appendFileRangeToDocument(doc, doc.filePath, offset, newSize);
+		if (!appended.empty())
+			appendTextToVisibleScintilla(viewIndex, doc, appended);
+	}
+}
+
+static void handleFileChangedForTab(const std::wstring& path, FileMonitorAction action,
+                                    int viewIndex, int tabIndex)
+{
+	auto& docs = docsForView(viewIndex);
+	if (tabIndex < 0 || tabIndex >= (int)docs.size()) return;
+	DocumentData& doc = docs[tabIndex];
+
+	if (action == FileMonitorAction::Removed)
+	{
+		stopFollowAt(viewIndex, tabIndex, true);
+		return;
+	}
+
+	// If user has unsaved changes, don't clobber them.
+	if (doc.modified)
+	{
+		doc.followSuspended = true;
+		return;
+	}
+
+	uint64_t newSize = fileSizeBytes(path);
+	if (newSize == doc.lastKnownFileSize) return; // metadata-only touch
+
+	bool isVisibleTab = (tabIndex == activeTabForView(viewIndex));
+
+	if (newSize < doc.lastKnownFileSize)
+	{
+		if (replaceDocumentWithFile(doc, path) && isVisibleTab)
+			replaceVisibleScintillaFromDocument(viewIndex, doc);
+		return;
+	}
+
+	uint64_t offset = doc.lastKnownFileSize;
+	std::string appended = appendFileRangeToDocument(doc, path, offset, newSize);
+	if (isVisibleTab && !appended.empty())
+		appendTextToVisibleScintilla(viewIndex, doc, appended);
+}
+
+static void onFileChanged(const std::wstring& path, FileMonitorAction action)
+{
+	for (int vi = 0; vi < 2; ++vi)
+	{
+		auto& docs = docsForView(vi);
+		for (int ti = 0; ti < (int)docs.size(); ++ti)
+		{
+			if (docs[ti].followMode && docs[ti].filePath == path)
+				handleFileChangedForTab(path, action, vi, ti);
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Toggle entry points
+// ---------------------------------------------------------------------------
+
+void toggleFollowMode(int viewIndex, int tabIndex)
+{
+	auto& docs = docsForView(viewIndex);
+	if (tabIndex < 0 || tabIndex >= (int)docs.size()) return;
+	DocumentData& doc = docs[tabIndex];
+
+	if (doc.followMode)
+	{
+		stopFollowAt(viewIndex, tabIndex, true);
+		return;
+	}
+
+	// Turn ON — works for any tab, but requires a file path for the watch.
+	doc.followMode = true;
+	doc.followSuspended = false;
+
+	void* sci = scintillaForView(viewIndex);
+	if (tabIndex == activeTabForView(viewIndex) && sci)
+	{
+		intptr_t lineCount = ScintillaBridge_sendMessage(sci, SCI_GETLINECOUNT, 0, 0);
+		doc.lineBirthTimes.assign((size_t)std::max<intptr_t>(0, lineCount), (uint64_t)0);
+	}
+	else
+	{
+		doc.lineBirthTimes.assign(lineCountForContent(doc.content), (uint64_t)0);
+	}
+
+	if (!doc.filePath.empty())
+	{
+		doc.lastKnownFileSize = fileSizeBytes(doc.filePath);
+		if (ctx().fileMonitor)
+		{
+			std::wstring p = doc.filePath;
+			ctx().fileMonitor->addFilePath(p, [p](FileMonitorAction action, const std::wstring& /*evtPath*/) {
+				dispatch_async(dispatch_get_main_queue(), ^{
+					onFileChanged(p, action);
+				});
+			});
+		}
+	}
+
+	updateTabFollowedIndicator(viewIndex, tabIndex);
+	if (tabIndex == activeTabForView(viewIndex))
+		applyAgeBarVisibilityForActive(viewIndex);
+}
+
+void toggleFollowModeForActiveTab(int viewIndex)
+{
+	int tab = activeTabForView(viewIndex);
+	if (tab < 0) return;
+	toggleFollowMode(viewIndex, tab);
+}

--- a/macos/platform/menu_builder.mm
+++ b/macos/platform/menu_builder.mm
@@ -148,6 +148,8 @@ HMENU buildMenuBar()
 	AppendMenuW(hViewMenu, MF_STRING | (ctx().fileSwitcherEnabled ? MF_CHECKED : MF_UNCHECKED),
 	            IDM_VIEW_FILESWITCHER, L"File &Switcher\tCtrl+Shift+O");
 	AppendMenuW(hViewMenu, MF_SEPARATOR, 0, nullptr);
+	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_FOLLOW, L"Follow File &Changes\tCtrl+Alt+F");
+	AppendMenuW(hViewMenu, MF_SEPARATOR, 0, nullptr);
 	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_ZOOMIN, L"Zoom &In\tCtrl+=");
 	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_ZOOMOUT, L"Zoom &Out\tCtrl+-");
 	AppendMenuW(hViewMenu, MF_STRING, IDM_VIEW_ZOOMRESTORE, L"&Reset Zoom\tCtrl+0");

--- a/macos/platform/npp_constants.h
+++ b/macos/platform/npp_constants.h
@@ -121,6 +121,7 @@ constexpr double NPP_STATUS_BAR_HEIGHT = 22.0;
 #define IDM_VIEW_FILEBROWSER         42088
 #define IDM_VIEW_FILESWITCHER        42089
 #define IDM_FILE_OPENFOLDER          42094
+#define IDM_VIEW_FOLLOW              42095
 
 // Upstream Notepad++ view command IDs sent by plugins through NPPM_MENUCOMMAND.
 #define IDM_VIEW_GOTO_ANOTHER_VIEW     10001
@@ -141,6 +142,7 @@ constexpr double NPP_STATUS_BAR_HEIGHT = 22.0;
 #define IDM_TAB_COPY_FILENAME    42211
 #define IDM_TAB_COPY_DIR_PATH    42212
 #define IDM_TAB_REVEAL_FINDER    42213
+#define IDM_TAB_FOLLOW           42214
 
 // Help menu commands
 #define IDM_HELP_ABOUT           46001

--- a/macos/platform/preferences_dialog.mm
+++ b/macos/platform/preferences_dialog.mm
@@ -10,11 +10,35 @@
 #include "scintilla_bridge.h"
 #include "settings_manager.h"
 #include "language_defs.h"
+#include "age_bar_view.h"
+
+// Convert 0xAARRGGBB to NSColor and back.
+static NSColor* colorFromARGB32(uint32_t argb)
+{
+	CGFloat a = ((argb >> 24) & 0xFF) / 255.0;
+	CGFloat r = ((argb >> 16) & 0xFF) / 255.0;
+	CGFloat g = ((argb >>  8) & 0xFF) / 255.0;
+	CGFloat b = ( argb        & 0xFF) / 255.0;
+	return [NSColor colorWithCalibratedRed:r green:g blue:b alpha:a];
+}
+
+static uint32_t argb32FromColor(NSColor* c)
+{
+	NSColor* rgb = [c colorUsingColorSpace:[NSColorSpace sRGBColorSpace]];
+	if (!rgb) return 0xFF000000;
+	CGFloat r, g, b, a;
+	[rgb getRed:&r green:&g blue:&b alpha:&a];
+	uint32_t A = (uint32_t)(a * 255.0 + 0.5) & 0xFF;
+	uint32_t R = (uint32_t)(r * 255.0 + 0.5) & 0xFF;
+	uint32_t G = (uint32_t)(g * 255.0 + 0.5) & 0xFF;
+	uint32_t B = (uint32_t)(b * 255.0 + 0.5) & 0xFF;
+	return (A << 24) | (R << 16) | (G << 8) | B;
+}
 
 void showPreferencesDlg()
 {
 	@autoreleasepool {
-		NSPanel* panel = [[NSPanel alloc] initWithContentRect:NSMakeRect(0, 0, 380, 370)
+		NSPanel* panel = [[NSPanel alloc] initWithContentRect:NSMakeRect(0, 0, 420, 530)
 		                                    styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable
 		                                    backing:NSBackingStoreBuffered
 		                                    defer:NO];
@@ -22,6 +46,63 @@ void showPreferencesDlg()
 		[panel center];
 
 		NSView* content = panel.contentView;
+
+		// -- Follow Mode section ----------------------------------------------
+		NSTextField* fmTitle = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 490, 200, 22)];
+		fmTitle.stringValue = @"Follow Mode (Age Heatmap)";
+		fmTitle.bezeled = NO;
+		fmTitle.drawsBackground = NO;
+		fmTitle.editable = NO;
+		fmTitle.selectable = NO;
+		fmTitle.font = [NSFont boldSystemFontOfSize:12];
+		[content addSubview:fmTitle];
+
+		auto addLabel = [&](CGFloat x, CGFloat y, CGFloat w, NSString* s) {
+			NSTextField* t = [[NSTextField alloc] initWithFrame:NSMakeRect(x, y, w, 16)];
+			t.stringValue = s;
+			t.bezeled = NO;
+			t.drawsBackground = NO;
+			t.editable = NO;
+			t.selectable = NO;
+			t.font = [NSFont systemFontOfSize:10];
+			t.textColor = [NSColor secondaryLabelColor];
+			[content addSubview:t];
+		};
+		addLabel(30,  466, 60, @"Newest");
+		addLabel(105, 466, 60, @"Medium");
+		addLabel(180, 466, 60, @"Oldest");
+		addLabel(260, 466, 150, @"Time thresholds (seconds)");
+
+		NSColorWell* wellNew = [[NSColorWell alloc] initWithFrame:NSMakeRect(30, 440, 60, 22)];
+		NSColorWell* wellMid = [[NSColorWell alloc] initWithFrame:NSMakeRect(105, 440, 60, 22)];
+		NSColorWell* wellOld = [[NSColorWell alloc] initWithFrame:NSMakeRect(180, 440, 60, 22)];
+		wellNew.color = colorFromARGB32(ctx().followColorNew);
+		wellMid.color = colorFromARGB32(ctx().followColorMedium);
+		wellOld.color = colorFromARGB32(ctx().followColorOld);
+		[content addSubview:wellNew];
+		[content addSubview:wellMid];
+		[content addSubview:wellOld];
+
+		addLabel(260, 444, 35, @"New");
+		addLabel(310, 444, 35, @"Med");
+		addLabel(360, 444, 35, @"Old");
+
+		NSTextField* thrNew = [[NSTextField alloc] initWithFrame:NSMakeRect(260, 420, 40, 22)];
+		NSTextField* thrMid = [[NSTextField alloc] initWithFrame:NSMakeRect(310, 420, 40, 22)];
+		NSTextField* thrOld = [[NSTextField alloc] initWithFrame:NSMakeRect(360, 420, 40, 22)];
+		thrNew.stringValue = [NSString stringWithFormat:@"%d", ctx().followThresholdNewSec];
+		thrMid.stringValue = [NSString stringWithFormat:@"%d", ctx().followThresholdMediumSec];
+		thrOld.stringValue = [NSString stringWithFormat:@"%d", ctx().followThresholdOldSec];
+		[content addSubview:thrNew];
+		[content addSubview:thrMid];
+		[content addSubview:thrOld];
+
+		addLabel(20, 395, 380, @"Each followed file's right-edge bar colors lines by age (oldest at bottom).");
+
+		// Divider between Follow Mode and the existing controls
+		NSBox* divider = [[NSBox alloc] initWithFrame:NSMakeRect(20, 375, 380, 1)];
+		divider.boxType = NSBoxSeparator;
+		[content addSubview:divider];
 
 		NSTextField* asmLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(20, 305, 130, 20)];
 		asmLabel.stringValue = @".asm files:";
@@ -203,6 +284,20 @@ void showPreferencesDlg()
 			    ctx().activeTab2 < static_cast<int>(ctx().documents2.size()))
 				applyLanguageToView(ctx().scintillaView2, ctx().documents2[ctx().activeTab2].languageIndex);
 
+			// Follow Mode: pull colors and thresholds, clamp threshold ordering.
+			ctx().followColorNew    = argb32FromColor(wellNew.color);
+			ctx().followColorMedium = argb32FromColor(wellMid.color);
+			ctx().followColorOld    = argb32FromColor(wellOld.color);
+			int tN = thrNew.stringValue.intValue;
+			int tM = thrMid.stringValue.intValue;
+			int tO = thrOld.stringValue.intValue;
+			if (tN < 0) tN = 0;
+			if (tM < tN + 1) tM = tN + 1;
+			if (tO < tM + 1) tO = tM + 1;
+			ctx().followThresholdNewSec    = tN;
+			ctx().followThresholdMediumSec = tM;
+			ctx().followThresholdOldSec    = tO;
+
 			auto& ss = SettingsManager::instance().settings;
 			ss.fontName = ctx().fontName;
 			ss.fontSize = ctx().fontSize;
@@ -210,8 +305,16 @@ void showPreferencesDlg()
 			ss.showCaretLine = ctx().showCaretLine;
 			ss.autoIndent = ctx().autoIndent;
 			ss.useTabs = ctx().useTabs;
+			ss.followColorNew = ctx().followColorNew;
+			ss.followColorMedium = ctx().followColorMedium;
+			ss.followColorOld = ctx().followColorOld;
+			ss.followThresholdNewSec = ctx().followThresholdNewSec;
+			ss.followThresholdMediumSec = ctx().followThresholdMediumSec;
+			ss.followThresholdOldSec = ctx().followThresholdOldSec;
 			// asmDefault already set above
 			SettingsManager::instance().save();
+
+			invalidateAllAgeBars();
 		}
 
 		[panel orderOut:nil];

--- a/macos/platform/settings_manager.h
+++ b/macos/platform/settings_manager.h
@@ -48,6 +48,15 @@ struct AppSettings
 
 	// Recent files
 	std::vector<std::string> recentFiles;
+
+	// Follow Mode: 0xAARRGGBB colors and seconds thresholds for the age heatmap.
+	// Defaults: green / amber / black; 5s / 60s / 300s.
+	uint32_t followColorNew = 0xFF00C800;
+	uint32_t followColorMedium = 0xFFE0A040;
+	uint32_t followColorOld = 0xFF202020;
+	int followThresholdNewSec = 5;
+	int followThresholdMediumSec = 60;
+	int followThresholdOldSec = 300;
 };
 
 class SettingsManager

--- a/macos/platform/settings_manager.mm
+++ b/macos/platform/settings_manager.mm
@@ -134,6 +134,20 @@ bool SettingsManager::load()
 		settings.functionListHeightRatio = ratio;
 	}
 
+	// Follow mode
+	if ([json[@"followColorNew"] isKindOfClass:[NSNumber class]])
+		settings.followColorNew = [json[@"followColorNew"] unsignedIntValue];
+	if ([json[@"followColorMedium"] isKindOfClass:[NSNumber class]])
+		settings.followColorMedium = [json[@"followColorMedium"] unsignedIntValue];
+	if ([json[@"followColorOld"] isKindOfClass:[NSNumber class]])
+		settings.followColorOld = [json[@"followColorOld"] unsignedIntValue];
+	if ([json[@"followThresholdNewSec"] isKindOfClass:[NSNumber class]])
+		settings.followThresholdNewSec = [json[@"followThresholdNewSec"] intValue];
+	if ([json[@"followThresholdMediumSec"] isKindOfClass:[NSNumber class]])
+		settings.followThresholdMediumSec = [json[@"followThresholdMediumSec"] intValue];
+	if ([json[@"followThresholdOldSec"] isKindOfClass:[NSNumber class]])
+		settings.followThresholdOldSec = [json[@"followThresholdOldSec"] intValue];
+
 	// Recent files
 	settings.recentFiles.clear();
 	NSArray* recent = json[@"recentFiles"];
@@ -211,6 +225,12 @@ bool SettingsManager::save()
 		@"fileBrowserRootPath": stringFromFileSystemPath(settings.fileBrowserRootPath) ?: @"",
 		@"rightPanelWidth": @(settings.rightPanelWidth),
 		@"functionListHeightRatio": @(settings.functionListHeightRatio),
+		@"followColorNew":          @(settings.followColorNew),
+		@"followColorMedium":       @(settings.followColorMedium),
+		@"followColorOld":          @(settings.followColorOld),
+		@"followThresholdNewSec":   @(settings.followThresholdNewSec),
+		@"followThresholdMediumSec":@(settings.followThresholdMediumSec),
+		@"followThresholdOldSec":   @(settings.followThresholdOldSec),
 		@"recentFiles":  recentArr
 	};
 

--- a/macos/platform/split_view.mm
+++ b/macos/platform/split_view.mm
@@ -21,6 +21,8 @@
 #include "document_map.h"
 #include "function_list_panel.h"
 #include "panel_layout.h"
+#include "age_bar_view.h"
+#include "follow_mode.h"
 #include "file_switcher_panel.h"
 #include "scintilla_notify.h"
 #include "plugin_manager.h"
@@ -114,8 +116,10 @@ void doSplit()
 	[ctx().splitView addArrangedSubview:ctx().editorContainer];
 
 	NSRect rightFrame = NSMakeRect(0, 0, ctx().splitView.frame.size.width / 2, ctx().splitView.frame.size.height);
-	ctx().editorContainer2 = [[NSView alloc] initWithFrame:rightFrame];
-	ctx().editorContainer2.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+	NppEditorContainer* rightContainer = [[NppEditorContainer alloc] initWithFrame:rightFrame];
+	rightContainer.viewIndex = 1;
+	rightContainer.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+	ctx().editorContainer2 = rightContainer;
 	[ctx().splitView addArrangedSubview:ctx().editorContainer2];
 
 	CGFloat containerHeight = rightFrame.size.height;
@@ -133,6 +137,8 @@ void doSplit()
 	ctx().sciContainer2 = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, containerWidth, containerHeight)];
 	ctx().sciContainer2.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 	[ctx().editorContainer2 addSubview:ctx().sciContainer2];
+	rightContainer.scintillaChild = ctx().sciContainer2;
+	[rightContainer applyLayout];
 
 	// Reuse the pre-created second Scintilla view (created hidden at startup for plugin compatibility)
 	if (ctx().scintillaView2)
@@ -246,6 +252,8 @@ void doSplit()
 								scheduleSmartHighlight(ctx().scintillaView2);
 							handleSyncScrollUpdate(ctx().scintillaView2, scn->updated);
 							handleDocumentMapUpdateUI(ctx().scintillaView2, scn->updated);
+							if (scn->updated & SC_UPDATE_V_SCROLL)
+								invalidateAgeBarForView(1);
 						}
 					}
 					else if (scn->nmhdr.code == SCN_CHARADDED)
@@ -265,6 +273,8 @@ void doSplit()
 					{
 						if (scn->linesAdded != 0)
 							refreshLineNumberMargin(ctx().scintillaView2);
+
+						handleFollowModified(1, scn);
 
 						if (ctx().scintillaView2 && ctx().autoCloseBrackets)
 						{

--- a/macos/platform/tab_bar_view.h
+++ b/macos/platform/tab_bar_view.h
@@ -32,6 +32,8 @@
 - (NSString*)titleForTabAtIndex:(NSInteger)index;
 - (void)setModified:(BOOL)modified forTabAtIndex:(NSInteger)index;
 - (BOOL)isModifiedAtIndex:(NSInteger)index;
+- (void)setFollowed:(BOOL)followed forTabAtIndex:(NSInteger)index;
+- (BOOL)isFollowedAtIndex:(NSInteger)index;
 
 // Reorder (moves tab internally without notifying delegate)
 - (void)moveTabFrom:(NSInteger)fromIndex to:(NSInteger)toIndex;

--- a/macos/platform/tab_bar_view.mm
+++ b/macos/platform/tab_bar_view.mm
@@ -10,6 +10,7 @@
 @interface NppTabItem : NSObject
 @property (nonatomic, copy) NSString* title;
 @property (nonatomic, assign) BOOL modified;
+@property (nonatomic, assign) BOOL followed;
 @end
 
 @implementation NppTabItem
@@ -108,6 +109,7 @@ static const CGFloat kScrollWheelMultiplier = 3.0;
 	NppTabItem* item = [[NppTabItem alloc] init];
 	item.title = title ?: @"";
 	item.modified = NO;
+	item.followed = NO;
 
 	if (index < 0 || index > static_cast<NSInteger>(_tabs.count))
 		index = static_cast<NSInteger>(_tabs.count);
@@ -238,6 +240,21 @@ static const CGFloat kScrollWheelMultiplier = 3.0;
 	if (index < 0 || index >= static_cast<NSInteger>(_tabs.count))
 		return NO;
 	return _tabs[static_cast<NSUInteger>(index)].modified;
+}
+
+- (void)setFollowed:(BOOL)followed forTabAtIndex:(NSInteger)index
+{
+	if (index < 0 || index >= static_cast<NSInteger>(_tabs.count))
+		return;
+	_tabs[static_cast<NSUInteger>(index)].followed = followed;
+	[self setNeedsDisplay:YES];
+}
+
+- (BOOL)isFollowedAtIndex:(NSInteger)index
+{
+	if (index < 0 || index >= static_cast<NSInteger>(_tabs.count))
+		return NO;
+	return _tabs[static_cast<NSUInteger>(index)].followed;
 }
 
 // ============================================================
@@ -584,6 +601,34 @@ static const CGFloat kScrollWheelMultiplier = 3.0;
 	// Calculate text area (leave room for close button on right, modified dot on left)
 	CGFloat textX = tabRect.origin.x + kTabPaddingH;
 	CGFloat textMaxWidth = tabRect.size.width - kTabPaddingH * 2 - kCloseButtonSize - kCloseButtonPadding;
+
+	// Follow Mode eye icon — leftmost glyph so it stays visible even when truncation kicks in.
+	if (item.followed)
+	{
+		static const CGFloat kEyeSize = 13.0;
+		NSImage* eye = nil;
+		if (@available(macOS 11.0, *))
+			eye = [NSImage imageWithSystemSymbolName:@"eye" accessibilityDescription:@"Following file"];
+		if (eye)
+		{
+			NSColor* eyeColor = isDark
+				? [NSColor colorWithCalibratedWhite:0.85 alpha:alpha]
+				: [NSColor colorWithCalibratedWhite:0.2 alpha:alpha];
+			NSImage* tinted = [eye copy];
+			[tinted lockFocus];
+			[eyeColor set];
+			NSRect r = NSMakeRect(0, 0, tinted.size.width, tinted.size.height);
+			NSRectFillUsingOperation(r, NSCompositingOperationSourceAtop);
+			[tinted unlockFocus];
+			[tinted setTemplate:NO];
+
+			CGFloat eyeY = NSMidY(tabRect) - kEyeSize / 2.0;
+			NSRect eyeRect = NSMakeRect(textX, eyeY, kEyeSize, kEyeSize);
+			[tinted drawInRect:eyeRect fromRect:NSZeroRect operation:NSCompositingOperationSourceOver fraction:alpha];
+		}
+		textX += kEyeSize + 3.0;
+		textMaxWidth -= kEyeSize + 3.0;
+	}
 
 	if (item.modified)
 	{

--- a/macos/platform/tab_context_menu.mm
+++ b/macos/platform/tab_context_menu.mm
@@ -10,6 +10,7 @@
 #include "save_prompt.h"
 #include "file_path_ops.h"
 #include "handle_registry.h"
+#include "follow_mode.h"
 
 // Action context stored per menu invocation
 struct TabActionContext
@@ -128,6 +129,11 @@ static TabActionContext s_tabActionCtx;
 			}
 			break;
 		}
+		case IDM_TAB_FOLLOW:
+		{
+			toggleFollowMode(viewIndex, tabIndex);
+			break;
+		}
 	}
 }
 
@@ -213,6 +219,17 @@ void showTabContextMenu(int viewIndex, int tabIndex, NSPoint screenPoint)
 	revealItem.tag = IDM_TAB_REVEAL_FINDER;
 	if (!hasPath) revealItem.enabled = NO;
 	[menu addItem:revealItem];
+
+	[menu addItem:[NSMenuItem separatorItem]];
+
+	NSString* followLabel = docs[tabIndex].followMode ? @"Stop Following Changes" : @"Follow Changes";
+	NSMenuItem* followItem = [[NSMenuItem alloc] initWithTitle:followLabel
+	                                                    action:@selector(menuAction:) keyEquivalent:@""];
+	followItem.target = s_tabContextTarget;
+	followItem.tag = IDM_TAB_FOLLOW;
+	if (docs[tabIndex].followMode)
+		followItem.state = NSControlStateValueOn;
+	[menu addItem:followItem];
 
 	// Pop up at the screen point using the tab bar's HWND native view
 	HWND tabHwnd = (viewIndex == 0) ? ctx().tabHwnd : ctx().tabHwnd2;

--- a/macos/platform/wndproc.mm
+++ b/macos/platform/wndproc.mm
@@ -56,6 +56,23 @@ void updateSynchronizeScrollingMenu(HWND hWnd)
 	}
 }
 
+bool activeDocumentFollowMode()
+{
+	auto& docs = (ctx().activeView == 0) ? ctx().documents : ctx().documents2;
+	int tab = (ctx().activeView == 0) ? ctx().activeTab : ctx().activeTab2;
+	return tab >= 0 && tab < (int)docs.size() && docs[tab].followMode;
+}
+
+void updateFollowModeMenu(HWND hWnd)
+{
+	HMENU hMenu = GetMenu(hWnd);
+	if (hMenu)
+	{
+		CheckMenuItem(hMenu, IDM_VIEW_FOLLOW,
+		              MF_BYCOMMAND | (activeDocumentFollowMode() ? MF_CHECKED : MF_UNCHECKED));
+	}
+}
+
 void togglePluginVerticalSync(HWND hWnd)
 {
 	if (!ctx().isSplit)
@@ -677,15 +694,7 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 			case IDM_VIEW_FOLLOW:
 			{
 				toggleFollowModeForActiveTab(ctx().activeView);
-				HMENU hMenu = GetMenu(hWnd);
-				if (hMenu)
-				{
-					int tab = (ctx().activeView == 0) ? ctx().activeTab : ctx().activeTab2;
-					auto& docs = (ctx().activeView == 0) ? ctx().documents : ctx().documents2;
-					bool on = (tab >= 0 && tab < (int)docs.size() && docs[tab].followMode);
-					CheckMenuItem(hMenu, IDM_VIEW_FOLLOW,
-					              MF_BYCOMMAND | (on ? MF_CHECKED : MF_UNCHECKED));
-				}
+				updateFollowModeMenu(hWnd);
 				return 0;
 			}
 			case IDM_FILE_OPENFOLDER:
@@ -860,6 +869,8 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 					              MF_BYCOMMAND | (ctx().syncScrolling && ctx().isSplit ? MF_CHECKED : MF_UNCHECKED));
 					CheckMenuItem(hMenu, IDM_VIEW_CHANGE_HISTORY,
 					              MF_BYCOMMAND | (ctx().showChangeHistory ? MF_CHECKED : MF_UNCHECKED));
+					CheckMenuItem(hMenu, IDM_VIEW_FOLLOW,
+					              MF_BYCOMMAND | (activeDocumentFollowMode() ? MF_CHECKED : MF_UNCHECKED));
 				}
 			}
 			updateFilePathMenuState();

--- a/macos/platform/wndproc.mm
+++ b/macos/platform/wndproc.mm
@@ -19,6 +19,7 @@
 #include "status_bar.h"
 #include "file_path_ops.h"
 #include "tab_context_menu.h"
+#include "follow_mode.h"
 #include "incremental_search.h"
 #include "find_in_files.h"
 #include "brace_match.h"
@@ -671,6 +672,20 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 				if (hMenu)
 					CheckMenuItem(hMenu, IDM_VIEW_FILESWITCHER,
 					              MF_BYCOMMAND | (ctx().fileSwitcherEnabled ? MF_CHECKED : MF_UNCHECKED));
+				return 0;
+			}
+			case IDM_VIEW_FOLLOW:
+			{
+				toggleFollowModeForActiveTab(ctx().activeView);
+				HMENU hMenu = GetMenu(hWnd);
+				if (hMenu)
+				{
+					int tab = (ctx().activeView == 0) ? ctx().activeTab : ctx().activeTab2;
+					auto& docs = (ctx().activeView == 0) ? ctx().documents : ctx().documents2;
+					bool on = (tab >= 0 && tab < (int)docs.size() && docs[tab].followMode);
+					CheckMenuItem(hMenu, IDM_VIEW_FOLLOW,
+					              MF_BYCOMMAND | (on ? MF_CHECKED : MF_UNCHECKED));
+				}
 				return 0;
 			}
 			case IDM_FILE_OPENFOLDER:


### PR DESCRIPTION
## Summary

- Add macOS follow-file mode plumbing, including the age bar view, tab/menu integration, settings, and per-file FSEvents watches.
- Make followed documents update their DocumentData content, file size, and line age state even while their tab is inactive.
- Mirror follow append/reload operations into Scintilla only for the currently visible followed tab, with follow-age tracking suppressed during programmatic mirrors.

## Root Cause

Follow-mode file monitor callbacks previously treated Scintilla as the canonical buffer. When the followed tab was inactive, callbacks skipped the update path, so the stored DocumentData stayed stale until a later catch-up path ran.

## Impact

A followed file now keeps advancing in the background without stealing focus or mutating an inactive Scintilla view. Switching back to the tab restores already-current content and reattaches the editor to the bottom.

## Validation

- cmake --build macos/build --target PaperWasp
